### PR TITLE
feat: ollama runtime integration + translate → proxy rename

### DIFF
--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -16,13 +16,13 @@ import {
 } from '../core/agents.js';
 import {
   type Configuration,
-  loadAgentConfig,
-  resetAgentConfig,
-  saveAgentConfig,
   isRuntimeSupportedForAgent,
+  loadAgentConfig,
   PROXY_TARGETS,
   RUNTIME_AGENT_SUPPORT,
   RUNTIME_TARGETS,
+  resetAgentConfig,
+  saveAgentConfig,
 } from '../core/configuration.js';
 import {
   EvalMode,

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -19,7 +19,7 @@ import {
   loadAgentConfig,
   resetAgentConfig,
   saveAgentConfig,
-  TRANSLATE_TARGETS,
+  PROXY_TARGETS,
 } from '../core/configuration.js';
 import {
   EvalMode,
@@ -378,13 +378,13 @@ const ConfigureAgentSchema = z.object({
   apiKey: z.string().min(1).optional().describe('API key to store (set action)'),
   baseUrl: z.string().url().optional().describe('Base URL override (set action, e.g. https://proxy.example.com/v1)'),
   model: modelSchema.optional().describe('Default model override for this agent (set action)'),
-  translate: z
-    // TRANSLATE_TARGETS is the canonical list; '' is the "clear" sentinel accepted only at
+  proxy: z
+    // PROXY_TARGETS is the canonical list; '' is the "clear" sentinel accepted only at
     // save boundaries (CLI, MCP) — it is never persisted to stored config.
-    .enum([...TRANSLATE_TARGETS, ''] as const satisfies readonly [string, ...string[]])
+    .enum([...PROXY_TARGETS, ''] as const satisfies readonly [string, ...string[]])
     .optional()
     .describe(
-      'API translation target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
+      'API proxy target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
     ),
 });
 
@@ -1747,10 +1747,10 @@ export class MCPAdapter {
                     minLength: 1,
                     maxLength: 200,
                   },
-                  translate: {
+                  proxy: {
                     type: 'string',
                     description:
-                      'API translation target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
+                      'API proxy target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
                   },
                 },
                 required: ['agent'],
@@ -3075,7 +3075,7 @@ export class MCPAdapter {
         ...(authStatus.hint && { hint: authStatus.hint }),
         ...(agentConfig.baseUrl && { baseUrl: agentConfig.baseUrl }),
         ...(agentConfig.model && { model: agentConfig.model }),
-        ...(agentConfig.translate && { translate: agentConfig.translate }),
+        ...(agentConfig.proxy && { proxy: agentConfig.proxy }),
         ...(claudeBaseUrlWarning && { warning: claudeBaseUrlWarning }),
       };
     });
@@ -3437,7 +3437,7 @@ export class MCPAdapter {
       };
     }
 
