### PR TITLE
chore: release v1.1.0 — Agent Eval Mode & Skill System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+---
+
+## [1.1.0] - 2026-04-01
+
 ### Added
-- **Agent Eval Mode**: Loops can now use an AI agent to evaluate iteration results instead of a shell command. Pass `--eval-mode agent` (CLI) or `evalMode: 'agent'` (MCP) to have the agent review output and decide pass/fail or score. Use `--eval-prompt` / `evalPrompt` to supply a custom evaluation prompt.
+- **Agent Eval Mode**: Loops can use an AI agent to evaluate iteration results instead of shell commands. `evalMode: 'agent'` (MCP) / `--eval-mode agent` (CLI). Custom evaluation prompts via `evalPrompt` / `--eval-prompt`.
+- **Agent Orchestration Skill**: Structured skill files in `skills/autobeat/` with capability hierarchy, tool reference, composition patterns, and monitoring guides.
+- **Skill Installer**: `beat init --install-skills [--skills-agents claude,codex]` copies skill files to agent-specific directories (`.claude/`, `.agents/`, `.gemini/`).
+- **MCP Instructions**: Server-side instructions injected into MCP protocol for structured agent context.
+- **ListAgents MCP Tool**: List available agents with registration and auth status.
+- **ConfigureAgent MCP Tool**: Check auth status, store API key, or reset stored key for an agent.
+
+### Fixed
+- **CRON schedule nextRunAt**: `createSchedule()` factory now populates `nextRunAt` for CRON schedules immediately. Previously returned `undefined` until the handler persisted it.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ When adding task dependencies:
 
 ### MCP Tools
 
-All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `ScheduleTask`, `ListSchedules`, `ScheduleStatus`, `CancelSchedule`, `PauseSchedule`, `ResumeSchedule`, `CreatePipeline`, `SchedulePipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleLoop`
+All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `RetryTask`, `ResumeTask`, `CreatePipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`, `ListSchedules`, `ScheduleStatus`, `PauseSchedule`, `ResumeSchedule`, `CancelSchedule`, `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`, `ListAgents`, `ConfigureAgent`
 
 ## File Locations
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,34 @@
 
 This document lists all features that are **currently implemented and working** in Autobeat.
 
-Last Updated: March 2026
+Last Updated: April 2026
+
+## ✅ Agent Eval Mode & Skill System (v1.1.0)
+
+### Agent Eval Mode
+- Loops can use an AI agent to evaluate iteration results instead of a shell command
+- `evalMode: 'agent'` (MCP) / `--eval-mode agent` (CLI)
+- Custom evaluation prompts via `evalPrompt` / `--eval-prompt`
+- Agent judges pass/fail (retry strategy) or scores 0-100 (optimize strategy)
+- `AgentExitConditionEvaluator` and `CompositeExitConditionEvaluator` handle evaluation dispatch
+
+### Agent Orchestration Skill
+- Skill files in `skills/autobeat/` provide structured context for AI agents
+- Capability hierarchy decision tree (Task < Pipeline < Loop < Orchestrator)
+- Complete MCP tool and CLI command reference
+- Composition patterns and anti-patterns
+- Reference guides: orchestration, loops, dependencies, monitoring, capability matrix
+
+### Skill Installer
+- `beat init --install-skills`: install skill files to agent-specific directories
+- `--skills-agents claude,codex,gemini`: target specific agents
+- Detects existing skills and prompts for update
+- Agent-specific paths: `.claude/skills/autobeat`, `.agents/skills/autobeat`, `.gemini/skills/autobeat`
+
+### MCP Enhancements
+- **MCP Instructions**: server-side instructions injected into MCP Server for structured agent context
+- **ListAgents**: list available agents with registration and auth status (no parameters)
+- **ConfigureAgent**: check auth status (`check`), store API key (`set`), or reset stored key (`reset`)
 
 ## ✅ Autonomous Orchestration (v1.0.0)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # Autobeat Development Roadmap
 
-## Current Status: v1.0.0 RELEASED (2026-03-28)
+## Current Status: v1.1.0 RELEASED (2026-04-01)
 
