### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.4.0] - 2026-04-22
+
+### Added
+- **System prompt support**: `--system-prompt` flag on `beat run`, `beat loop`, `beat orchestrate`; `systemPrompt` param on MCP `DelegateTask`, `CreateLoop`, `CreateOrchestrator` tools; wired through Claude (`--append-system-prompt`), Codex (`-c developer_instructions`), and Gemini (`GEMINI_SYSTEM_MD` env var) adapters (#134, #147)
+- **Custom orchestrator scaffolding**: `beat orchestrate init <goal>` CLI command and `InitCustomOrchestrator` MCP tool; generates state file, exit condition script, and ready-to-copy system prompt snippets (#135, #148)
+- **Agent configuration docs**: New README section covering API keys, base URLs, model selection, and local LLM usage (#150)
+
+### Database
+- **Migration v23**: Adds `system_prompt TEXT` column to `tasks` table (nullable, auto-applied)
+
+---
+
 ## [1.3.1] - 2026-04-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,10 @@ Safety nets that exist in the codebase but are not part of the manual release st
 - `loop_iterations` table: per-iteration execution records with scores and results (migration v10)
 - `tasks.orchestrator_id` column: nullable FK for sub-task attribution to an orchestration (migration v18)
 - `task_usage` table: one row per task with input/output/cache tokens and total_cost_usd (migration v19)
+- Performance indexes for dashboard polling (migration v20)
+- `workers.last_heartbeat`, loops eval columns: `eval_type`, `judge_agent`, `judge_prompt`, `eval_prompt` (migration v21)
+- CHECK constraints on `eval_type` and `judge_agent` in loops table (migration v22)
+- `tasks.system_prompt` column: nullable TEXT for per-task system prompt injection (migration v23)
 
 ### Dependencies
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,20 @@
 
 This document lists all features that are **currently implemented and working** in Autobeat.
 
-Last Updated: April 2026 (2026-04-16)
+Last Updated: April 2026 (2026-04-22)
+
+## ✅ System Prompts & Custom Orchestrators (v1.4.0)
+
+- **System prompt support**: `--system-prompt` flag on `beat run`, `beat loop`, `beat orchestrate`; `systemPrompt` param on MCP `DelegateTask`, `CreateLoop`, `CreateOrchestrator`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop` tools
+- **Per-agent injection**: Claude (`--append-system-prompt`), Codex (`-c developer_instructions`), Gemini (`GEMINI_SYSTEM_MD` env var)
+- **System prompt persistence**: Stored per-task in database; survives retry/resume — `TaskStatus` returns it via `includeSystemPrompt: true`
+- **Custom orchestrator scaffolding**: `beat orchestrate init <goal>` CLI command and `InitCustomOrchestrator` MCP tool
+- **Generated artifacts**: State file, exit condition script, and system prompt snippets for delegation, state management, and constraint enforcement
+- **Agent configuration documentation**: README section covering API keys, base URLs, model selection, and local LLM usage
+
+### Database (v1.4.0)
+
+- **Migration 23**: Adds `system_prompt TEXT` column to `tasks` table (nullable, auto-applied)
 
 ## ✅ Dashboard Redesign, Eval Redesign & Reliability (v1.3.0)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,17 @@
 # Autobeat Development Roadmap
 
-## Current Status: v1.3.0 RELEASED (2026-04-16)
+## Current Status: v1.4.0 RELEASED (2026-04-22)
 
-Dashboard redesign (Metrics + Workspace views), live agent output streaming, cost/token tracking, three eval strategies (feedforward, judge, schema), atomic PID file locking, SpawnOptions refactor, and extracted pure functions. Includes database migrations v18-v22.
+System prompt support across all three agent adapters (Claude, Codex, Gemini) and custom orchestrator scaffolding (`beat orchestrate init` + `InitCustomOrchestrator` MCP tool). Includes database migration v23.
 
 ---
 
 ## Released Versions
+
+### v1.4.0 - System Prompts & Custom Orchestrators ✅
+**Status**: **RELEASED** (2026-04-22)
+
+System prompt injection for tasks, loops, and orchestrators across Claude, Codex, and Gemini adapters. Custom orchestrator scaffolding via CLI and MCP tool. Agent configuration documentation. Database migration v23.
 
 ### v1.3.0 - Dashboard Redesign, Eval Redesign & Reliability ✅
 **Status**: **RELEASED** (2026-04-16)
@@ -156,6 +161,7 @@ Multi-server support, shared state (Redis backend), fault tolerance, task affini
 | **v1.1.0** | ✅ Released | **Agent Eval Mode & Skill System** |
 | **v1.2.0** | ✅ Released | **Terminal Dashboard & Agent Config** |
 | **v1.3.0** | ✅ Released | **Dashboard Redesign, Eval Redesign & Reliability** |
+| **v1.4.0** | ✅ Released | **System Prompts & Custom Orchestrators** |
 
 ---
 

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## Latest Release
 
-- **[v1.3.1](./RELEASE_NOTES_v1.3.1.md)** — Preflight Script Hardening (2026-04-16)
+- **[v1.4.0](./RELEASE_NOTES_v1.4.0.md)** — System Prompts & Custom Orchestrators (2026-04-22)
 
 ## Previous Releases
+- [v1.3.1](./RELEASE_NOTES_v1.3.1.md) — Preflight Script Hardening (2026-04-16)
 - [v1.3.0](./RELEASE_NOTES_v1.3.0.md) — Dashboard Redesign, Eval Redesign & Reliability (2026-04-16)
 - [v1.2.0](./RELEASE_NOTES_v1.2.0.md) — Terminal Dashboard & Agent Config Passthrough (2026-04-10)
 - [v1.1.0](./RELEASE_NOTES_v1.1.0.md) — Agent Eval Mode & Skill System (2026-04-01)

--- a/docs/releases/RELEASE_NOTES_v1.4.0.md
+++ b/docs/releases/RELEASE_NOTES_v1.4.0.md
@@ -1,0 +1,146 @@
+# Autobeat v1.4.0 — System Prompts & Custom Orchestrators
+
+Two additive features that extend the orchestration workflow: per-task system prompt injection across all three agent adapters, and scaffolding tools for building custom orchestrators from scratch. Plus expanded agent configuration documentation in the README.
+
+---
+
+## Highlights
+
+- **System prompt support**: Inject custom instructions into any agent via `--system-prompt` on CLI or `systemPrompt` on MCP tools — wired through Claude, Codex, and Gemini adapters
+- **Custom orchestrator scaffolding**: `beat orchestrate init` CLI and `InitCustomOrchestrator` MCP tool generate state files, exit condition scripts, and system prompt snippets
+- **Agent configuration docs**: New README section covering API keys, base URLs, model selection, and local LLM usage
+
+---
+
+## System Prompt Support
+
+Pass a system prompt to any task, loop, or orchestrator. The prompt is injected per-agent:
+
+| Agent | Mechanism |
+|-------|-----------|
+| Claude | `--append-system-prompt` flag |
+| Codex | `-c developer_instructions` flag |
+| Gemini | `GEMINI_SYSTEM_MD` environment variable |
+
+### CLI
+
+```bash
+# Single task
+beat run "Refactor auth module" --system-prompt "Use dependency injection, no globals"
+
+# Loop
+beat loop "Optimize bundle size" --until "size < 100kb" \
+  --system-prompt "Focus on tree-shaking and code splitting"
+
+# Orchestrator
+beat orchestrate "Build auth system" \
+  --system-prompt "Use JWT for tokens, bcrypt for hashing"
+```
+
+### MCP Tools
+
+```json
+{
+  "tool": "DelegateTask",
+  "arguments": {
+    "prompt": "Refactor auth module",
+    "systemPrompt": "Use dependency injection, no globals"
+  }
+}
+```
+
+System prompts are supported on: `DelegateTask`, `CreateLoop`, `CreateOrchestrator`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`.
+
+The `TaskStatus` tool accepts `includeSystemPrompt: true` to return the stored system prompt.
+
+---
+
+## Custom Orchestrator Scaffolding
+
+Build custom orchestrators from scratch with generated scaffolding artifacts.
+
+### CLI
+
+```bash
+beat orchestrate init "Build a microservices API gateway"
+```
+
+Generates:
+- **State file** (`autobeat-orchestrator-state-<id>.json`) — persistent orchestration state with plan, steps, and iteration history
+- **Exit condition script** (`autobeat-exit-condition-<id>.sh`) — shell script template for evaluating orchestration completion
+- **System prompt snippets** — ready-to-copy instructions for delegation, state management, and constraint enforcement
+
+### MCP Tool
+
+```json
+{
+  "tool": "InitCustomOrchestrator",
+  "arguments": {
+    "goal": "Build a microservices API gateway",
+    "workingDirectory": "/path/to/project"
+  }
+}
+```
+
+See [Custom Orchestrators Guide](../../docs/CUSTOM_ORCHESTRATORS.md) for full documentation.
+
+---
+
+## Agent Configuration Documentation
+
+New README section documenting:
+- API key setup for Claude, Codex, and Gemini
+- Custom base URLs for proxies and local deployments
+- Model selection via `--model` flag and `~/.autobeat/config.json`
+- Local LLM usage with compatible API endpoints
+
+---
+
+## Database
+
+- **Migration v23**: Adds `system_prompt TEXT` column to `tasks` table (nullable, auto-applied on startup)
+
+---
+
+## What's Changed Since v1.3.1
+
+- System prompt support for tasks, loops, and orchestrators (#134, #147)
+- Custom orchestrator scaffolding — `beat orchestrate init` CLI + `InitCustomOrchestrator` MCP tool (#135, #148)
+- Agent configuration section added to README (#150)
+
+---
+
+## Migration Notes
+
+- **Migration v23** is auto-applied on first startup — no user action required
+- The `system_prompt` column is nullable; existing tasks are unaffected
+- No breaking changes to CLI, MCP tools, or configuration
+
+---
+
+## Installation
+
+```bash
+npm install -g autobeat@1.4.0
+```
+
+Or via npx in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "autobeat": {
+      "command": "npx",
+      "args": ["-y", "autobeat@1.4.0", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- [npm](https://www.npmjs.com/package/autobeat)
+- [Documentation](https://github.com/dean0x/autobeat)
+- [Issues](https://github.com/dean0x/autobeat/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autobeat",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autobeat",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobeat",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"


### PR DESCRIPTION
## Summary

- Version bump `1.3.1` → `1.4.0`
- Release notes, CHANGELOG, FEATURES, ROADMAP updated
- CLAUDE.md database section updated with missing migrations v20-v23

### What's in v1.4.0

- **System prompt support** (#134, #147): `--system-prompt` flag on CLI; `systemPrompt` on MCP tools; wired through Claude, Codex, and Gemini adapters
- **Custom orchestrator scaffolding** (#135, #148): `beat orchestrate init` CLI + `InitCustomOrchestrator` MCP tool
- **Agent configuration docs** (#150): README section covering API keys, base URLs, model selection

### Database

- Migration v23: `system_prompt TEXT` on tasks table (nullable, auto-applied)

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run check` (biome lint) — pass
- [x] `npm run build` — pass
- [x] All 13 test suites — 2,979 tests passing
- [x] Release notes index validated against files on disk