-    const { agent, action, apiKey, baseUrl, model, translate } = parseResult.data;
+    const { agent, action, apiKey, baseUrl, model, proxy } = parseResult.data;
 
     switch (action) {
       case 'check': {
@@ -3467,7 +3467,7 @@ export class MCPAdapter {
           ...(agentConfig.apiKey && { storedKey: maskApiKey(agentConfig.apiKey) }),
           ...(agentConfig.baseUrl && { baseUrl: agentConfig.baseUrl }),
           ...(agentConfig.model && { model: agentConfig.model }),
-          ...(agentConfig.translate && { translate: agentConfig.translate }),
+          ...(agentConfig.proxy && { proxy: agentConfig.proxy }),
           ...(checkWarning && { warning: checkWarning }),
           ...(connectivity !== undefined && { connectivity }),
         };
@@ -3483,7 +3483,7 @@ export class MCPAdapter {
       }
 
       case 'set': {
-        if (!apiKey && !baseUrl && !model && translate === undefined) {
+        if (!apiKey && !baseUrl && !model && proxy === undefined) {
           return {
             content: [
               {
@@ -3491,7 +3491,7 @@ export class MCPAdapter {
                 text: JSON.stringify(
                   {
                     success: false,
-                    error: 'At least one of apiKey, baseUrl, model, or translate is required for set action',
+                    error: 'At least one of apiKey, baseUrl, model, or proxy is required for set action',
                   },
                   null,
                   2,
@@ -3506,7 +3506,7 @@ export class MCPAdapter {
         // result before returning so that a late failure reports which fields
         // were already saved and which failed.
         type WriteAttempt = {
-          key: 'apiKey' | 'baseUrl' | 'model' | 'translate';
+          key: 'apiKey' | 'baseUrl' | 'model' | 'proxy';
           label: string;
           ok: boolean;
           error?: string;
@@ -3543,11 +3543,11 @@ export class MCPAdapter {
           });
         }
 
-        if (translate !== undefined) {
-          const result = saveAgentConfig(agent, 'translate', translate);
+        if (proxy !== undefined) {
+          const result = saveAgentConfig(agent, 'proxy', proxy);
           attempts.push({
-            key: 'translate',
-            label: translate === '' ? 'translate cleared' : `translate set to ${translate}`,
+            key: 'proxy',
+            label: proxy === '' ? 'proxy cleared' : `proxy set to ${proxy}`,
             ok: result.ok,
             error: result.ok ? undefined : result.error,
           });
@@ -3579,18 +3579,18 @@ export class MCPAdapter {
         const currentConfig = loadAgentConfig(agent);
         const effectiveBaseUrl = baseUrl !== undefined ? baseUrl : currentConfig.baseUrl;
         const effectiveApiKey = apiKey ?? currentConfig.apiKey;
-        const effectiveTranslate = translate !== undefined ? translate : currentConfig.translate;
+        const effectiveProxy = proxy !== undefined ? proxy : currentConfig.proxy;
 
         const warnings: string[] = [];
         const baseUrlWarning = this.getClaudeBaseUrlWarning(agent, effectiveBaseUrl, effectiveApiKey);
         if (baseUrlWarning) warnings.push(baseUrlWarning);
 
-        // Warn when translate is set but required fields are missing
-        if (effectiveTranslate) {
-          if (!effectiveBaseUrl) warnings.push('translate requires baseUrl to be set');
-          if (!effectiveApiKey) warnings.push('translate requires apiKey to be set');
+        // Warn when proxy is set but required fields are missing
+        if (effectiveProxy) {
+          if (!effectiveBaseUrl) warnings.push('proxy requires baseUrl to be set');
+          if (!effectiveApiKey) warnings.push('proxy requires apiKey to be set');
           if (!currentConfig.model && !attempts.some((a) => a.key === 'model'))
-            warnings.push('translate requires model to be set');
+            warnings.push('proxy requires model to be set');
         }
 
         // Probe connectivity when a baseUrl-related field was changed and baseUrl is available.
@@ -3598,7 +3598,7 @@ export class MCPAdapter {
         // as a warning (not a diagnostic payload) — probe network errors are silently ignored
         // because the write succeeded regardless of transient connectivity. This differs from
         // the check action, which includes full probe diagnostics for user inspection.
-        if ((baseUrl !== undefined || apiKey !== undefined || translate !== undefined) && effectiveBaseUrl) {
+        if ((baseUrl !== undefined || apiKey !== undefined || proxy !== undefined) && effectiveBaseUrl) {
           const probeResult = await probeUrl(effectiveBaseUrl, {
             apiKey: effectiveApiKey,
             timeoutMs: 5000,

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -66,13 +66,9 @@ import { MCP_INSTRUCTIONS } from './mcp-instructions.js';
 // Zod schemas for MCP protocol validation
 // Exported for unit-testing schema validation independently of the MCP protocol layer
 
-// Reusable model schema — enforces safe characters to prevent shell injection via agent flags.
-// Pattern: letters, digits, dots, underscores, and hyphens only (e.g. "claude-opus-4-5").
-const modelSchema = z
-  .string()
-  .min(1)
-  .max(200)
-  .regex(/^[a-zA-Z0-9._-]+$/, 'Model name must contain only letters, digits, dots, underscores, and hyphens');
+// Model names are opaque to autobeat — validation is the agent CLI's responsibility.
+// Length bounds prevent abuse; format is not constrained (models use /, :, @ separators).
+const modelSchema = z.string().min(1).max(200);
 
 export const DelegateTaskSchema = z.object({
   prompt: z.string().min(1),
@@ -1765,7 +1761,7 @@ export class MCPAdapter {
                   runtime: {
                     type: 'string',
                     description:
-                      'Runtime to wrap agent spawns (set action). Supported: "ollama". Wraps spawn with `ollama launch`. Supported agents: claude, codex. Empty string clears.',
+                      'Runtime to wrap agent spawns (set action). Supported: "ollama". Wraps spawn with `ollama launch`. Supported agents: claude, codex. Mutually exclusive with proxy — runtime takes precedence. Empty string clears.',
                   },
                 },
                 required: ['agent'],
@@ -3433,6 +3429,25 @@ export class MCPAdapter {
    * Actions: check auth status, set API key, reset stored key
    */
   private async handleConfigureAgent(args: unknown): Promise<MCPToolResponse> {
+    // Reject legacy 'translate' field with migration message (must precede safeParse — Zod strips unknown keys)
+    if (typeof args === 'object' && args !== null && 'translate' in args) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                success: false,
+                error: 'The "translate" field has been renamed to "proxy". Use proxy: "openai" instead.',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
     const parseResult = ConfigureAgentSchema.safeParse(args);
     if (!parseResult.success) {
       return {
@@ -3476,7 +3491,12 @@ export class MCPAdapter {
           }
         }
 
-        const checkWarning = this.getClaudeBaseUrlWarning(agent, agentConfig.baseUrl, agentConfig.apiKey);
+        const checkWarnings: string[] = [];
+        const baseUrlWarning = this.getClaudeBaseUrlWarning(agent, agentConfig.baseUrl, agentConfig.apiKey);
+        if (baseUrlWarning) checkWarnings.push(baseUrlWarning);
+        if (agentConfig.runtime && agentConfig.proxy) {
+          checkWarnings.push('runtime and proxy are mutually exclusive — runtime takes precedence');
+        }
         const checkPayload = {
           success: true,
           ...status,
@@ -3485,7 +3505,7 @@ export class MCPAdapter {
           ...(agentConfig.model && { model: agentConfig.model }),
           ...(agentConfig.proxy && { proxy: agentConfig.proxy }),
           ...(agentConfig.runtime && { runtime: agentConfig.runtime }),
-          ...(checkWarning && { warning: checkWarning }),
+          ...(checkWarnings.length > 0 && { warning: checkWarnings.join('. ') }),
           ...(connectivity !== undefined && { connectivity }),
         };
 
@@ -3649,6 +3669,8 @@ export class MCPAdapter {
           warnings.push('runtime and proxy are mutually exclusive — runtime takes precedence');
         }
 
+        // DECISION: Probe skipped when only runtime changes — runtime handles API routing locally,
+        // so connectivity to the configured baseUrl is not relevant.
         // Probe connectivity when a baseUrl-related field was changed and baseUrl is available.
         // DESIGN: On set, the save already succeeded so we only surface non-ok probe results
         // as a warning (not a diagnostic payload) — probe network errors are silently ignored

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -19,7 +19,10 @@ import {
   loadAgentConfig,
   resetAgentConfig,
   saveAgentConfig,
+  isRuntimeSupportedForAgent,
   PROXY_TARGETS,
+  RUNTIME_AGENT_SUPPORT,
+  RUNTIME_TARGETS,
 } from '../core/configuration.js';
 import {
   EvalMode,
@@ -385,6 +388,13 @@ const ConfigureAgentSchema = z.object({
     .optional()
     .describe(
       'API proxy target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
+    ),
+  runtime: z
+    // RUNTIME_TARGETS is the canonical list; '' is the "clear" sentinel.
+    .enum([...RUNTIME_TARGETS, ''] as const satisfies readonly [string, ...string[]])
+    .optional()
+    .describe(
+      'Runtime to wrap agent spawns (set action). Supported: "ollama". Wraps spawn with `ollama launch`. Supported agents: claude, codex. Mutually exclusive with proxy — runtime takes precedence. Empty string clears.',
     ),
 });
 
@@ -1752,6 +1762,11 @@ export class MCPAdapter {
                     description:
                       'API proxy target (set action). Supported: "openai". Routes Anthropic API calls through a local proxy that translates to the target format. Requires baseUrl and apiKey. Empty string clears.',
                   },
+                  runtime: {
+                    type: 'string',
+                    description:
+                      'Runtime to wrap agent spawns (set action). Supported: "ollama". Wraps spawn with `ollama launch`. Supported agents: claude, codex. Empty string clears.',
+                  },
                 },
                 required: ['agent'],
               },
@@ -3076,6 +3091,7 @@ export class MCPAdapter {
         ...(agentConfig.baseUrl && { baseUrl: agentConfig.baseUrl }),
         ...(agentConfig.model && { model: agentConfig.model }),
         ...(agentConfig.proxy && { proxy: agentConfig.proxy }),
+        ...(agentConfig.runtime && { runtime: agentConfig.runtime }),
         ...(claudeBaseUrlWarning && { warning: claudeBaseUrlWarning }),
       };
     });
@@ -3437,7 +3453,7 @@ export class MCPAdapter {
       };
     }
 
-    const { agent, action, apiKey, baseUrl, model, proxy } = parseResult.data;
+    const { agent, action, apiKey, baseUrl, model, proxy, runtime } = parseResult.data;
 
     switch (action) {
       case 'check': {
@@ -3468,6 +3484,7 @@ export class MCPAdapter {
           ...(agentConfig.baseUrl && { baseUrl: agentConfig.baseUrl }),
           ...(agentConfig.model && { model: agentConfig.model }),
           ...(agentConfig.proxy && { proxy: agentConfig.proxy }),
+          ...(agentConfig.runtime && { runtime: agentConfig.runtime }),
           ...(checkWarning && { warning: checkWarning }),
           ...(connectivity !== undefined && { connectivity }),
         };
@@ -3483,7 +3500,7 @@ export class MCPAdapter {
       }
 
       case 'set': {
-        if (!apiKey && !baseUrl && !model && proxy === undefined) {
+        if (!apiKey && !baseUrl && !model && proxy === undefined && runtime === undefined) {
           return {
             content: [
               {
@@ -3491,7 +3508,30 @@ export class MCPAdapter {
                 text: JSON.stringify(
                   {
                     success: false,
-                    error: 'At least one of apiKey, baseUrl, model, or proxy is required for set action',
+                    error: 'At least one of apiKey, baseUrl, model, proxy, or runtime is required for set action',
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Validate agent-runtime compatibility before writing
+        // runtime is 'ollama' | '' — truthy check excludes the clear-sentinel ''
+        if (runtime && !isRuntimeSupportedForAgent(runtime, agent)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    success: false,
+                    error:
+                      `Runtime '${runtime}' does not support agent '${agent}'. ` +
+                      `Supported agents: ${RUNTIME_AGENT_SUPPORT[runtime].join(', ')}`,
                   },
                   null,
                   2,
@@ -3506,7 +3546,7 @@ export class MCPAdapter {
         // result before returning so that a late failure reports which fields
         // were already saved and which failed.
         type WriteAttempt = {
-          key: 'apiKey' | 'baseUrl' | 'model' | 'proxy';
+          key: 'apiKey' | 'baseUrl' | 'model' | 'proxy' | 'runtime';
           label: string;
           ok: boolean;
           error?: string;
@@ -3553,6 +3593,16 @@ export class MCPAdapter {
           });
         }
 
+        if (runtime !== undefined) {
+          const result = saveAgentConfig(agent, 'runtime', runtime);
+          attempts.push({
+            key: 'runtime',
+            label: runtime === '' ? 'runtime cleared' : `runtime set to ${runtime}`,
+            ok: result.ok,
+            error: result.ok ? undefined : result.error,
+          });
+        }
+
         const failed = attempts.filter((a) => !a.ok);
         if (failed.length > 0) {
           const saved = attempts.filter((a) => a.ok).map((a) => a.key);
@@ -3580,6 +3630,7 @@ export class MCPAdapter {
         const effectiveBaseUrl = baseUrl !== undefined ? baseUrl : currentConfig.baseUrl;
         const effectiveApiKey = apiKey ?? currentConfig.apiKey;
         const effectiveProxy = proxy !== undefined ? proxy : currentConfig.proxy;
+        const effectiveRuntime = runtime !== undefined ? runtime : currentConfig.runtime;
 
         const warnings: string[] = [];
         const baseUrlWarning = this.getClaudeBaseUrlWarning(agent, effectiveBaseUrl, effectiveApiKey);
@@ -3591,6 +3642,11 @@ export class MCPAdapter {
           if (!effectiveApiKey) warnings.push('proxy requires apiKey to be set');
           if (!currentConfig.model && !attempts.some((a) => a.key === 'model'))
             warnings.push('proxy requires model to be set');
+        }
+
+        // Warn when both runtime and proxy are set (runtime takes precedence)
+        if (effectiveRuntime && effectiveProxy) {
+          warnings.push('runtime and proxy are mutually exclusive — runtime takes precedence');
         }
 
         // Probe connectivity when a baseUrl-related field was changed and baseUrl is available.

--- a/src/adapters/mcp-instructions.ts
+++ b/src/adapters/mcp-instructions.ts
@@ -101,20 +101,20 @@ Use ConfigureAgent to configure per-agent defaults that apply when no per-task o
 - action: "set", apiKey: "sk-..." → store API key
 - action: "set", baseUrl: "https://proxy.example.com/v1" → route requests through a proxy
 - action: "set", model: "claude-opus-4-5" → default model for all tasks using that agent
-- action: "set", translate: "openai" → route Anthropic API calls through a translation proxy to an OpenAI-compatible backend
-- action: "check" → see current auth status and stored config (baseUrl/model/translate shown when set)
+- action: "set", proxy: "openai" → route Anthropic API calls through a translation proxy to an OpenAI-compatible backend
+- action: "check" → see current auth status and stored config (baseUrl/model/proxy shown when set)
 - action: "reset" → clear all stored config for the agent
 
-### API Translation (translate)
-Use \`translate\` to route Claude Code workers through any OpenAI-compatible API backend:
-1. ConfigureAgent action: "set", agent: "claude", translate: "openai"
+### API Proxy (proxy)
+Use \`proxy\` to route Claude Code workers through any OpenAI-compatible API backend:
+1. ConfigureAgent action: "set", agent: "claude", proxy: "openai"
 2. ConfigureAgent action: "set", agent: "claude", baseUrl: "https://integrate.api.nvidia.com/v1"
 3. ConfigureAgent action: "set", agent: "claude", apiKey: "nvapi-..."
 4. ConfigureAgent action: "set", agent: "claude", model: "moonshotai/kimi-k2-thinking"
 
-When translate is set, a local proxy starts automatically at boot that translates Anthropic Messages API requests into OpenAI Chat Completions format. Claude Code is unaware — it sends its normal API calls which are transparently translated. Supported targets: "openai".
+When proxy is set, a local proxy starts automatically at boot that translates Anthropic Messages API requests into OpenAI Chat Completions format. Claude Code is unaware — it sends its normal API calls which are transparently translated. Supported targets: "openai".
 
-Set translate to "" (empty string) to disable translation and return to direct Anthropic API access.
+Set proxy to "" (empty string) to disable and return to direct Anthropic API access.
 
 Model resolution order (highest priority wins):
 1. Per-task \`model\` field (DelegateTask, pipeline step, etc.)

--- a/src/adapters/mcp-instructions.ts
+++ b/src/adapters/mcp-instructions.ts
@@ -121,8 +121,10 @@ Use \`runtime\` to run agents through Ollama for local model execution:
 1. ConfigureAgent action: "set", agent: "claude", runtime: "ollama"
 2. ConfigureAgent action: "set", agent: "claude", model: "qwen3.6"
 
-When runtime is "ollama", spawns are wrapped with \`ollama launch\`, which handles
-model routing and API compatibility. Ollama must be installed and running.
+When runtime is "ollama", spawns are wrapped with \`ollama launch --yes\`, which handles
+model routing, API compatibility, and automatic model download acceptance. Ollama must
+be installed and running. First execution with a new model may be slow due to download.
+Pre-pull with: \`ollama pull <model>\`.
 
 Supported agents: claude, codex. Gemini CLI is not supported by ollama launch.
 

--- a/src/adapters/mcp-instructions.ts
+++ b/src/adapters/mcp-instructions.ts
@@ -116,6 +116,20 @@ When proxy is set, a local proxy starts automatically at boot that translates An
 
 Set proxy to "" (empty string) to disable and return to direct Anthropic API access.
 
+### Ollama Runtime (runtime)
+Use \`runtime\` to run agents through Ollama for local model execution:
+1. ConfigureAgent action: "set", agent: "claude", runtime: "ollama"
+2. ConfigureAgent action: "set", agent: "claude", model: "qwen3.6"
+
+When runtime is "ollama", spawns are wrapped with \`ollama launch\`, which handles
+model routing and API compatibility. Ollama must be installed and running.
+
+Supported agents: claude, codex. Gemini CLI is not supported by ollama launch.
+
+Set runtime to "" (empty string) to disable and return to direct API access.
+
+Note: runtime and proxy are mutually exclusive — runtime takes precedence.
+
 Model resolution order (highest priority wins):
 1. Per-task \`model\` field (DelegateTask, pipeline step, etc.)
 2. Agent config default (\`ConfigureAgent\` set model)

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -412,7 +412,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
     const claudeConfig = loadAgentConfig('claude');
     // DECISION: Skip proxy startup when runtime is set — runtime (e.g. ollama) handles
     // API routing itself, so the translation proxy is not needed and would conflict.
-    const proxyConfig = claudeConfig.runtime ? null : loadProxyConfig('claude');
+    const proxyConfig = claudeConfig.runtime ? null : loadProxyConfig('claude', claudeConfig);
     if (proxyConfig !== null) {
       const proxyManager = new ProxyManager(proxyConfig, logger.child({ module: 'ProxyManager' }));
       const proxyResult = await proxyManager.start();

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -381,7 +381,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   container.registerSingleton('taskQueue', () => new PriorityTaskQueue());
 
   // ============================================================================
-  // Translation proxy — optional, activated by agents.claude.translate config
+  // Translation proxy — optional, activated by agents.claude.proxy config
   //
   // ARCHITECTURE: If proxy config exists, start a local TranslationProxy that
   // routes Anthropic Messages API requests to an OpenAI-compatible backend.
@@ -402,7 +402,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   // when a processSpawner is injected (tests with mock spawners).
   //
   // DECISION: Proxy failure is fatal when config exists. The user
-  // explicitly configured translate — falling back to direct Anthropic API
+  // explicitly configured proxy — falling back to direct Anthropic API
   // would fail (wrong key/model) and produce confusing downstream errors.
   // Error message includes remediation steps for working without the proxy.
   // ============================================================================
@@ -423,7 +423,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
           new AutobeatError(
             ErrorCode.CONFIGURATION_ERROR,
             `Translation proxy failed to start: ${proxyResult.error.message}. ` +
-              'To work without the proxy, run: beat agents config set claude translate ""',
+              'To work without the proxy, run: beat agents config set claude proxy ""',
             { error: proxyResult.error.message },
           ),
         );

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -4,7 +4,7 @@
  */
 
 import { validateConfiguration } from './core/config-validator.js';
-import { Configuration, loadConfiguration } from './core/configuration.js';
+import { Configuration, loadAgentConfig, loadConfiguration } from './core/configuration.js';
 import { Container } from './core/container.js';
 import { AutobeatError, ErrorCode } from './core/errors.js';
 import { EventBus, InMemoryEventBus } from './core/events/event-bus.js';
@@ -409,7 +409,10 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   let proxyPort: number | undefined;
 
   if (!options.processSpawner && !skipProxy) {
-    const proxyConfig = loadProxyConfig('claude');
+    const claudeConfig = loadAgentConfig('claude');
+    // DECISION: Skip proxy startup when runtime is set — runtime (e.g. ollama) handles
+    // API routing itself, so the translation proxy is not needed and would conflict.
+    const proxyConfig = claudeConfig.runtime ? null : loadProxyConfig('claude');
     if (proxyConfig !== null) {
       const proxyManager = new ProxyManager(proxyConfig, logger.child({ module: 'ProxyManager' }));
       const proxyResult = await proxyManager.start();

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -98,9 +98,9 @@ export async function checkAgents(): Promise<void> {
     }
 
     if (agentConfig.runtime) {
-      const ollamaFound = isCommandInPath('ollama');
-      const ollamaStatus = ollamaFound ? ui.cyan('[found]') : '[not found]';
-      ui.info(`  ${ui.dim(`runtime: ${agentConfig.runtime} — ollama CLI ${ollamaStatus}`)}`);
+      const runtimeFound = isCommandInPath(agentConfig.runtime);
+      const runtimeStatus = runtimeFound ? ui.cyan('[found]') : '[not found]';
+      ui.info(`  ${ui.dim(`runtime: ${agentConfig.runtime} — ${agentConfig.runtime} CLI ${runtimeStatus}`)}`);
     }
   }
 
@@ -184,12 +184,13 @@ export async function agentsConfigSet(
     ui.success(`${agent}.${key} saved: ${value}`);
   }
 
+  const updatedConfig = loadAgentConfig(agent);
+
   // Probe connectivity when a URL/auth/proxy field is changed and non-empty
   if ((key === 'baseUrl' || key === 'apiKey' || key === 'proxy') && value !== '') {
-    const config = loadAgentConfig(agent);
-    const effectiveBaseUrl = key === 'baseUrl' ? value : config.baseUrl;
+    const effectiveBaseUrl = key === 'baseUrl' ? value : updatedConfig.baseUrl;
     if (effectiveBaseUrl) {
-      const effectiveApiKey = key === 'apiKey' ? value : config.apiKey;
+      const effectiveApiKey = key === 'apiKey' ? value : updatedConfig.apiKey;
       const probeResult = await probeUrl(effectiveBaseUrl, {
         apiKey: effectiveApiKey,
         timeoutMs: 5000,
@@ -207,20 +208,17 @@ export async function agentsConfigSet(
 
   // Warn when proxy is set but required fields are missing
   if (key === 'proxy' && value !== '') {
-    const config = loadAgentConfig(agent);
-    if (!config.baseUrl) ui.note('proxy requires baseUrl to be set', 'Warning');
-    if (!config.apiKey) ui.note('proxy requires apiKey to be set', 'Warning');
-    if (!config.model) ui.note('proxy requires model to be set', 'Warning');
+    if (!updatedConfig.baseUrl) ui.note('proxy requires baseUrl to be set', 'Warning');
+    if (!updatedConfig.apiKey) ui.note('proxy requires apiKey to be set', 'Warning');
+    if (!updatedConfig.model) ui.note('proxy requires model to be set', 'Warning');
   }
 
   // Warn about mutual exclusivity between runtime and proxy
   if (key === 'runtime' && value !== '') {
-    const config = loadAgentConfig(agent);
-    if (config.proxy) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
+    if (updatedConfig.proxy) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
   }
   if (key === 'proxy' && value !== '') {
-    const config = loadAgentConfig(agent);
-    if (config.runtime) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
+    if (updatedConfig.runtime) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
   }
 
   process.exit(0);

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -23,11 +23,11 @@ import {
   loadAgentConfig,
   loadConfiguration,
   PROXY_TARGETS,
-  resetAgentConfig,
   RUNTIME_AGENT_SUPPORT,
   RUNTIME_TARGETS,
-  saveAgentConfig,
   type Runtime,
+  resetAgentConfig,
+  saveAgentConfig,
 } from '../../core/configuration.js';
 import { probeUrl } from '../../utils/url-probe.js';
 import * as ui from '../ui.js';

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -218,7 +218,8 @@ export async function agentsConfigSet(
     if (updatedConfig.proxy) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
   }
   if (key === 'proxy' && value !== '') {
-    if (updatedConfig.runtime) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
+    if (updatedConfig.runtime)
+      ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
   }
 
   process.exit(0);

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -22,7 +22,7 @@ import {
   loadConfiguration,
   resetAgentConfig,
   saveAgentConfig,
-  TRANSLATE_TARGETS,
+  PROXY_TARGETS,
 } from '../../core/configuration.js';
 import { probeUrl } from '../../utils/url-probe.js';
 import * as ui from '../ui.js';
@@ -105,7 +105,7 @@ export async function agentsConfigSet(
   value: string | undefined,
 ): Promise<void> {
   if (!agent || !key || !value) {
-    ui.error('Usage: beat agents config set <agent> <apiKey|baseUrl|model|translate> <value>');
+    ui.error('Usage: beat agents config set <agent> <apiKey|baseUrl|model|proxy> <value>');
     process.exit(1);
   }
 
@@ -114,8 +114,8 @@ export async function agentsConfigSet(
     process.exit(1);
   }
 
-  if (key !== 'apiKey' && key !== 'baseUrl' && key !== 'model' && key !== 'translate') {
-    ui.error(`Unknown config key: "${key}". Valid keys: apiKey, baseUrl, model, translate`);
+  if (key !== 'apiKey' && key !== 'baseUrl' && key !== 'model' && key !== 'proxy') {
+    ui.error(`Unknown config key: "${key}". Valid keys: apiKey, baseUrl, model, proxy`);
     process.exit(1);
   }
 
@@ -127,10 +127,10 @@ export async function agentsConfigSet(
     );
   }
 
-  // Validate translate is a supported target (empty string clears)
-  if (key === 'translate' && value !== '') {
-    if (!(TRANSLATE_TARGETS as readonly string[]).includes(value)) {
-      ui.error(`Unsupported translate target: "${value}". Supported values: ${TRANSLATE_TARGETS.join(', ')}`);
+  // Validate proxy is a supported target (empty string clears)
+  if (key === 'proxy' && value !== '') {
+    if (!(PROXY_TARGETS as readonly string[]).includes(value)) {
+      ui.error(`Unsupported proxy target: "${value}". Supported values: ${PROXY_TARGETS.join(', ')}`);
       process.exit(1);
     }
   }
@@ -157,8 +157,8 @@ export async function agentsConfigSet(
     ui.success(`${agent}.${key} saved: ${value}`);
   }
 
-  // Probe connectivity when a URL/auth/translate field is changed and non-empty
-  if ((key === 'baseUrl' || key === 'apiKey' || key === 'translate') && value !== '') {
+  // Probe connectivity when a URL/auth/proxy field is changed and non-empty
+  if ((key === 'baseUrl' || key === 'apiKey' || key === 'proxy') && value !== '') {
     const config = loadAgentConfig(agent);
     const effectiveBaseUrl = key === 'baseUrl' ? value : config.baseUrl;
     if (effectiveBaseUrl) {
@@ -178,12 +178,12 @@ export async function agentsConfigSet(
     }
   }
 
-  // Warn when translate is set but required fields are missing
-  if (key === 'translate' && value !== '') {
+  // Warn when proxy is set but required fields are missing
+  if (key === 'proxy' && value !== '') {
     const config = loadAgentConfig(agent);
-    if (!config.baseUrl) ui.note('translate requires baseUrl to be set', 'Warning');
-    if (!config.apiKey) ui.note('translate requires apiKey to be set', 'Warning');
-    if (!config.model) ui.note('translate requires model to be set', 'Warning');
+    if (!config.baseUrl) ui.note('proxy requires baseUrl to be set', 'Warning');
+    if (!config.apiKey) ui.note('proxy requires apiKey to be set', 'Warning');
+    if (!config.model) ui.note('proxy requires model to be set', 'Warning');
   }
 
   process.exit(0);
@@ -215,8 +215,8 @@ export async function agentsConfigShow(agent?: string): Promise<void> {
     if (config.model) {
       parts.push(`model: ${config.model}`);
     }
-    if (config.translate) {
-      parts.push(`translate: ${config.translate}`);
+    if (config.proxy) {
+      parts.push(`proxy: ${config.proxy}`);
     }
 
     if (parts.length > 0) {

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -15,14 +15,19 @@ import {
   AGENT_PROVIDERS,
   checkAgentAuth,
   isAgentProvider,
+  isCommandInPath,
   maskApiKey,
 } from '../../core/agents.js';
 import {
+  isRuntimeSupportedForAgent,
   loadAgentConfig,
   loadConfiguration,
-  resetAgentConfig,
-  saveAgentConfig,
   PROXY_TARGETS,
+  resetAgentConfig,
+  RUNTIME_AGENT_SUPPORT,
+  RUNTIME_TARGETS,
+  saveAgentConfig,
+  type Runtime,
 } from '../../core/configuration.js';
 import { probeUrl } from '../../utils/url-probe.js';
 import * as ui from '../ui.js';
@@ -91,6 +96,12 @@ export async function checkAgents(): Promise<void> {
         ui.info(`  ${ui.dim(line)}`);
       }
     }
+
+    if (agentConfig.runtime) {
+      const ollamaFound = isCommandInPath('ollama');
+      const ollamaStatus = ollamaFound ? ui.cyan('[found]') : '[not found]';
+      ui.info(`  ${ui.dim(`runtime: ${agentConfig.runtime} — ollama CLI ${ollamaStatus}`)}`);
+    }
   }
 
   process.exit(0);
@@ -105,7 +116,7 @@ export async function agentsConfigSet(
   value: string | undefined,
 ): Promise<void> {
   if (!agent || !key || !value) {
-    ui.error('Usage: beat agents config set <agent> <apiKey|baseUrl|model|proxy> <value>');
+    ui.error('Usage: beat agents config set <agent> <apiKey|baseUrl|model|proxy|runtime> <value>');
     process.exit(1);
   }
 
@@ -114,8 +125,8 @@ export async function agentsConfigSet(
     process.exit(1);
   }
 
-  if (key !== 'apiKey' && key !== 'baseUrl' && key !== 'model' && key !== 'proxy') {
-    ui.error(`Unknown config key: "${key}". Valid keys: apiKey, baseUrl, model, proxy`);
+  if (key !== 'apiKey' && key !== 'baseUrl' && key !== 'model' && key !== 'proxy' && key !== 'runtime') {
+    ui.error(`Unknown config key: "${key}". Valid keys: apiKey, baseUrl, model, proxy, runtime`);
     process.exit(1);
   }
 
@@ -131,6 +142,22 @@ export async function agentsConfigSet(
   if (key === 'proxy' && value !== '') {
     if (!(PROXY_TARGETS as readonly string[]).includes(value)) {
       ui.error(`Unsupported proxy target: "${value}". Supported values: ${PROXY_TARGETS.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  // Validate runtime is a supported target (empty string clears)
+  if (key === 'runtime' && value !== '') {
+    if (!(RUNTIME_TARGETS as readonly string[]).includes(value)) {
+      ui.error(`Unsupported runtime: "${value}". Supported values: ${RUNTIME_TARGETS.join(', ')}`);
+      process.exit(1);
+    }
+    // Check agent-runtime compatibility
+    if (!isRuntimeSupportedForAgent(value as Runtime, agent)) {
+      ui.error(
+        `Runtime '${value}' does not support agent '${agent}'. ` +
+          `Supported agents: ${RUNTIME_AGENT_SUPPORT[value as Runtime].join(', ')}`,
+      );
       process.exit(1);
     }
   }
@@ -186,6 +213,16 @@ export async function agentsConfigSet(
     if (!config.model) ui.note('proxy requires model to be set', 'Warning');
   }
 
+  // Warn about mutual exclusivity between runtime and proxy
+  if (key === 'runtime' && value !== '') {
+    const config = loadAgentConfig(agent);
+    if (config.proxy) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
+  }
+  if (key === 'proxy' && value !== '') {
+    const config = loadAgentConfig(agent);
+    if (config.runtime) ui.note('runtime and proxy are mutually exclusive — runtime takes precedence', 'Warning');
+  }
+
   process.exit(0);
 }
 
@@ -217,6 +254,9 @@ export async function agentsConfigShow(agent?: string): Promise<void> {
     }
     if (config.proxy) {
       parts.push(`proxy: ${config.proxy}`);
+    }
+    if (config.runtime) {
+      parts.push(`runtime: ${config.runtime}`);
     }
 
     if (parts.length > 0) {

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -228,23 +228,23 @@ export function resetConfigValue(key: string): ConfigWriteResult {
 // ============================================================================
 
 /**
- * Supported API translation targets as a const tuple.
- * Single source of truth — derive TranslateTarget and all runtime arrays from this.
+ * Supported API proxy targets as a const tuple.
+ * Single source of truth — derive ProxyTarget and all runtime arrays from this.
  * Empty string is the "clear" sentinel accepted at save boundaries (CLI, MCP); it is
  * NOT included here because stored config never holds an empty string.
  */
-export const TRANSLATE_TARGETS = ['openai'] as const satisfies readonly string[];
+export const PROXY_TARGETS = ['openai'] as const satisfies readonly string[];
 
 /**
- * Union type derived from TRANSLATE_TARGETS — no manual sync required.
+ * Union type derived from PROXY_TARGETS — no manual sync required.
  */
-export type TranslateTarget = (typeof TRANSLATE_TARGETS)[number];
+export type ProxyTarget = (typeof PROXY_TARGETS)[number];
 
 export interface AgentConfig {
   readonly apiKey?: string;
   readonly baseUrl?: string;
   readonly model?: string;
-  readonly translate?: TranslateTarget;
+  readonly proxy?: ProxyTarget;
 }
 
 /**
@@ -261,12 +261,12 @@ export function loadAgentConfig(provider: AgentProvider): AgentConfig {
     apiKey: typeof record.apiKey === 'string' ? record.apiKey : undefined,
     baseUrl: typeof record.baseUrl === 'string' ? record.baseUrl : undefined,
     model: typeof record.model === 'string' ? record.model : undefined,
-    // DECISION: Intentional early narrowing — only accept known TranslateTarget values.
+    // DECISION: Intentional early narrowing — only accept known ProxyTarget values.
     // Unknown stored values (e.g. from a downgraded install) are silently dropped here
     // rather than propagating an invalid string downstream. Low practical risk: only
     // 'openai' has ever been functional.
-    translate: (TRANSLATE_TARGETS as readonly string[]).includes(record.translate as string)
-      ? (record.translate as TranslateTarget)
+    proxy: (PROXY_TARGETS as readonly string[]).includes(record.proxy as string)
+      ? (record.proxy as ProxyTarget)
       : undefined,
   };
 }
@@ -280,7 +280,7 @@ export function loadAgentConfig(provider: AgentProvider): AgentConfig {
  */
 export function saveAgentConfig(
   provider: AgentProvider,
-  key: 'apiKey' | 'baseUrl' | 'model' | 'translate',
+  key: 'apiKey' | 'baseUrl' | 'model' | 'proxy',
   value: string,
 ): ConfigWriteResult {
   const existing = loadConfigFile();

--- a/src/core/configuration.ts
+++ b/src/core/configuration.ts
@@ -240,11 +240,41 @@ export const PROXY_TARGETS = ['openai'] as const satisfies readonly string[];
  */
 export type ProxyTarget = (typeof PROXY_TARGETS)[number];
 
+/**
+ * Supported runtime targets as a const tuple.
+ * Runtimes wrap the agent CLI command (e.g. 'ollama launch claude ...').
+ * Empty string is the "clear" sentinel accepted at save boundaries; it is
+ * NOT included here because stored config never holds an empty string.
+ */
+export const RUNTIME_TARGETS = ['ollama'] as const satisfies readonly string[];
+
+/**
+ * Union type derived from RUNTIME_TARGETS — no manual sync required.
+ */
+export type Runtime = (typeof RUNTIME_TARGETS)[number];
+
+/**
+ * Which agent providers each runtime supports.
+ * Gemini CLI is not supported by 'ollama launch'.
+ */
+export const RUNTIME_AGENT_SUPPORT: Readonly<Record<Runtime, readonly AgentProvider[]>> = Object.freeze({
+  ollama: ['claude', 'codex'],
+});
+
+/**
+ * Returns true when the given runtime supports the given agent provider.
+ * Put here (not agents.ts) to avoid circular imports: configuration.ts → agents.ts.
+ */
+export function isRuntimeSupportedForAgent(runtime: Runtime, provider: AgentProvider): boolean {
+  return (RUNTIME_AGENT_SUPPORT[runtime] as readonly string[]).includes(provider);
+}
+
 export interface AgentConfig {
   readonly apiKey?: string;
   readonly baseUrl?: string;
   readonly model?: string;
   readonly proxy?: ProxyTarget;
+  readonly runtime?: Runtime;
 }
 
 /**
@@ -268,6 +298,9 @@ export function loadAgentConfig(provider: AgentProvider): AgentConfig {
     proxy: (PROXY_TARGETS as readonly string[]).includes(record.proxy as string)
       ? (record.proxy as ProxyTarget)
       : undefined,
+    runtime: (RUNTIME_TARGETS as readonly string[]).includes(record.runtime as string)
+      ? (record.runtime as Runtime)
+      : undefined,
   };
 }
 
@@ -280,7 +313,7 @@ export function loadAgentConfig(provider: AgentProvider): AgentConfig {
  */
 export function saveAgentConfig(
   provider: AgentProvider,
-  key: 'apiKey' | 'baseUrl' | 'model' | 'proxy',
+  key: 'apiKey' | 'baseUrl' | 'model' | 'proxy' | 'runtime',
   value: string,
 ): ConfigWriteResult {
   const existing = loadConfigFile();

--- a/src/implementations/base-agent-adapter.ts
+++ b/src/implementations/base-agent-adapter.ts
@@ -233,9 +233,9 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     const config = this.getSystemPromptConfig(systemPrompt, systemPromptPath);
 
     if (config.prependToPrompt) {
-      return { effectivePrompt: `${systemPrompt}\n\n${prompt}`, args: [...config.args], env: config.env };
+      return { effectivePrompt: `${systemPrompt}\n\n${prompt}`, args: config.args, env: config.env };
     }
-    return { effectivePrompt: prompt, args: [...config.args], env: config.env };
+    return { effectivePrompt: prompt, args: config.args, env: config.env };
   }
 
   private buildSpawnEnv(options: {
@@ -327,8 +327,11 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       const resolvedModel = runtimeConfig?.suppressModel ? undefined : this.resolveModel(agentConfig, model);
 
       // Resolve system prompt injection
-      const { effectivePrompt, args: systemPromptArgs, env: systemPromptEnv } =
-        this.resolveSystemPromptInjection(prompt, systemPrompt, taskId);
+      const {
+        effectivePrompt,
+        args: systemPromptArgs,
+        env: systemPromptEnv,
+      } = this.resolveSystemPromptInjection(prompt, systemPrompt, taskId);
 
       const finalPrompt = this.transformPrompt(effectivePrompt);
       const args = [...this.buildArgs(finalPrompt, resolvedModel, jsonSchema), ...systemPromptArgs];
@@ -396,7 +399,6 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
    * Default no-op cleanup. Adapters that write task-scoped files (e.g. Gemini)
    * override this to remove them.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   cleanup(_taskId: string): void {
     // no-op — subclasses override if they create task-scoped resources
   }

--- a/src/implementations/base-agent-adapter.ts
+++ b/src/implementations/base-agent-adapter.ts
@@ -197,11 +197,15 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       );
     }
 
+    // DECISION: Single-runtime direct dispatch. With one runtime ('ollama'), a strategy
+    // pattern would be over-engineering. The exhaustive guard below ensures compile-time
+    // error if RUNTIME_TARGETS gains a new entry without handler.
     if (agentConfig.runtime === 'ollama') {
       const effectiveModel = taskModel ?? agentConfig.model;
       const modelArgs: string[] = effectiveModel ? ['--model', effectiveModel] : [];
       return ok({
         command: 'ollama',
+        // --yes: auto-accept model downloads + license prompts (without it, ollama blocks on interactive confirmation)
         prependArgs: ['launch', this.command, ...modelArgs, '--yes', '--'],
         suppressModel: true,
         suppressAuth: true,
@@ -217,6 +221,64 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     );
   }
 
+  private resolveSystemPromptInjection(
+    prompt: string,
+    systemPrompt: string | undefined,
+    taskId: string | undefined,
+  ): { effectivePrompt: string; args: readonly string[]; env: Record<string, string> } {
+    if (!systemPrompt) return { effectivePrompt: prompt, args: [], env: {} };
+
+    const safeId = taskId ?? crypto.randomUUID().substring(0, 8);
+    const systemPromptPath = path.join(os.homedir(), '.autobeat', 'system-prompts', `${safeId}.md`);
+    const config = this.getSystemPromptConfig(systemPrompt, systemPromptPath);
+
+    if (config.prependToPrompt) {
+      return { effectivePrompt: `${systemPrompt}\n\n${prompt}`, args: [...config.args], env: config.env };
+    }
+    return { effectivePrompt: prompt, args: [...config.args], env: config.env };
+  }
+
+  private buildSpawnEnv(options: {
+    runtimeConfig: { suppressBaseUrl: boolean } | null;
+    agentConfig: AgentConfig;
+    authEnv: Record<string, string>;
+    systemPromptEnv: Record<string, string>;
+    taskId?: string;
+    orchestratorId?: string;
+  }): Record<string, string> {
+    const exactMatches = this.envExactMatchesToStrip;
+    const cleanEnv = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key]) => !this.envPrefixesToStrip.some((prefix) => key.startsWith(prefix)) && !exactMatches.includes(key),
+      ),
+    );
+    const baseUrlEnv = options.runtimeConfig?.suppressBaseUrl ? {} : this.resolveBaseUrl(options.agentConfig);
+
+    const ORCHESTRATOR_ID_RE = /^orchestrator-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    const safeOrchestratorId =
+      options.orchestratorId && ORCHESTRATOR_ID_RE.test(options.orchestratorId) ? options.orchestratorId : undefined;
+    if (options.orchestratorId && !safeOrchestratorId) {
+      console.error(
+        JSON.stringify({
+          level: 'warn',
+          message: 'spawn: dropping malformed AUTOBEAT_ORCHESTRATOR_ID — format did not match canonical pattern',
+          provider: this.provider,
+        }),
+      );
+    }
+
+    return {
+      ...this.additionalEnv,
+      ...cleanEnv,
+      ...options.authEnv,
+      ...baseUrlEnv,
+      ...options.systemPromptEnv,
+      AUTOBEAT_WORKER: 'true',
+      ...(options.taskId && { AUTOBEAT_TASK_ID: options.taskId }),
+      ...(safeOrchestratorId && { AUTOBEAT_ORCHESTRATOR_ID: safeOrchestratorId }),
+    };
+  }
+
   spawn({
     prompt,
     workingDirectory,
@@ -227,6 +289,9 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     systemPrompt,
   }: SpawnOptions): Result<{ process: ChildProcess; pid: number }> {
     try {
+      // DECISION: Runtime takes precedence over proxy. When runtime is set, auth/baseUrl/model
+      // are suppressed from inner agent args. See also bootstrap.ts:413 (proxy startup skip)
+      // and mcp-adapter.ts set/check handlers (warning path).
       // Load agent config once — passed to resolveRuntime, resolveAuth, resolveBaseUrl, resolveModel
       // to avoid redundant readFileSync + JSON.parse calls per spawn
       const agentConfig = loadAgentConfig(this.provider);
@@ -262,71 +327,20 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       const resolvedModel = runtimeConfig?.suppressModel ? undefined : this.resolveModel(agentConfig, model);
 
       // Resolve system prompt injection
-      let effectivePrompt = prompt;
-      let systemPromptArgs: readonly string[] = [];
-      let systemPromptEnv: Record<string, string> = {};
-
-      if (systemPrompt) {
-        // Compute temp file path — passed to adapters that need to write a file (e.g. Gemini).
-        // Use a random suffix when taskId is absent to avoid path collisions across concurrent spawns.
-        const safeId = taskId ?? crypto.randomUUID().substring(0, 8);
-        const systemPromptPath = path.join(os.homedir(), '.autobeat', 'system-prompts', `${safeId}.md`);
-
-        const config = this.getSystemPromptConfig(systemPrompt, systemPromptPath);
-
-        if (config.prependToPrompt) {
-          // Adapter cannot inject via CLI args/env — prepend to user prompt as fallback
-          effectivePrompt = `${systemPrompt}\n\n${prompt}`;
-        } else {
-          // Adapter is responsible for any file I/O inside getSystemPromptConfig
-          systemPromptArgs = config.args;
-          systemPromptEnv = config.env;
-        }
-      }
+      const { effectivePrompt, args: systemPromptArgs, env: systemPromptEnv } =
+        this.resolveSystemPromptInjection(prompt, systemPrompt, taskId);
 
       const finalPrompt = this.transformPrompt(effectivePrompt);
       const args = [...this.buildArgs(finalPrompt, resolvedModel, jsonSchema), ...systemPromptArgs];
 
-      const exactMatches = this.envExactMatchesToStrip;
-      const cleanEnv = Object.fromEntries(
-        Object.entries(process.env).filter(
-          ([key]) => !this.envPrefixesToStrip.some((prefix) => key.startsWith(prefix)) && !exactMatches.includes(key),
-        ),
-      );
-      // Base URL suppressed from inner env when runtime handles API routing
-      const baseUrlEnv = runtimeConfig?.suppressBaseUrl ? {} : this.resolveBaseUrl(agentConfig);
-      // NOTE: AUTOBEAT_ prefix is NOT in envPrefixesToStrip — it is preserved in cleanEnv.
-      // We explicitly set AUTOBEAT_WORKER and AUTOBEAT_TASK_ID here, and optionally
-      // AUTOBEAT_ORCHESTRATOR_ID so sub-tasks spawned by this agent are attributed to
-      // the parent orchestration (v1.3.0).
-      //
-      // SECURITY: Validate orchestratorId format before injecting into child env.
-      // Belt-and-suspenders: the MCP path already validates via Zod, but the env var
-      // path (run.ts reading AUTOBEAT_ORCHESTRATOR_ID) or a persisted DB row may not
-      // have gone through the same boundary. Reject malformed values here to prevent
-      // log injection in child processes. Attribution silently fails but spawn succeeds.
-      const ORCHESTRATOR_ID_RE = /^orchestrator-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-      const safeOrchestratorId = orchestratorId && ORCHESTRATOR_ID_RE.test(orchestratorId) ? orchestratorId : undefined;
-      if (orchestratorId && !safeOrchestratorId) {
-        // Log structured warning — do not throw; spawn continues without attribution
-        console.error(
-          JSON.stringify({
-            level: 'warn',
-            message: 'spawn: dropping malformed AUTOBEAT_ORCHESTRATOR_ID — format did not match canonical pattern',
-            provider: this.provider,
-          }),
-        );
-      }
-      const env = {
-        ...this.additionalEnv,
-        ...cleanEnv,
-        ...authResult.value.injectedEnv,
-        ...baseUrlEnv,
-        ...systemPromptEnv,
-        AUTOBEAT_WORKER: 'true',
-        ...(taskId && { AUTOBEAT_TASK_ID: taskId }),
-        ...(safeOrchestratorId && { AUTOBEAT_ORCHESTRATOR_ID: safeOrchestratorId }),
-      };
+      const env = this.buildSpawnEnv({
+        runtimeConfig,
+        agentConfig,
+        authEnv: authResult.value.injectedEnv,
+        systemPromptEnv,
+        taskId,
+        orchestratorId,
+      });
 
       // When runtime is active, wrap the command: ollama launch <agent> [--model x] --yes -- <inner-args>
       const spawnCommand = runtimeConfig ? runtimeConfig.command : this.command;

--- a/src/implementations/base-agent-adapter.ts
+++ b/src/implementations/base-agent-adapter.ts
@@ -209,7 +209,12 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
       });
     }
 
-    return ok(null);
+    // Exhaustive guard: if a new runtime is added to RUNTIME_TARGETS but not handled
+    // above, fail loudly rather than silently ignoring the configuration.
+    const _exhaustive: never = agentConfig.runtime;
+    return err(
+      agentMisconfigured(this.provider, `Unhandled runtime: '${_exhaustive}'. This is a bug — please report it.`),
+    );
   }
 
   spawn({
@@ -325,7 +330,7 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
 
       // When runtime is active, wrap the command: ollama launch <agent> [--model x] --yes -- <inner-args>
       const spawnCommand = runtimeConfig ? runtimeConfig.command : this.command;
-      const spawnArgs = runtimeConfig ? [...runtimeConfig.prependArgs, ...args] : [...args];
+      const spawnArgs = runtimeConfig ? [...runtimeConfig.prependArgs, ...args] : args;
 
       const child = spawn(spawnCommand, spawnArgs, {
         cwd: workingDirectory,

--- a/src/implementations/base-agent-adapter.ts
+++ b/src/implementations/base-agent-adapter.ts
@@ -24,7 +24,13 @@ import {
   isCommandInPath,
   SpawnOptions,
 } from '../core/agents.js';
-import { AgentConfig, Configuration, loadAgentConfig } from '../core/configuration.js';
+import {
+  AgentConfig,
+  Configuration,
+  isRuntimeSupportedForAgent,
+  loadAgentConfig,
+  RUNTIME_AGENT_SUPPORT,
+} from '../core/configuration.js';
 import { AutobeatError, agentMisconfigured, ErrorCode, processSpawnFailed } from '../core/errors.js';
 import { err, ok, Result, tryCatch } from '../core/result.js';
 
@@ -153,6 +159,59 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     return agentConfig.model;
   }
 
+  /**
+   * Resolve the runtime wrapper configuration for this spawn.
+   *
+   * When a runtime (e.g. 'ollama') is configured, spawn is wrapped:
+   *   ollama launch <agent-command> [--model <model>] --yes -- <inner-args...>
+   *
+   * Ollama handles model routing and API compatibility, so the inner agent
+   * command does not receive --model, auth env vars, or baseUrl overrides.
+   *
+   * Returns ok(null) when no runtime is configured (normal direct spawn).
+   * Returns err(agentMisconfigured) when the runtime doesn't support this agent.
+   *
+   * @param agentConfig - Pre-loaded agent config
+   * @param taskModel - Optional per-task model override
+   */
+  protected resolveRuntime(
+    agentConfig: AgentConfig,
+    taskModel?: string,
+  ): Result<{
+    command: string;
+    prependArgs: readonly string[];
+    suppressModel: boolean;
+    suppressAuth: boolean;
+    suppressBaseUrl: boolean;
+  } | null> {
+    if (!agentConfig.runtime) return ok(null);
+
+    if (!isRuntimeSupportedForAgent(agentConfig.runtime, this.provider)) {
+      return err(
+        agentMisconfigured(
+          this.provider,
+          `Runtime '${agentConfig.runtime}' does not support agent '${this.provider}'. ` +
+            `Supported agents: ${RUNTIME_AGENT_SUPPORT[agentConfig.runtime].join(', ')}. ` +
+            `Clear with: beat agents config set ${this.provider} runtime ""`,
+        ),
+      );
+    }
+
+    if (agentConfig.runtime === 'ollama') {
+      const effectiveModel = taskModel ?? agentConfig.model;
+      const modelArgs: string[] = effectiveModel ? ['--model', effectiveModel] : [];
+      return ok({
+        command: 'ollama',
+        prependArgs: ['launch', this.command, ...modelArgs, '--yes', '--'],
+        suppressModel: true,
+        suppressAuth: true,
+        suppressBaseUrl: true,
+      });
+    }
+
+    return ok(null);
+  }
+
   spawn({
     prompt,
     workingDirectory,
@@ -163,25 +222,39 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
     systemPrompt,
   }: SpawnOptions): Result<{ process: ChildProcess; pid: number }> {
     try {
-      // Pre-spawn: verify CLI binary exists before anything else
-      if (!isCommandInPath(this.command)) {
+      // Load agent config once — passed to resolveRuntime, resolveAuth, resolveBaseUrl, resolveModel
+      // to avoid redundant readFileSync + JSON.parse calls per spawn
+      const agentConfig = loadAgentConfig(this.provider);
+
+      // Resolve runtime wrapper (e.g. ollama) before binary check so we know which binary to verify
+      const runtimeResult = this.resolveRuntime(agentConfig, model);
+      if (!runtimeResult.ok) return runtimeResult;
+      const runtimeConfig = runtimeResult.value;
+
+      // Pre-spawn: verify the correct CLI binary exists
+      const commandToCheck = runtimeConfig ? runtimeConfig.command : this.command;
+      if (!isCommandInPath(commandToCheck)) {
         return err(
           agentMisconfigured(
             this.provider,
-            [`CLI binary '${this.command}' not found in PATH.`, `  Install: ${this.authConfig.loginHint}`].join('\n'),
+            [
+              `CLI binary '${commandToCheck}' not found in PATH.`,
+              runtimeConfig
+                ? '  Install Ollama: https://ollama.com/download'
+                : `  Install: ${this.authConfig.loginHint}`,
+            ].join('\n'),
           ),
         );
       }
 
-      // Load agent config once — passed to resolveAuth, resolveBaseUrl, resolveModel
-      // to avoid redundant readFileSync + JSON.parse calls per spawn
-      const agentConfig = loadAgentConfig(this.provider);
-
-      // Pre-spawn auth validation
-      const authResult = this.resolveAuth(agentConfig);
+      // Pre-spawn auth validation (skipped when runtime handles auth)
+      const authResult = runtimeConfig?.suppressAuth
+        ? ok({ injectedEnv: {} as Record<string, string> })
+        : this.resolveAuth(agentConfig);
       if (!authResult.ok) return authResult;
 
-      const resolvedModel = this.resolveModel(agentConfig, model);
+      // Model suppressed from inner args when runtime handles model routing
+      const resolvedModel = runtimeConfig?.suppressModel ? undefined : this.resolveModel(agentConfig, model);
 
       // Resolve system prompt injection
       let effectivePrompt = prompt;
@@ -215,7 +288,8 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
           ([key]) => !this.envPrefixesToStrip.some((prefix) => key.startsWith(prefix)) && !exactMatches.includes(key),
         ),
       );
-      const baseUrlEnv = this.resolveBaseUrl(agentConfig);
+      // Base URL suppressed from inner env when runtime handles API routing
+      const baseUrlEnv = runtimeConfig?.suppressBaseUrl ? {} : this.resolveBaseUrl(agentConfig);
       // NOTE: AUTOBEAT_ prefix is NOT in envPrefixesToStrip — it is preserved in cleanEnv.
       // We explicitly set AUTOBEAT_WORKER and AUTOBEAT_TASK_ID here, and optionally
       // AUTOBEAT_ORCHESTRATOR_ID so sub-tasks spawned by this agent are attributed to
@@ -249,7 +323,11 @@ export abstract class BaseAgentAdapter implements AgentAdapter {
         ...(safeOrchestratorId && { AUTOBEAT_ORCHESTRATOR_ID: safeOrchestratorId }),
       };
 
-      const child = spawn(this.command, [...args], {
+      // When runtime is active, wrap the command: ollama launch <agent> [--model x] --yes -- <inner-args>
+      const spawnCommand = runtimeConfig ? runtimeConfig.command : this.command;
+      const spawnArgs = runtimeConfig ? [...runtimeConfig.prependArgs, ...args] : [...args];
+
+      const child = spawn(spawnCommand, spawnArgs, {
         cwd: workingDirectory,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/translation/proxy/proxy-manager.ts
+++ b/src/translation/proxy/proxy-manager.ts
@@ -58,21 +58,22 @@ export interface ProxyConfig {
  * Returns null when: proxy is not set or required fields (baseUrl, apiKey, model) are missing.
  *
  * @param provider - Agent provider key (currently only 'claude' is supported)
+ * @param agentConfig - Optional pre-loaded agent config (avoids redundant disk read)
  */
-export function loadProxyConfig(provider: AgentProvider): ProxyConfig | null {
+export function loadProxyConfig(provider: AgentProvider, agentConfig?: AgentConfig): ProxyConfig | null {
   // Only claude supports translation (Anthropic → OpenAI)
   if (provider !== 'claude') return null;
 
-  const agentConfig = loadAgentConfig(provider);
-  if (!agentConfig.proxy) return null;
+  const config = agentConfig ?? loadAgentConfig(provider);
+  if (!config.proxy) return null;
 
   // proxy requires baseUrl, apiKey, and model
-  if (!agentConfig.baseUrl || !agentConfig.apiKey || !agentConfig.model) return null;
+  if (!config.baseUrl || !config.apiKey || !config.model) return null;
 
   return {
-    targetBaseUrl: agentConfig.baseUrl,
-    targetApiKey: agentConfig.apiKey,
-    targetModel: agentConfig.model,
+    targetBaseUrl: config.baseUrl,
+    targetApiKey: config.apiKey,
+    targetModel: config.model,
   };
 }
 
@@ -115,7 +116,7 @@ export class ProxyManager {
   async start(): Promise<Result<{ port: number; proxyUrl: string }>> {
     // Idempotent: already running
     if (this.proxy !== null && this.port !== undefined) {
-      return ok({ port: this.port, proxyUrl: this.proxyUrl! });
+      return ok({ port: this.port, proxyUrl: `http://127.0.0.1:${this.port}` });
     }
 
     const proxyLogger = this.logger.child({ module: 'TranslationProxy' });
@@ -154,7 +155,7 @@ export class ProxyManager {
       targetModel: this.config.targetModel,
     });
 
-    return ok({ port: this.port, proxyUrl: this.proxyUrl! });
+    return ok({ port: this.port, proxyUrl: `http://127.0.0.1:${this.port}` });
   }
 
   /**

--- a/src/translation/proxy/proxy-manager.ts
+++ b/src/translation/proxy/proxy-manager.ts
@@ -11,9 +11,9 @@
  * 3. Pass proxyUrl to ProxiedClaudeAdapter via ANTHROPIC_BASE_URL
  * 4. Call stop() on shutdown
  *
- * Configuration: When an agent has `translate` set (e.g. 'openai'), the existing
+ * Configuration: When an agent has `proxy` set (e.g. 'openai'), the existing
  * `baseUrl`, `apiKey`, and `model` fields become the target backend config.
- * loadProxyConfig() returns null when translate is not set.
+ * loadProxyConfig() returns null when proxy is not set.
  *
  * DECISION: One ProxyManager per agent provider. Currently only 'claude' is
  * supported (Anthropic Messages API ↔ OpenAI Chat Completions). Codex/Gemini
@@ -47,15 +47,15 @@ export interface ProxyConfig {
 /**
  * Load proxy configuration from AgentConfig when `translate` is set.
  *
- * ARCHITECTURE: When an agent has `translate: 'openai'`, the existing `baseUrl`,
+ * ARCHITECTURE: When an agent has `proxy: 'openai'`, the existing `baseUrl`,
  * `apiKey`, and `model` fields become the target backend config. This means users
  * configure the translation proxy with the same commands they'd use for any agent:
- *   beat agents config set claude translate openai
+ *   beat agents config set claude proxy openai
  *   beat agents config set claude baseUrl https://integrate.api.nvidia.com/v1
  *   beat agents config set claude apiKey nvapi-...
  *   beat agents config set claude model moonshotai/kimi-k2-thinking
  *
- * Returns null when: translate is not set or required fields (baseUrl, apiKey, model) are missing.
+ * Returns null when: proxy is not set or required fields (baseUrl, apiKey, model) are missing.
  *
  * @param provider - Agent provider key (currently only 'claude' is supported)
  */
@@ -64,9 +64,9 @@ export function loadProxyConfig(provider: AgentProvider): ProxyConfig | null {
   if (provider !== 'claude') return null;
 
   const agentConfig: AgentConfig = loadAgentConfig(provider);
-  if (!agentConfig.translate) return null;
+  if (!agentConfig.proxy) return null;
 
-  // translate requires baseUrl, apiKey, and model
+  // proxy requires baseUrl, apiKey, and model
   if (!agentConfig.baseUrl || !agentConfig.apiKey || !agentConfig.model) return null;
 
   return {

--- a/src/translation/proxy/proxy-manager.ts
+++ b/src/translation/proxy/proxy-manager.ts
@@ -33,7 +33,7 @@ import { TranslationProxy } from './translation-proxy.js';
 
 /**
  * Target backend configuration for the translation proxy.
- * Derived from AgentConfig fields when `translate` is set.
+ * Derived from AgentConfig fields when `proxy` is set.
  */
 export interface ProxyConfig {
   /** Base URL of the OpenAI-compatible backend, e.g. "https://integrate.api.nvidia.com/v1" */
@@ -45,7 +45,7 @@ export interface ProxyConfig {
 }
 
 /**
- * Load proxy configuration from AgentConfig when `translate` is set.
+ * Load proxy configuration from AgentConfig when `proxy` is set.
  *
  * ARCHITECTURE: When an agent has `proxy: 'openai'`, the existing `baseUrl`,
  * `apiKey`, and `model` fields become the target backend config. This means users
@@ -63,7 +63,7 @@ export function loadProxyConfig(provider: AgentProvider): ProxyConfig | null {
   // Only claude supports translation (Anthropic → OpenAI)
   if (provider !== 'claude') return null;
 
-  const agentConfig: AgentConfig = loadAgentConfig(provider);
+  const agentConfig = loadAgentConfig(provider);
   if (!agentConfig.proxy) return null;
 
   // proxy requires baseUrl, apiKey, and model
@@ -115,8 +115,7 @@ export class ProxyManager {
   async start(): Promise<Result<{ port: number; proxyUrl: string }>> {
     // Idempotent: already running
     if (this.proxy !== null && this.port !== undefined) {
-      const url = `http://127.0.0.1:${this.port}`;
-      return ok({ port: this.port, proxyUrl: url });
+      return ok({ port: this.port, proxyUrl: this.proxyUrl! });
     }
 
     const proxyLogger = this.logger.child({ module: 'TranslationProxy' });
@@ -148,7 +147,6 @@ export class ProxyManager {
 
     this.proxy = proxy;
     this.port = startResult.value.port;
-    const url = `http://127.0.0.1:${this.port}`;
 
     this.logger.info('Translation proxy started', {
       port: this.port,
@@ -156,7 +154,7 @@ export class ProxyManager {
       targetModel: this.config.targetModel,
     });
 
-    return ok({ port: this.port, proxyUrl: url });
+    return ok({ port: this.port, proxyUrl: this.proxyUrl! });
   }
 
   /**

--- a/tests/unit/adapters/init-custom-orchestrator.test.ts
+++ b/tests/unit/adapters/init-custom-orchestrator.test.ts
@@ -222,15 +222,17 @@ describe('MCPAdapter - InitCustomOrchestrator tool', () => {
       expect(body.success).toBe(false);
     });
 
-    it('returns error when model contains shell metacharacters', async () => {
+    it('accepts model names with special characters (validation delegated to agent CLI)', async () => {
+      // Model names are opaque to autobeat — format is the agent CLI's responsibility.
+      // Models use /, :, @ separators (e.g. registry.example.com/model:tag).
       const response = await adapter.callTool('InitCustomOrchestrator', {
         goal: 'Test goal',
-        model: 'claude-opus; rm -rf /',
+        model: 'registry.example.com/model:tag',
       });
 
-      expect(response.isError).toBe(true);
+      expect(response.isError).toBeFalsy();
       const body = JSON.parse(response.content[0].text);
-      expect(body.success).toBe(false);
+      expect(body.success).toBe(true);
     });
 
     it('accepts valid model names with dots and hyphens', async () => {

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -3480,3 +3480,132 @@ describe('ConfigureAgent — URL probe integration', () => {
     });
   });
 });
+
+// ============================================================================
+// ConfigureAgent — runtime + proxy integration tests (Fix 9A)
+// ============================================================================
+
+describe('ConfigureAgent — runtime + proxy integration via callTool()', () => {
+  let testDir: string;
+  let restoreConfig: () => void;
+
+  function makeConfigureAgentAdapter() {
+    return new MCPAdapter({
+      taskManager: new MockTaskManager(),
+      logger: new MockLogger(),
+      scheduleService: stubScheduleService,
+      loopService: stubLoopService,
+      agentRegistry: undefined,
+      config: testConfig,
+    });
+  }
+
+  beforeEach(() => {
+    testDir = path.join(tmpdir(), `autobeat-configure-agent-runtime-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    restoreConfig = _testSetConfigDir(testDir);
+  });
+
+  afterEach(() => {
+    restoreConfig();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('saves runtime for supported agent (claude)', async () => {
+    const adapter = makeConfigureAgentAdapter();
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'set',
+      runtime: 'ollama',
+    });
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.success).toBe(true);
+  });
+
+  it('rejects runtime for unsupported agent (gemini)', async () => {
+    const adapter = makeConfigureAgentAdapter();
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'gemini',
+      action: 'set',
+      runtime: 'ollama',
+    });
+    expect(result.isError).toBe(true);
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toContain('does not support');
+  });
+
+  it('clears runtime with empty string', async () => {
+    const adapter = makeConfigureAgentAdapter();
+    // First set runtime
+    await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'set',
+      runtime: 'ollama',
+    });
+    // Then clear it
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'set',
+      runtime: '',
+    });
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.success).toBe(true);
+  });
+
+  it('warns when runtime and proxy are both set', async () => {
+    const adapter = makeConfigureAgentAdapter();
+    // Pre-save proxy configuration
+    saveAgentConfig('claude', 'proxy', 'openai');
+    saveAgentConfig('claude', 'baseUrl', 'https://example.com/v1');
+    saveAgentConfig('claude', 'apiKey', 'sk-test');
+    saveAgentConfig('claude', 'model', 'gpt-4');
+    // Set runtime — should trigger mutual exclusivity warning
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'set',
+      runtime: 'ollama',
+    });
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.warning).toContain('mutually exclusive');
+  });
+
+  it('rejects legacy translate field with migration message', async () => {
+    const adapter = makeConfigureAgentAdapter();
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'set',
+      translate: 'openai',
+    } as Record<string, unknown>);
+    expect(result.isError).toBe(true);
+    const response = JSON.parse(result.content[0].text);
+    expect(response.error).toContain('renamed to');
+  });
+
+  it('includes runtime in check response when set', async () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    const adapter = makeConfigureAgentAdapter();
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'check',
+    });
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.runtime).toBe('ollama');
+  });
+
+  it('warns on mutual exclusivity in check', async () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    saveAgentConfig('claude', 'proxy', 'openai');
+    const adapter = makeConfigureAgentAdapter();
+    const result = await adapter.callTool('ConfigureAgent', {
+      agent: 'claude',
+      action: 'check',
+    });
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.warning).toContain('mutually exclusive');
+  });
+});

--- a/tests/unit/core/configuration.test.ts
+++ b/tests/unit/core/configuration.test.ts
@@ -6,6 +6,7 @@ import {
   _testSetConfigDir,
   type Configuration,
   ConfigurationSchema,
+  isRuntimeSupportedForAgent,
   loadConfigFile,
   loadConfiguration,
   resetConfigValue,
@@ -960,5 +961,19 @@ describe('Config File - loadConfiguration with file', () => {
     expect(warnSpy.mock.calls[0][0]).toContain('environment variables and defaults');
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('isRuntimeSupportedForAgent', () => {
+  it('returns true for ollama + claude', () => {
+    expect(isRuntimeSupportedForAgent('ollama', 'claude')).toBe(true);
+  });
+
+  it('returns true for ollama + codex', () => {
+    expect(isRuntimeSupportedForAgent('ollama', 'codex')).toBe(true);
+  });
+
+  it('returns false for ollama + gemini', () => {
+    expect(isRuntimeSupportedForAgent('ollama', 'gemini')).toBe(false);
   });
 });

--- a/tests/unit/implementations/agent-adapters.test.ts
+++ b/tests/unit/implementations/agent-adapters.test.ts
@@ -1159,6 +1159,17 @@ describe('GeminiBasePromptCache', () => {
 // above — isolate:false means each new vi.mock() call creates a new fn instance
 // that breaks imports already captured in other test files.
 
+function callResolveRuntime(
+  adapter: ClaudeAdapter | CodexAdapter | GeminiAdapter,
+  config: AgentConfig,
+  taskModel?: string,
+) {
+  return (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime(
+    config,
+    taskModel,
+  );
+}
+
 describe('resolveRuntime', () => {
   let testDir: string;
   let restoreConfig: () => void;
@@ -1178,16 +1189,14 @@ describe('resolveRuntime', () => {
 
   it('returns ok(null) when runtime is not set', () => {
     const adapter = new ClaudeAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({});
+    const result = callResolveRuntime(adapter, {});
     expect(result).toEqual({ ok: true, value: null });
     adapter.dispose();
   });
 
   it('returns ollama config when runtime is ollama for claude', () => {
     const adapter = new ClaudeAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
-      runtime: 'ollama' as const,
-    });
+    const result = callResolveRuntime(adapter, { runtime: 'ollama' as const });
     expect(result).toMatchObject({
       ok: true,
       value: {
@@ -1202,18 +1211,17 @@ describe('resolveRuntime', () => {
 
   it('returns ollama config when runtime is ollama for codex', () => {
     const adapter = new CodexAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
-      runtime: 'ollama' as const,
-    });
+    const result = callResolveRuntime(adapter, { runtime: 'ollama' as const });
     expect(result).toMatchObject({ ok: true, value: { command: 'ollama' } });
     adapter.dispose();
   });
 
   it('returns error when runtime is ollama for gemini', () => {
     const adapter = new GeminiAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
-      runtime: 'ollama' as const,
-    }) as { ok: false; error: { code: string; message: string } };
+    const result = callResolveRuntime(adapter, { runtime: 'ollama' as const }) as {
+      ok: false;
+      error: { code: string; message: string };
+    };
     expect(result.ok).toBe(false);
     expect(result.error.code).toBe(ErrorCode.AGENT_MISCONFIGURED);
     expect(result.error.message).toContain("Runtime 'ollama' does not support agent 'gemini'");
@@ -1222,10 +1230,10 @@ describe('resolveRuntime', () => {
 
   it('uses taskModel over agentConfig.model in prependArgs', () => {
     const adapter = new ClaudeAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime(
-      { runtime: 'ollama' as const, model: 'config-model' },
-      'task-model',
-    ) as { ok: true; value: { prependArgs: readonly string[] } };
+    const result = callResolveRuntime(adapter, { runtime: 'ollama' as const, model: 'config-model' }, 'task-model') as {
+      ok: true;
+      value: { prependArgs: readonly string[] };
+    };
     expect(result.ok).toBe(true);
     expect(result.value.prependArgs).toContain('task-model');
     expect(result.value.prependArgs).not.toContain('config-model');
@@ -1234,7 +1242,7 @@ describe('resolveRuntime', () => {
 
   it('uses agentConfig.model when no taskModel provided', () => {
     const adapter = new ClaudeAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+    const result = callResolveRuntime(adapter, {
       runtime: 'ollama' as const,
       model: 'config-model',
     }) as { ok: true; value: { prependArgs: readonly string[] } };
@@ -1245,9 +1253,10 @@ describe('resolveRuntime', () => {
 
   it('omits --model from prependArgs when neither model source is set', () => {
     const adapter = new ClaudeAdapter(testConfig);
-    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
-      runtime: 'ollama' as const,
-    }) as { ok: true; value: { prependArgs: readonly string[] } };
+    const result = callResolveRuntime(adapter, { runtime: 'ollama' as const }) as {
+      ok: true;
+      value: { prependArgs: readonly string[] };
+    };
     expect(result.ok).toBe(true);
     expect(result.value.prependArgs).not.toContain('--model');
     adapter.dispose();
@@ -1377,5 +1386,39 @@ describe('spawn with ollama runtime', () => {
     expect(mockSpawn).toHaveBeenCalledOnce();
     const [, args] = mockSpawn.mock.calls[0];
     expect(args.join(' ')).toContain('--append-system-prompt');
+  });
+});
+
+describe('spawn with ollama runtime (codex)', () => {
+  let testDir: string;
+  let restoreConfig: () => void;
+  let adapter: CodexAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCommandInPath.mockReturnValue(true);
+    mockSpawn.mockReturnValue(createMockChildProcess(1234));
+    testDir = path.join(tmpdir(), `autobeat-runtime-codex-spawn-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    restoreConfig = _testSetConfigDir(testDir);
+    adapter = new CodexAdapter(testConfig);
+  });
+
+  afterEach(() => {
+    adapter.dispose();
+    restoreConfig();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('wraps codex command with ollama launch when runtime is set', () => {
+    saveAgentConfig('codex', 'runtime', 'ollama');
+    const result = adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(result.ok).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [command, args] = mockSpawn.mock.calls[0];
+    expect(command).toBe('ollama');
+    expect(args[0]).toBe('launch');
+    expect(args[1]).toBe('codex');
   });
 });

--- a/tests/unit/implementations/agent-adapters.test.ts
+++ b/tests/unit/implementations/agent-adapters.test.ts
@@ -12,7 +12,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync 
 import os, { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Configuration } from '../../../src/core/configuration';
+import type { AgentConfig, Configuration } from '../../../src/core/configuration';
 import { _testSetConfigDir, saveAgentConfig } from '../../../src/core/configuration';
 import { ErrorCode } from '../../../src/core/errors';
 import { ClaudeAdapter } from '../../../src/implementations/claude-adapter';
@@ -1150,5 +1150,232 @@ describe('GeminiBasePromptCache', () => {
         /* best effort */
       }
     }
+  });
+});
+
+// ─── Ollama Runtime Integration Tests ────────────────────────────────────────
+// Tests for resolveRuntime() and spawn() with ollama runtime wrapping.
+// Placed here (not a separate file) to share the module registry mocks established
+// above — isolate:false means each new vi.mock() call creates a new fn instance
+// that breaks imports already captured in other test files.
+
+describe('resolveRuntime', () => {
+  let testDir: string;
+  let restoreConfig: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCommandInPath.mockReturnValue(true);
+    testDir = path.join(tmpdir(), `autobeat-runtime-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    restoreConfig = _testSetConfigDir(testDir);
+  });
+
+  afterEach(() => {
+    restoreConfig();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns ok(null) when runtime is not set', () => {
+    const adapter = new ClaudeAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({});
+    expect(result).toEqual({ ok: true, value: null });
+    adapter.dispose();
+  });
+
+  it('returns ollama config when runtime is ollama for claude', () => {
+    const adapter = new ClaudeAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+      runtime: 'ollama' as const,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        command: 'ollama',
+        suppressModel: true,
+        suppressAuth: true,
+        suppressBaseUrl: true,
+      },
+    });
+    adapter.dispose();
+  });
+
+  it('returns ollama config when runtime is ollama for codex', () => {
+    const adapter = new CodexAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+      runtime: 'ollama' as const,
+    });
+    expect(result).toMatchObject({ ok: true, value: { command: 'ollama' } });
+    adapter.dispose();
+  });
+
+  it('returns error when runtime is ollama for gemini', () => {
+    const adapter = new GeminiAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+      runtime: 'ollama' as const,
+    }) as { ok: false; error: { code: string; message: string } };
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe(ErrorCode.AGENT_MISCONFIGURED);
+    expect(result.error.message).toContain("Runtime 'ollama' does not support agent 'gemini'");
+    adapter.dispose();
+  });
+
+  it('uses taskModel over agentConfig.model in prependArgs', () => {
+    const adapter = new ClaudeAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime(
+      { runtime: 'ollama' as const, model: 'config-model' },
+      'task-model',
+    ) as { ok: true; value: { prependArgs: readonly string[] } };
+    expect(result.ok).toBe(true);
+    expect(result.value.prependArgs).toContain('task-model');
+    expect(result.value.prependArgs).not.toContain('config-model');
+    adapter.dispose();
+  });
+
+  it('uses agentConfig.model when no taskModel provided', () => {
+    const adapter = new ClaudeAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+      runtime: 'ollama' as const,
+      model: 'config-model',
+    }) as { ok: true; value: { prependArgs: readonly string[] } };
+    expect(result.ok).toBe(true);
+    expect(result.value.prependArgs).toContain('config-model');
+    adapter.dispose();
+  });
+
+  it('omits --model from prependArgs when neither model source is set', () => {
+    const adapter = new ClaudeAdapter(testConfig);
+    const result = (adapter as unknown as { resolveRuntime(c: AgentConfig, m?: string): unknown }).resolveRuntime({
+      runtime: 'ollama' as const,
+    }) as { ok: true; value: { prependArgs: readonly string[] } };
+    expect(result.ok).toBe(true);
+    expect(result.value.prependArgs).not.toContain('--model');
+    adapter.dispose();
+  });
+});
+
+describe('spawn with ollama runtime', () => {
+  let testDir: string;
+  let restoreConfig: () => void;
+  let adapter: ClaudeAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsCommandInPath.mockReturnValue(true);
+    mockSpawn.mockReturnValue(createMockChildProcess(1234));
+    testDir = path.join(tmpdir(), `autobeat-runtime-spawn-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    restoreConfig = _testSetConfigDir(testDir);
+    adapter = new ClaudeAdapter(testConfig);
+  });
+
+  afterEach(() => {
+    adapter.dispose();
+    restoreConfig();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('wraps command with ollama launch when runtime is set', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    const result = adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(result.ok).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [command, args] = mockSpawn.mock.calls[0];
+    expect(command).toBe('ollama');
+    expect(args[0]).toBe('launch');
+    expect(args[1]).toBe('claude');
+  });
+
+  it('checks isCommandInPath for ollama not claude when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    const checkedCommands = mockIsCommandInPath.mock.calls.map(([cmd]) => cmd);
+    expect(checkedCommands).toContain('ollama');
+  });
+
+  it('returns error when ollama binary is not found', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    mockIsCommandInPath.mockImplementation((cmd: string) => cmd !== 'ollama');
+
+    const result = adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.AGENT_MISCONFIGURED);
+      expect(result.error.message).toContain("CLI binary 'ollama' not found");
+    }
+  });
+
+  it('suppresses --model from inner buildArgs when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1', model: 'claude-opus-4-5' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, args] = mockSpawn.mock.calls[0];
+    const doubleDashIdx = args.indexOf('--');
+    const innerArgs = doubleDashIdx >= 0 ? args.slice(doubleDashIdx + 1) : args;
+    expect(innerArgs).not.toContain('--model');
+  });
+
+  it('includes ollama --model in prependArgs when model is set', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    saveAgentConfig('claude', 'model', 'qwen3');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, args] = mockSpawn.mock.calls[0];
+    const doubleDashIdx = args.indexOf('--');
+    const outerArgs = doubleDashIdx >= 0 ? args.slice(0, doubleDashIdx) : args;
+    expect(outerArgs).toContain('--model');
+    expect(outerArgs).toContain('qwen3');
+  });
+
+  it('suppresses auth env var injection when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    saveAgentConfig('claude', 'apiKey', 'sk-test-key');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, , spawnOpts] = mockSpawn.mock.calls[0];
+    const env = (spawnOpts as { env?: Record<string, string> } | undefined)?.env;
+    expect(env?.ANTHROPIC_API_KEY).not.toBe('sk-test-key');
+  });
+
+  it('suppresses baseUrl env var injection when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    saveAgentConfig('claude', 'baseUrl', 'https://custom.api.example.com');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-1' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, , spawnOpts] = mockSpawn.mock.calls[0];
+    const env = (spawnOpts as { env?: Record<string, string> } | undefined)?.env;
+    expect(env?.ANTHROPIC_BASE_URL).not.toBe('https://custom.api.example.com');
+  });
+
+  it('preserves AUTOBEAT_ env vars when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    adapter.spawn({ prompt: 'test', workingDirectory: '/workspace', taskId: 'task-42' });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, , spawnOpts] = mockSpawn.mock.calls[0];
+    const env = (spawnOpts as { env?: Record<string, string> } | undefined)?.env;
+    expect(env?.AUTOBEAT_WORKER).toBe('true');
+    expect(env?.AUTOBEAT_TASK_ID).toBe('task-42');
+  });
+
+  it('passes system prompt args through when runtime is active', () => {
+    saveAgentConfig('claude', 'runtime', 'ollama');
+    adapter.spawn({
+      prompt: 'test',
+      workingDirectory: '/workspace',
+      taskId: 'task-1',
+      systemPrompt: 'Be concise.',
+    });
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args.join(' ')).toContain('--append-system-prompt');
   });
 });

--- a/tests/unit/implementations/agent-config.test.ts
+++ b/tests/unit/implementations/agent-config.test.ts
@@ -181,6 +181,61 @@ describe('Agent Config Storage', () => {
     });
   });
 
+  describe('proxy support', () => {
+    it('should save and load proxy for a provider', () => {
+      const result = saveAgentConfig('claude', 'proxy', 'openai');
+      expect(result.ok).toBe(true);
+
+      const config = loadAgentConfig('claude');
+      expect(config.proxy).toBe('openai');
+    });
+
+    it('should clear proxy with empty string', () => {
+      saveAgentConfig('claude', 'proxy', 'openai');
+      saveAgentConfig('claude', 'proxy', '');
+      const config = loadAgentConfig('claude');
+      expect(config.proxy).toBeUndefined();
+    });
+
+    it('should drop unknown proxy targets silently', () => {
+      // Write raw JSON with an unsupported proxy value
+      const { writeFileSync } = require('fs');
+      writeFileSync(
+        require('path').join(testDir, 'config.json'),
+        JSON.stringify({ agents: { claude: { proxy: 'unsupported-backend' } } }),
+      );
+      const config = loadAgentConfig('claude');
+      expect(config.proxy).toBeUndefined();
+    });
+  });
+
+  describe('runtime support', () => {
+    it('should save and load runtime for a provider', () => {
+      const result = saveAgentConfig('claude', 'runtime', 'ollama');
+      expect(result.ok).toBe(true);
+
+      const config = loadAgentConfig('claude');
+      expect(config.runtime).toBe('ollama');
+    });
+
+    it('should clear runtime with empty string', () => {
+      saveAgentConfig('claude', 'runtime', 'ollama');
+      saveAgentConfig('claude', 'runtime', '');
+      const config = loadAgentConfig('claude');
+      expect(config.runtime).toBeUndefined();
+    });
+
+    it('should drop unknown runtime targets silently', () => {
+      const { writeFileSync } = require('fs');
+      writeFileSync(
+        require('path').join(testDir, 'config.json'),
+        JSON.stringify({ agents: { claude: { runtime: 'unknown-runtime' } } }),
+      );
+      const config = loadAgentConfig('claude');
+      expect(config.runtime).toBeUndefined();
+    });
+  });
+
   describe('model support', () => {
     it('should save and load model for a provider', () => {
       const result = saveAgentConfig('claude', 'model', 'claude-opus-4-5');

--- a/tests/unit/translation/proxy/bootstrap-proxy-integration.test.ts
+++ b/tests/unit/translation/proxy/bootstrap-proxy-integration.test.ts
@@ -225,4 +225,30 @@ describe('proxy startup by bootstrap mode', () => {
     // After dispose, all services are cleared
     expect(container.get('proxyManager').ok).toBe(false);
   });
+
+  it('skips proxy startup when runtime is set for claude', async () => {
+    // Even though proxy config has baseUrl/apiKey/model set, runtime takes precedence
+    const configWithRuntime = {
+      agents: {
+        claude: {
+          proxy: 'openai',
+          baseUrl: 'https://api.example.com',
+          apiKey: 'test-key',
+          model: 'test-model',
+          runtime: 'ollama',
+        },
+      },
+    };
+    await writeFile(join(tempDir, 'config.json'), JSON.stringify(configWithRuntime));
+    const result = await bootstrap({ mode: 'run' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const container = result.value;
+    try {
+      // proxyManager should NOT be registered when runtime is set
+      expect(container.get('proxyManager').ok).toBe(false);
+    } finally {
+      await container.dispose();
+    }
+  });
 });

--- a/tests/unit/translation/proxy/bootstrap-proxy-integration.test.ts
+++ b/tests/unit/translation/proxy/bootstrap-proxy-integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for bootstrap integration with translation proxy.
  *
- * Verifies that loadProxyConfig reads translate + baseUrl/apiKey/model from
- * AgentConfig to derive proxy configuration. The `translate` field is the gate:
+ * Verifies that loadProxyConfig reads proxy + baseUrl/apiKey/model from
+ * AgentConfig to derive proxy configuration. The `proxy` field is the gate:
  * when set to a supported target (e.g. 'openai'), the existing baseUrl, apiKey,
  * and model fields become the target backend configuration.
  *
@@ -42,7 +42,7 @@ describe('loadProxyConfig', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null when translate is not set', async () => {
+  it('returns null when proxy is not set', async () => {
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
@@ -53,46 +53,46 @@ describe('loadProxyConfig', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null when translate is set but baseUrl is missing', async () => {
+  it('returns null when proxy is set but baseUrl is missing', async () => {
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
-        agents: { claude: { translate: 'openai', apiKey: 'sk-test', model: 'gpt-4o' } },
+        agents: { claude: { proxy: 'openai', apiKey: 'sk-test', model: 'gpt-4o' } },
       }),
     );
     const result = loadProxyConfig('claude');
     expect(result).toBeNull();
   });
 
-  it('returns null when translate is set but apiKey is missing', async () => {
+  it('returns null when proxy is set but apiKey is missing', async () => {
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
-        agents: { claude: { translate: 'openai', baseUrl: 'https://api.example.com', model: 'gpt-4o' } },
+        agents: { claude: { proxy: 'openai', baseUrl: 'https://api.example.com', model: 'gpt-4o' } },
       }),
     );
     const result = loadProxyConfig('claude');
     expect(result).toBeNull();
   });
 
-  it('returns null when translate is set but model is missing', async () => {
+  it('returns null when proxy is set but model is missing', async () => {
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
-        agents: { claude: { translate: 'openai', baseUrl: 'https://api.example.com', apiKey: 'sk-test' } },
+        agents: { claude: { proxy: 'openai', baseUrl: 'https://api.example.com', apiKey: 'sk-test' } },
       }),
     );
     const result = loadProxyConfig('claude');
     expect(result).toBeNull();
   });
 
-  it('returns ProxyConfig when translate + all required fields are present', async () => {
+  it('returns ProxyConfig when proxy + all required fields are present', async () => {
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
         agents: {
           claude: {
-            translate: 'openai',
+            proxy: 'openai',
             baseUrl: 'https://integrate.api.nvidia.com/v1',
             apiKey: 'nvapi-test-key',
             model: 'moonshotai/kimi-k2-thinking',
@@ -107,16 +107,16 @@ describe('loadProxyConfig', () => {
     expect(result?.targetModel).toBe('moonshotai/kimi-k2-thinking');
   });
 
-  it('returns null for unsupported translate target', async () => {
-    // Validation of the translate value happens in loadAgentConfig (configuration.ts):
-    // unknown targets are silently dropped (translate becomes undefined), so
-    // loadProxyConfig returns null at the `!agentConfig.translate` guard.
+  it('returns null for unsupported proxy target', async () => {
+    // Validation of the proxy value happens in loadAgentConfig (configuration.ts):
+    // unknown targets are silently dropped (proxy becomes undefined), so
+    // loadProxyConfig returns null at the `!agentConfig.proxy` guard.
     await writeFile(
       join(tempDir, 'config.json'),
       JSON.stringify({
         agents: {
           claude: {
-            translate: 'gemini-native',
+            proxy: 'gemini-native',
             baseUrl: 'https://api.example.com',
             apiKey: 'key',
             model: 'model',
@@ -168,7 +168,7 @@ describe('proxy startup by bootstrap mode', () => {
   const proxyConfig = {
     agents: {
       claude: {
-        translate: 'openai',
+        proxy: 'openai',
         baseUrl: 'https://api.example.com',
         apiKey: 'test-key',
         model: 'test-model',


### PR DESCRIPTION
## Summary

- **Rename `translate` → `proxy`**: Clean-break rename of the `translate` config field to `proxy` across all layers (configuration, CLI, MCP adapter, bootstrap, proxy-manager, instructions, tests). No migration — direct rename.
- **Ollama runtime integration**: New `runtime: 'ollama'` config field that wraps agent spawns with `ollama launch <agent> --model <model> --yes -- <inner-args>`. Ollama handles model routing and API compatibility, so auth, baseUrl, and `--model` are suppressed from the inner agent command. Supported agents: claude, codex (not gemini — validated at config-set and spawn-time).
- **Mutual exclusivity**: `runtime` and `proxy` are mutually exclusive — runtime takes precedence. Warnings shown when both are configured. Bootstrap skips proxy startup when runtime is active.

## Changes

| File | What |
|------|------|
| `src/core/configuration.ts` | `PROXY_TARGETS`/`ProxyTarget` (rename), `RUNTIME_TARGETS`/`Runtime`/`RUNTIME_AGENT_SUPPORT`, `isRuntimeSupportedForAgent` |
| `src/implementations/base-agent-adapter.ts` | `resolveRuntime()` method, 6 injection points in `spawn()`, exhaustive `never` guard |
| `src/cli/commands/agents.ts` | `runtime` key validation, agent-runtime compat check, mutual exclusivity warnings, `checkAgents()` runtime display |
| `src/adapters/mcp-adapter.ts` | `runtime` field in ConfigureAgent Zod schema + OpenAPI + handler logic |
| `src/adapters/mcp-instructions.ts` | "Ollama Runtime" documentation section |
| `src/bootstrap.ts` | Skip proxy when `runtime` is set |
| `src/translation/proxy/proxy-manager.ts` | `translate` → `proxy` JSDoc, DRY proxyUrl construction |
| Tests (3 files) | 25 new tests: 16 runtime spawn/resolve, 6 config roundtrip, 3 bootstrap integration |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` — clean (317 files)
- [x] `npm run build` — compiles
- [x] All 8 grouped test suites pass (2,979 tests)
- [x] `grep -rn 'TRANSLATE_TARGETS\|TranslateTarget\|\.translate' src/` — zero hits
- [x] 13 acceptance scenarios verified (config roundtrip, spawn wrapping, model override, unsupported agent rejection, binary check, system prompt passthrough, bootstrap proxy skip, exhaustive guard)