-Orchestrator Mode -- the autonomous meta-agent that uses Autobeat's own MCP tools to break down goals, spawn workers, monitor progress, and iterate until done.
+Agent eval mode, skill system, and skill installer. Built on top of v1.0.0's autonomous orchestration.
 
 ---
 
@@ -49,6 +49,11 @@ DAG-based dependencies, cycle detection, TOCTOU protection, failure cascading, p
 Autoscaling workers, event-driven architecture, SQLite persistence.
 
 ---
+
+### v1.1.0 - Agent Eval Mode & Skill System ✅
+**Status**: **RELEASED** (2026-04-01)
+
+Agent eval mode for loop exit conditions (AI judges pass/fail instead of shell commands). Agent orchestration skill with structured reference files. Skill installer via `beat init --install-skills`. MCP instructions and ConfigureAgent/ListAgents tools.
 
 ## v1.0.0 - Autonomous Orchestration
 
@@ -138,6 +143,7 @@ Multi-server support, shared state (Redis backend), fault tolerance, task affini
 | v0.7.0 | ✅ Released | Task/Pipeline Loops |
 | v0.8.0–v0.8.2 | ✅ Released | Loop Enhancements, Git Integration, Rename |
 | **v1.0.0** | ✅ Released | **Autonomous Orchestration** |
+| **v1.1.0** | ✅ Released | **Agent Eval Mode & Skill System** |
 
 ---
 

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -1,145 +1,18 @@
-# 🚀 Autobeat v0.4.0 - Latest Release
+# Autobeat Release Notes
 
-See [RELEASE_NOTES_v0.4.0.md](./RELEASE_NOTES_v0.4.0.md) for the latest release notes.
+## Latest Release
+
+- **[v1.1.0](./RELEASE_NOTES_v1.1.0.md)** — Agent Eval Mode & Skill System (2026-04-01)
 
 ## Previous Releases
-- [v0.3.0](./RELEASE_NOTES_v0.3.0.md) - Task Dependencies & DAG Support
-- [v0.2.0](./RELEASE_NOTES_v0.2.0.md) - Concurrent Execution & Auto-scaling
-- [v0.1.0](./RELEASE_NOTES_v0.1.0.md) - Initial Release
 
