### PR TITLE
chore: prepare v0.4.1 release — CreatePipeline MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Nothing yet.
 
 ---
 
+## [0.4.1] - 2026-03-04
+
+### 🚀 Features
+- **CreatePipeline MCP Tool**: New `CreatePipeline` tool for creating sequential task pipelines via MCP (closes CLI/MCP feature parity gap). Accepts 2–20 steps with per-step priority and working directory overrides
+- **Pipeline Service Extraction**: Pipeline creation logic extracted from CLI into `ScheduleManagerService.createPipeline()` — one business logic path shared by MCP and CLI
+
+### 🏗️ Architecture
+- **CLI Pipeline Refactor**: `beat pipeline` command refactored from inline schedule loop to shared service call (68 → 42 lines)
+
+### 🧪 Test Coverage
+- 17 new tests (11 service + 6 adapter) covering pipeline bounds, chaining, priority/workDir inheritance, prompt truncation, and failure propagation
+
+---
+
 ## [0.4.0] - 2026-03-03
 
 First release as **backbeat** (renamed from `claudine`). 17 commits since v0.3.3, covering scheduling, resumption, architectural simplification, CLI overhaul, and two-phase rename.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -201,6 +201,7 @@ Last Updated: February 2026
 - **CancelSchedule**: Cancel an active schedule with optional reason
 - **PauseSchedule**: Pause an active schedule (can be resumed later)
 - **ResumeSchedule**: Resume a paused schedule
+- **CreatePipeline** (v0.4.1): Create sequential task pipelines with 2–20 steps, per-step delays, priority, and working directory overrides
 
 ### Schedule Types
 - **CRON**: Standard 5-field cron expressions for recurring task execution
@@ -252,6 +253,15 @@ Last Updated: February 2026
 - **REST API**: MCP protocol only
 
 ---
+
+---
+
+## 🆕 What's New in v0.4.1
+
+### CreatePipeline MCP Tool
+- **Pipeline Creation via MCP**: New `CreatePipeline` tool closes the last CLI/MCP feature parity gap
+- **2–20 Steps**: Sequential task pipelines with per-step delays, priority, and working directory overrides
+- **Shared Service**: Both MCP and CLI use `ScheduleManagerService.createPipeline()` — identical behavior
 
 ---
 

--- a/docs/releases/RELEASE_NOTES_v0.4.1.md
+++ b/docs/releases/RELEASE_NOTES_v0.4.1.md
@@ -1,0 +1,73 @@
+# Backbeat v0.4.1 — CreatePipeline MCP Tool
+
+Closes the last functional gap between CLI and MCP: pipeline creation is now available as an MCP tool.
+
+---
+
+## New Feature
+
+### CreatePipeline MCP Tool
+
+Create sequential task pipelines directly from MCP — no CLI required.
+
+**Key Capabilities:**
+- **2–20 steps** per pipeline with prompt and delay between steps
+- **Per-step overrides**: priority and working directory per step
+- **Shared service**: MCP and CLI both use `ScheduleManagerService.createPipeline()` — one code path, identical behavior
+
+**MCP Usage:**
+```typescript
+await CreatePipeline({
+  steps: [
+    { prompt: "set up DB", delayMinutes: 0 },
+    { prompt: "run migrations", delayMinutes: 5 },
+    { prompt: "seed data", delayMinutes: 10, priority: 0 }
+  ],
+  workingDirectory: "/path/to/project"
+});
+```
+
+**Equivalent CLI:**
+```bash
+beat pipeline "set up DB" --delay 5m "run migrations" --delay 10m "seed data"
+```
+
+### Pipeline Service Extraction
+
+Pipeline creation logic extracted from the CLI `beat pipeline` command into `ScheduleManagerService.createPipeline()`. The CLI was refactored from an inline schedule loop (68 lines) to a single service call (42 lines). Both MCP and CLI now share the same business logic path.
+
+---
+
+## Test Coverage
+
+- **17 new tests**: 11 service tests + 6 adapter tests
+- Covers: pipeline bounds (2–20 steps), schedule chaining, priority/workDir inheritance, prompt truncation, and failure propagation
+- **Total**: 860+ tests passing across all groups
+
+---
+
+## Installation
+
+```bash
+npm install -g backbeat@0.4.1
+```
+
+Or use npx:
+```json
+{
+  "mcpServers": {
+    "backbeat": {
+      "command": "npx",
+      "args": ["-y", "backbeat", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- NPM Package: https://www.npmjs.com/package/backbeat
+- Documentation: https://github.com/dean0x/backbeat/blob/main/docs/FEATURES.md
+- Issues: https://github.com/dean0x/backbeat/issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backbeat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backbeat",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- Bump version `0.4.0` → `0.4.1`
- Add release notes (`docs/releases/RELEASE_NOTES_v0.4.1.md`)
- Update CHANGELOG.md with `[0.4.1]` section
- Update FEATURES.md with `CreatePipeline` MCP tool entry

## Context
PR #68 (squash-merged) added the `CreatePipeline` MCP tool, closing the CLI/MCP feature parity gap. This PR prepares the patch release.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:services` — 131 passed
- [x] `npm run test:adapters` — 43 passed
- [x] `npm run test:cli` — 115 passed
- [x] Release notes file exists
- [x] Version in `package.json` is `0.4.1`
- [ ] After merge: trigger GitHub Actions → Release → Run workflow