### PR TITLE
fix: preflight script npm-offline and remote-sync checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.3.1] - 2026-04-16
+
+### Fixed
+- **Preflight script**: `npm view` failure (offline/timeout) no longer silently passes — warns and skips the published-version check instead of defaulting to `0.0.0` (#145)
+- **Preflight script**: Added remote sync check — detects local/remote branch divergence before release (#145)
+
+---
+
 ## [1.3.0] - 2026-04-16
 
 ### Added

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## Latest Release
 
-- **[v1.3.0](./RELEASE_NOTES_v1.3.0.md)** — Dashboard Redesign, Eval Redesign & Reliability (2026-04-16)
+- **[v1.3.1](./RELEASE_NOTES_v1.3.1.md)** — Preflight Script Hardening (2026-04-16)
 
 ## Previous Releases
+- [v1.3.0](./RELEASE_NOTES_v1.3.0.md) — Dashboard Redesign, Eval Redesign & Reliability (2026-04-16)
 - [v1.2.0](./RELEASE_NOTES_v1.2.0.md) — Terminal Dashboard & Agent Config Passthrough (2026-04-10)
 - [v1.1.0](./RELEASE_NOTES_v1.1.0.md) — Agent Eval Mode & Skill System (2026-04-01)
 - [v1.0.0](./RELEASE_NOTES_v1.0.0.md) — Autonomous Coding Agent Orchestration (2026-03-28)

--- a/docs/releases/RELEASE_NOTES_v1.3.1.md
+++ b/docs/releases/RELEASE_NOTES_v1.3.1.md
@@ -1,0 +1,59 @@
+# Autobeat v1.3.1 — Preflight Script Hardening
+
+Patch release fixing two issues in the release preflight script identified during code review.
+
+---
+
+## Fixes
+
+### npm Registry Offline Handling
+
+Previously, `npm view autobeat version` failures (network offline, registry timeout) were silently caught and defaulted to `0.0.0`, which would always pass the version-bump check — even if the version hadn't actually been bumped.
+
+Now: the script warns that it couldn't reach the registry and skips the published-version comparison entirely, rather than making a false assumption.
+
+### Remote Branch Sync Check
+
+The preflight script now verifies that the local branch is in sync with its remote tracking branch before proceeding. This catches cases where `main` has new commits that haven't been pulled, preventing releases from stale local state.
+
+---
+
+## What's Changed Since v1.3.0
+
+- Fixed silent npm offline pass in preflight script (#145)
+- Added remote sync verification to preflight script (#145)
+
+---
+
+## Migration Notes
+
+No migration required. This is a tooling-only patch — no changes to source code, database, or runtime behavior.
+
+---
+
+## Installation
+
+```bash
+npm install -g autobeat@1.3.1
+```
+
+Or via npx in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "autobeat": {
+      "command": "npx",
+      "args": ["-y", "autobeat@1.3.1", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- [npm](https://www.npmjs.com/package/autobeat)
+- [Documentation](https://github.com/dean0x/autobeat)
+- [Issues](https://github.com/dean0x/autobeat/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autobeat",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autobeat",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobeat",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -13,12 +13,16 @@ gh auth status 2>&1 || { echo "❌ Not authenticated to GitHub"; exit 1; }
 BRANCH=$(git branch --show-current)
 [[ "$BRANCH" == "main" || "$BRANCH" == release/* ]] || { echo "❌ Not on main or release branch (on: $BRANCH)"; exit 1; }
 git diff --quiet && git diff --cached --quiet || { echo "❌ Uncommitted changes"; exit 1; }
+git fetch origin --quiet
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse "@{u}" 2>/dev/null || echo "")
+[[ -z "$REMOTE" || "$LOCAL" == "$REMOTE" ]] || { echo "❌ Local branch is out of sync with remote — run git pull"; exit 1; }
 
 # Version checks
-PUBLISHED=$(npm view autobeat version 2>/dev/null || echo "0.0.0")
+PUBLISHED=$(npm view autobeat version 2>/dev/null) || { echo "⚠️  Could not reach npm registry — skipping published-version check"; PUBLISHED=""; }
 PACKAGE=$(node -p "require('./package.json').version")
 echo "Published: $PUBLISHED | Package: $PACKAGE"
-[[ "$PUBLISHED" != "$PACKAGE" ]] || { echo "❌ Version not bumped (both are $PUBLISHED)"; exit 1; }
+[[ -z "$PUBLISHED" || "$PUBLISHED" != "$PACKAGE" ]] || { echo "❌ Version not bumped (both are $PACKAGE)"; exit 1; }
 
 # Release notes check
 NOTES="docs/releases/RELEASE_NOTES_v${PACKAGE}.md"


### PR DESCRIPTION
## Summary

- **npm offline handling**: `npm view` failure no longer silently defaults to `0.0.0` — warns and skips the published-version check instead
- **Remote sync check**: Verifies local branch matches remote tracking branch before proceeding with release

Fixes two P2 comments from Greptile review on #145.

## Release

Patch release `v1.3.1` — version bump, CHANGELOG, and release notes included.

## Test plan

- [ ] `bash -n scripts/release-preflight.sh` — syntax valid
- [ ] `npm run typecheck && npm run check && npm run build` — all pass
- [ ] No TypeScript source changes — zero regression risk