----
-
-# 🚀 Autobeat v0.1.0 - Initial Release
-
-## Introducing Autobeat: Your MCP Sidekick for Claude Code
-
-Autobeat is an MCP (Model Context Protocol) server that enables Claude Code to delegate tasks to background Claude Code instances, allowing for true parallel task execution without context switching.
-
-## ✨ Features
-
-### Core Tools
-- **DelegateTask**: Spawn background Claude Code processes with custom prompts
-- **TaskStatus**: Monitor task execution state in real-time
-- **TaskLogs**: Retrieve captured output from delegated tasks
-- **CancelTask**: Gracefully terminate running tasks
-
-### Advanced Capabilities
-- **Custom Working Directories**: Control exactly where tasks execute
-- **Auto-Permissions**: Skip file permission prompts with `--dangerously-skip-permissions`
-- **Smart Output Capture**: 10MB buffer with overflow protection
-
-## 📦 Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/dean0x/autobeat.git
-cd autobeat
-
-# Install and build
-npm install
-npm run build
-
-# Setup MCP configuration
-./setup-mcp.sh
-```
-
-## 🎯 Use Cases
-
-- **Parallel Development**: Work on API while tests update in background
-- **Bulk Refactoring**: Update imports across entire codebase
-- **Documentation Generation**: Auto-generate docs while coding
-- **Test Execution**: Run test suites without blocking development
-- **Code Analysis**: Analyze codebase complexity in background
-
-## 📊 Example Usage
-
-```javascript
-// Delegate a task with custom directory
-Use DelegateTask with:
-- prompt: "Generate comprehensive API documentation"
-- workingDirectory: "/workspace/docs"
-
-// Check status
-Use TaskStatus to monitor progress
-
-// Get results
-Use TaskLogs to retrieve the documentation
-```
-
-## 🔧 Configuration
-
-Add to `~/.config/claude/mcp_servers.json`:
-
-```json
-{
-  "mcpServers": {
-    "autobeat": {
-      "command": "node",
-      "args": ["/path/to/autobeat/dist/index.js"],
-      "env": {}
-    }
-  }
-}
-```
-
-## 📈 Performance
-
-- Server startup: <100ms
-- Tool response: <50ms
-- Task execution: 7-40s (depends on complexity)
-- Memory usage: ~45MB base
-
-## 🚦 Current Limitations
-
-- Single task execution (concurrency coming in v0.2.0)
-- 30-minute timeout per task
-- Tasks don't persist across restarts (yet)
-
-## 🗺️ Roadmap
-
-### v0.2.0 (Next Week)
-- Concurrent task execution (3-5 tasks)
-- Task queue with FIFO processing
-- ListTasks tool for overview
-
-### v0.3.0 (2 Weeks)
-- CLI interface for terminal usage
-- Task persistence with SQLite
-- Auto-retry for failed tasks
-
-## 🤝 Contributing
-
-Contributions are welcome! Please check out our [contributing guidelines](./CONTRIBUTING.md) and feel free to:
-- Report bugs
-- Suggest features
-- Submit pull requests
-
-## 📝 License
-
-MIT License - see [LICENSE](./LICENSE) file for details
-
-## 🙏 Acknowledgments
-
-- Built with the [Model Context Protocol SDK](https://modelcontextprotocol.io)
-- Created with Claude Code
-- Special thanks to early testers and contributors
-
-## 📞 Support
-
-- **Issues**: [GitHub Issues](https://github.com/dean0x/autobeat/issues)
-- **Documentation**: [Full Docs](./docs/)
-- **Examples**: [Use Cases](./examples/use-cases.md)
-
-## 🎉 Get Started
-
-1. Install Autobeat
-2. Configure MCP
-3. Start delegating tasks!
-
-Ready to parallelize your development workflow? Let's go! 🚀
-
----
-
-**Repository**: https://github.com/dean0x/autobeat  
-**Version**: 0.1.0  
-**Release Date**: August 16, 2024
+- [v1.0.0](./RELEASE_NOTES_v1.0.0.md) — Autonomous Coding Agent Orchestration (2026-03-28)
+- [v0.8.2](./RELEASE_NOTES_v0.8.2.md) — Package Rename (2026-03-26)
+- [v0.8.0](./RELEASE_NOTES_v0.8.0.md) — Loop Enhancements & Git Integration (2026-03-25)
+- [v0.7.0](./RELEASE_NOTES_v0.7.0.md) — Task/Pipeline Loops (2026-03-22)
+- [v0.6.0](./RELEASE_NOTES_v0.6.0.md) — Architectural Simplification (2026-03-20)
+- [v0.5.0](./RELEASE_NOTES_v0.5.0.md) — Multi-Agent Support (2026-03-10)
+- [v0.4.0](./RELEASE_NOTES_v0.4.0.md) — Scheduling & Resumption (2026-03-03)
+- [v0.3.0](./RELEASE_NOTES_v0.3.0.md) — Task Dependencies & DAG Support
+- [v0.2.0](./RELEASE_NOTES_v0.2.0.md) — Concurrent Execution & Auto-scaling
+- [v0.1.0](./RELEASE_NOTES_v0.1.0.md) — Initial Release

--- a/docs/releases/RELEASE_NOTES_v1.1.0.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.0.md
@@ -1,0 +1,127 @@
+# Autobeat v1.1.0 — Agent Eval Mode & Skill System
+
+Loops can now delegate exit condition evaluation to an AI agent instead of a shell command. A new skill system provides structured reference files for AI agents, with an installer that copies them to agent-specific directories.
+
+---
+
+## Agent Eval Mode
+
+Loops support a new `evalMode: 'agent'` option that replaces shell-based exit condition evaluation with an AI agent. The agent reads iteration output and decides:
+
+- **Retry strategy**: pass or fail
+- **Optimize strategy**: numeric score (0-100)
+
+```bash
+# Retry loop with agent evaluation
+beat loop "Refactor the auth module" --strategy retry --eval-mode agent
+
+# Optimize loop with custom evaluation prompt
+beat loop "Optimize the query" --strategy optimize --maximize \
+  --eval-mode agent --eval-prompt "Score based on query execution time"
+```
+
+MCP:
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Refactor the auth module",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalPrompt": "Check if all tests pass and code is clean"
+  }
+}
+```
+
+### Architecture
+
+- `AgentExitConditionEvaluator`: handles agent-based evaluation by spawning an agent to review iteration output
+- `CompositeExitConditionEvaluator`: dispatches to shell or agent evaluator based on `evalMode`
+- Database: Migration 15 adds `eval_mode` and `eval_prompt` columns to `loops`, `eval_feedback` to `loop_iterations`
+
+---
+
+## Skill System & Installer
+
+### Agent Orchestration Skill
+
+Structured skill files in `skills/autobeat/` provide AI agents with:
+
+- Capability hierarchy decision tree (Task < Pipeline < Loop < Orchestrator)
+- Complete MCP tool and CLI command reference
+- Composition patterns and anti-patterns
+- Reference guides for orchestration, loops, dependencies, and monitoring
+
+### Skill Installer
+
+```bash
+# Install skills for all detected agents
+beat init --install-skills
+
+# Target specific agents
+beat init --install-skills --skills-agents claude,codex
+```
+
+Agent-specific paths:
+- Claude: `.claude/skills/autobeat/`
+- Codex: `.agents/skills/autobeat/`
+- Gemini: `.gemini/skills/autobeat/`
+
+### MCP Instructions
+
+Server-side instructions are injected into the MCP protocol, giving connected agents structured context about Autobeat's capabilities without requiring skill file installation.
+
+### New MCP Tools
+
+- **ListAgents**: list available agents with registration and auth status
+- **ConfigureAgent**: check auth status (`check`), store API key (`set`), or reset stored key (`reset`) for an agent
+
+---
+
+## Bug Fixes
+
+- **CRON schedule nextRunAt**: `createSchedule()` factory now populates `nextRunAt` for CRON schedules immediately. Previously returned `undefined` until the handler persisted it. ([#128](https://github.com/dean0x/autobeat/pull/128))
+
+---
+
+## What's Changed Since v1.0.0
+
+- **feat**: Agent eval mode for loop exit conditions ([#126](https://github.com/dean0x/autobeat/pull/126))
+- **feat**: Agent orchestration skill and skill installer ([#127](https://github.com/dean0x/autobeat/pull/127))
+- **fix**: Populate nextRunAt on CRON schedule creation ([#128](https://github.com/dean0x/autobeat/pull/128))
+
+---
+
+## Migration Notes
+
+- **Fully additive**: No breaking changes. No existing APIs, CLI commands, or MCP tools were changed or removed.
+- **Database**: Migration 15 adds eval columns. Auto-applied on startup. No user action needed.
+- **Existing workflows**: All existing commands work exactly as before. Agent eval mode is opt-in via `evalMode: 'agent'`.
+
+---
+
+## Installation
+
+```bash
+npm install -g autobeat@1.1.0
+```
+
+Or use npx:
+```json
+{
+  "mcpServers": {
+    "autobeat": {
+      "command": "npx",
+      "args": ["-y", "autobeat@1.1.0", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- NPM Package: https://www.npmjs.com/package/autobeat
+- Documentation: https://github.com/dean0x/autobeat/blob/main/docs/FEATURES.md
+- Issues: https://github.com/dean0x/autobeat/issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autobeat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autobeat",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobeat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- Bump version 1.0.0 → 1.1.0
- Add release notes, changelog, features, roadmap entries for v1.1.0
- Update CLAUDE.md MCP tools list (add 8 missing tools: RetryTask, ResumeTask, CreateOrchestrator, OrchestratorStatus, ListOrchestrators, CancelOrchestrator, ListAgents, ConfigureAgent)
- Update stale RELEASE_NOTES.md index (was pointing to v0.4.0)

## What's in v1.1.0

| PR | Type | Description |
|----|------|-------------|
| #126 | feat | Agent eval mode for loop exit conditions |
| #127 | feat | Agent orchestration skill and skill installer |
| #128 | fix | Populate nextRunAt on CRON schedule creation |

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test:core` — 359 passed
- [x] `npm run test:services` — 175 passed
- [x] `npm run test:cli` — 295 passed
- [x] `npm run test:adapters` — 100 passed
- [x] `npx biome check src/ tests/` — clean
- [ ] CI passes on PR
- [ ] Squash merge → trigger Release workflow