### PR TITLE
docs(skills): align with v1.2.0–v1.4.0 features

### DIFF
--- a/skills/autobeat/SKILL.md
+++ b/skills/autobeat/SKILL.md
@@ -49,7 +49,11 @@ Is it a fixed sequence of steps?
 Does it need iterative improvement?
   YES → Is the exit condition objective (shell exit code / script score)?
     YES → CreateLoop with evalMode: shell
-    NO  → CreateLoop with evalMode: agent (AI judges quality)
+    NO  → CreateLoop with evalMode: agent
+           Which eval sub-strategy?
+             Need findings-only feedback, always run to maxIterations? → evalType: feedforward (default)
+             Need AI judge to decide continue/stop?                   → evalType: judge
+             Need deterministic structured pass/fail (Claude only)?    → evalType: schema
 
 Is the goal open-ended and complex?
   YES → CreateOrchestrator (autonomous planning + delegation)
@@ -101,6 +105,10 @@ Should it run on a schedule?
 | `CancelOrchestrator` | Cancel an orchestration |
 | `ListAgents` | List available agents with auth status |
 | `ConfigureAgent` | Check auth, store/reset API keys |
+| `InitCustomOrchestrator` | Scaffold custom orchestrator (state file, exit script, snippets) |
+| `PipelineStatus` | Check pipeline entity status |
+| `ListPipelines` | List pipelines with status filter |
+| `CancelPipeline` | Cancel a pipeline and optionally its tasks |
 
 ### CLI Commands
 
@@ -118,6 +126,12 @@ Should it run on a schedule?
 | `beat schedule create "<prompt>" --cron "0 9 * * *"` | Cron schedule |
 | `beat orchestrate "<goal>"` | Start orchestration |
 | `beat orchestrate status <id>` | Check orchestration |
+| `beat orchestrate init "<goal>"` | Scaffold custom orchestrator |
+| `beat dashboard` / `beat dash` | Terminal dashboard TUI |
+| `beat list` / `beat ls` | List tasks |
+| `beat agents check` | Check agent auth status |
+| `beat agents config set/show/reset` | Agent config management |
+| `beat config show/set/reset/path` | Config management |
 
 ## Composition Patterns
 
@@ -139,17 +153,51 @@ C = DelegateTask("process subset 2", dependsOn: [A])
 D = DelegateTask("merge results", dependsOn: [B, C], continueFrom: B)
 ```
 
+## System Prompts
+
+Inject custom instructions into any agent. Identical mechanics across all tools that accept `systemPrompt`.
+
+| Agent | Mechanism | Behavior |
+|-------|-----------|----------|
+| Claude | `--append-system-prompt` | Appends to Claude's built-in system prompt |
+| Codex | `-c developer_instructions` | Sets developer instructions config |
+| Gemini | `GEMINI_SYSTEM_MD` env var | Combined with Gemini's base prompt file |
+
+Supported on: `DelegateTask`, `CreatePipeline` (pipeline + per-step), `CreateLoop`, `ScheduleTask`, `SchedulePipeline` (pipeline + per-step), `ScheduleLoop`, `CreateOrchestrator`.
+
+**Caveat**: `CreateOrchestrator` systemPrompt **replaces** auto-generated role instructions entirely (not appends). This prevents conflicting ROLE sections. Use `InitCustomOrchestrator` for custom orchestrators with full prompt control.
+
+## Model Selection
+
+Override the default model per task, per pipeline step, or per loop iteration.
+
+Resolution order: per-task `model` > agent-config default (`ConfigureAgent`) > agent's built-in default.
+
+Pipelines support per-step overrides: set `model` at pipeline level for the default, override on individual `steps[]` as needed.
+
+Model names are opaque to autobeat — validation is the agent CLI's responsibility.
+
+## Translation Proxy & Ollama Runtime
+
+Configure via `ConfigureAgent` (set action):
+
+- **`proxy: "openai"`**: Routes Anthropic API calls through a local proxy that translates to OpenAI-compatible format. Requires `baseUrl` and `apiKey`. Works with all agents.
+- **`runtime: "ollama"`**: Wraps agent spawns with `ollama launch`. Supported agents: claude, codex only (not gemini).
+
+Mutually exclusive — `runtime` takes precedence if both are set. Clear with empty string: `proxy: ""` or `runtime: ""`.
+
 ## Anti-Patterns
 
 | Mistake | Why It's Wrong | Fix |
 |---------|---------------|-----|
 | Pipeline with 1 step | Unnecessary overhead | Use DelegateTask |
 | Manual dependsOn chain for sequential tasks | Error-prone wiring | Use CreatePipeline |
-| Loop without exit condition (shell mode) | Runs forever | Set exitCondition or use evalMode: agent |
+| Loop without exit condition (shell mode) | Runs forever | Set exitCondition or use evalMode: agent with appropriate sub-strategy |
 | Orchestrator for simple sequences | Overkill | Use Pipeline or Loop |
 | Polling TaskStatus in a tight loop | Wastes resources | Check periodically (30s+) |
 | Ignoring workingDirectory | Tasks run in wrong directory | Always set workingDirectory |
 | Unlimited maxIterations with no failures cap | Risk of infinite loop | Set maxIterations or maxConsecutiveFailures |
+| Using CreateOrchestrator for custom eval | Auto-generated prompts don't support custom eval logic | Use InitCustomOrchestrator + CreateLoop |
 
 ## Extended References
 

--- a/skills/autobeat/SKILL.md
+++ b/skills/autobeat/SKILL.md
@@ -92,7 +92,7 @@ Should it run on a schedule?
 | `PauseLoop` | Pause a loop mid-iteration |
 | `ResumeLoop` | Resume a paused loop |
 | `ScheduleTask` | Schedule a task (cron or one-time) |
-| `SchedulePipeline` | Schedule a recurring pipeline |
+| `SchedulePipeline` | Schedule a recurring or one-time pipeline |
 | `ScheduleLoop` | Schedule a recurring loop |
 | `ListSchedules` | List schedules with status filter |
 | `ScheduleStatus` | Get schedule details + history |
@@ -192,7 +192,7 @@ Mutually exclusive — `runtime` takes precedence if both are set. Clear with em
 |---------|---------------|-----|
 | Pipeline with 1 step | Unnecessary overhead | Use DelegateTask |
 | Manual dependsOn chain for sequential tasks | Error-prone wiring | Use CreatePipeline |
-| Loop without exit condition (shell mode) | Runs forever | Set exitCondition or use evalMode: agent with appropriate sub-strategy |
+| Loop without exit condition (shell mode) | Runs forever | Set exitCondition, or use evalMode: agent with an evalType |
 | Orchestrator for simple sequences | Overkill | Use Pipeline or Loop |
 | Polling TaskStatus in a tight loop | Wastes resources | Check periodically (30s+) |
 | Ignoring workingDirectory | Tasks run in wrong directory | Always set workingDirectory |

--- a/skills/autobeat/references/capability-matrix.md
+++ b/skills/autobeat/references/capability-matrix.md
@@ -18,6 +18,10 @@ Submit a task to a background AI agent instance.
 | `dependsOn` | string[] | No | — | Task IDs this task depends on |
 | `continueFrom` | string | No | — | Task ID to receive checkpoint context from |
 | `agent` | string | No | configured default | claude, codex, or gemini |
+| `model` | string | No | — | Model override (overrides agent-config default) |
+| `systemPrompt` | string | No | — | System prompt injected into agent (Claude: --append-system-prompt, Codex: developer_instructions, Gemini: combined GEMINI_SYSTEM_MD) |
+| `metadata.orchestratorId` | string | No | — | Orchestration attribution (format: orchestrator-{UUID}, 49 chars exactly) |
+| `jsonSchema` | string | No | — | JSON schema for structured output (Claude only) |
 
 ### TaskStatus
 
@@ -26,6 +30,7 @@ Get status of delegated tasks.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `taskId` | string | No | — | Specific task ID (omit for all tasks) |
+| `includeSystemPrompt` | boolean | No | false | Include system prompt in response |
 
 ### TaskLogs
 
@@ -73,9 +78,13 @@ Create a sequential pipeline of 2-20 tasks.
 | `steps[].priority` | string | No | inherited | Priority override (P0, P1, P2) |
 | `steps[].workingDirectory` | string | No | inherited | Working directory override |
 | `steps[].agent` | string | No | inherited | Agent override |
+| `steps[].model` | string | No | inherited | Model override for this step |
+| `steps[].systemPrompt` | string | No | inherited | System prompt override for this step |
 | `priority` | string | No | P2 | Default priority for all steps |
 | `workingDirectory` | string | No | — | Default working directory for all steps |
 | `agent` | string | No | configured default | Default agent for all steps |
+| `model` | string | No | — | Default model for all steps (steps can override) |
+| `systemPrompt` | string | No | — | Default system prompt for all steps (steps can override) |
 
 ### ScheduleTask
 
@@ -95,6 +104,8 @@ Schedule a task for future or recurring execution.
 | `expiresAt` | string | No | — | ISO 8601 expiry datetime |
 | `afterSchedule` | string | No | — | Schedule ID to chain after |
 | `agent` | string | No | configured default | Agent for the task |
+| `model` | string | No | — | Model override (overrides agent-config default) |
+| `systemPrompt` | string | No | — | System prompt injected on every scheduled run |
 
 ### ListSchedules
 
@@ -153,6 +164,8 @@ Schedule a recurring or one-time pipeline.
 | `steps[].priority` | string | No | inherited | Priority override |
 | `steps[].workingDirectory` | string | No | inherited | Working directory override |
 | `steps[].agent` | string | No | inherited | Agent override |
+| `steps[].model` | string | No | inherited | Model override for this step |
+| `steps[].systemPrompt` | string | No | inherited | System prompt override for this step |
 | `scheduleType` | string | Yes | — | "cron" or "one_time" |
 | `cronExpression` | string | Cond. | — | 5-field cron expression |
 | `scheduledAt` | string | Cond. | — | ISO 8601 datetime |
@@ -164,6 +177,8 @@ Schedule a recurring or one-time pipeline.
 | `expiresAt` | string | No | — | ISO 8601 expiry |
 | `afterSchedule` | string | No | — | Chain after schedule ID |
 | `agent` | string | No | configured default | Default agent |
+| `model` | string | No | — | Default model for all steps (steps can override) |
+| `systemPrompt` | string | No | — | Default system prompt for all steps (steps can override) |
 
 ### CreateLoop
 
@@ -186,6 +201,11 @@ Create an iterative loop.
 | `pipelineSteps` | string[] | No | — | Pipeline step prompts (2-20, creates pipeline loop) |
 | `priority` | string | No | P2 | Task priority |
 | `agent` | string | No | configured default | Agent for iterations |
+| `model` | string | No | — | Model override per iteration (overrides agent-config default) |
+| `systemPrompt` | string | No | — | System prompt injected into each iteration task agent |
+| `evalType` | string | No | feedforward | Agent eval sub-strategy: feedforward, judge, or schema (only when evalMode is agent) |
+| `judgeAgent` | string | No | loop agent | Agent for judge decisions (judge evalType only) |
+| `judgePrompt` | string | No | — | Custom judge instructions (judge evalType only) |
 | `gitBranch` | string | No | — | Git branch for iteration tracking |
 
 *`prompt` required unless `pipelineSteps` provided.
@@ -199,6 +219,7 @@ Get loop details.
 | `loopId` | string | Yes | — | Loop ID |
 | `includeHistory` | boolean | No | false | Include iteration history |
 | `historyLimit` | number | No | 20 | Max iterations to return |
+| `includeSystemPrompt` | boolean | No | false | Include system prompt in response |
 
 ### ListLoops
 
@@ -258,6 +279,8 @@ Schedule a recurring or one-time loop.
 | `gitBranch` | string | No | — | Git branch for tracking |
 | `priority` | string | No | — | Task priority |
 | `agent` | string | No | — | Agent for iterations |
+| `model` | string | No | — | Model override per iteration |
+| `systemPrompt` | string | No | — | System prompt injected into each iteration task agent on every trigger |
 | `scheduleType` | string | Yes | — | "cron" or "one_time" |
 | `cronExpression` | string | Cond. | — | 5-field cron expression |
 | `scheduledAt` | string | Cond. | — | ISO 8601 datetime |
@@ -275,6 +298,8 @@ Create and start an autonomous orchestration.
 | `goal` | string | Yes | — | High-level goal (1-8000 chars) |
 | `workingDirectory` | string | No | — | Working directory for workers |
 | `agent` | string | No | configured default | Agent for the orchestrator |
+| `model` | string | No | — | Model override (overrides agent-config default) |
+| `systemPrompt` | string | No | — | Custom system prompt (replaces auto-generated role instructions when provided) |
 | `maxDepth` | number | No | 3 | Max delegation depth (1-10) |
 | `maxWorkers` | number | No | 5 | Max concurrent workers (1-20) |
 | `maxIterations` | number | No | 50 | Max orchestrator iterations (1-200) |
@@ -319,6 +344,52 @@ Check auth status, store API key, or reset stored key for an agent.
 | `agent` | string | Yes | — | Agent provider (claude, codex, gemini) |
 | `action` | string | No | check | set, check, or reset |
 | `apiKey` | string | No | — | API key to store (required for set action) |
+| `baseUrl` | string | No | — | Base URL override (set action, e.g. https://proxy.example.com/v1) |
+| `model` | string | No | — | Default model override for this agent (set action) |
+| `proxy` | string | No | — | API proxy target (set action). Supported: "openai". Empty string clears. |
+| `runtime` | string | No | — | Runtime to wrap agent spawns (set action). Supported: "ollama". Supported agents: claude, codex. Mutually exclusive with proxy — runtime takes precedence. Empty string clears. |
+
+### InitCustomOrchestrator
+
+Scaffold building blocks for a custom orchestrator (state file, exit script, instruction snippets).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `goal` | string | Yes | — | High-level goal for the custom orchestrator |
+| `workingDirectory` | string | No | server cwd | Working directory (absolute path) |
+| `agent` | string | No | configured default | AI agent for delegation commands |
+| `model` | string | No | — | Model for delegation commands |
+| `maxWorkers` | number | No | 5 | Max concurrent workers (1-20) |
+| `maxDepth` | number | No | 3 | Max delegation depth (1-10) |
+
+Returns: stateFilePath, exitConditionScript, suggestedExitCondition, instruction snippets (delegation, stateManagement, constraints).
+
+### PipelineStatus
+
+Get status of a pipeline entity.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pipelineId` | string | Yes | — | Pipeline entity ID (pipeline-xxxx) |
+
+### ListPipelines
+
+List pipelines with optional status filter.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `status` | string | No | — | pending, running, completed, failed, cancelled |
+| `limit` | number | No | 50 | Max results (1-100) |
+
+### CancelPipeline
+
+Cancel a pipeline and optionally its in-flight tasks.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pipelineId` | string | Yes | — | Pipeline entity ID |
+| `reason` | string | No | — | Cancellation reason |
+| `cancelTasks` | boolean | No | true | Also cancel in-flight step tasks |
 
 ## CLI Commands
 
@@ -327,6 +398,8 @@ Check auth status, store API key, or reset stored key for an agent.
 ```
 beat run "<prompt>" [options]
   --agent, -a <name>       Agent (claude, codex, gemini)
+  --model, -m <name>       Model override
+  --system-prompt "..."    System prompt injected into agent
   --priority, -p <level>   P0, P1, P2
   --working-directory, -w  Absolute path
   --timeout <ms>           Task timeout
@@ -359,6 +432,8 @@ beat loop --pipeline --step "..." --step "..." --until "<cmd>"  # Pipeline loop
 
 Options:
   --agent, -a <name>       Agent for iterations
+  --model, -m <name>       Model override per iteration
+  --system-prompt "..."    System prompt injected into each iteration task agent
   --priority, -p <level>   Task priority
   --working-directory, -w  Working directory
   --max-iterations <n>     Max iterations (0 = unlimited)
@@ -391,6 +466,8 @@ beat schedule create "<prompt>" [options]
   --step "..."             Pipeline step (repeatable, requires --pipeline)
   --loop                   Enable loop mode
   --agent, -a <name>       Default agent
+  --model, -m <name>       Model override
+  --system-prompt "..."    System prompt injected on every scheduled run
   --priority, -p <level>   Default priority
   --working-directory, -w  Working directory
 
@@ -406,6 +483,8 @@ beat schedule cancel <id> [--cancel-tasks] [reason]
 ```
 beat orchestrate "<goal>" [options]
   --agent, -a <name>       Agent for orchestrator
+  --model, -m <name>       Model override
+  --system-prompt "..."    Custom system prompt
   --working-directory, -w  Working directory
   --max-depth <n>          Max delegation depth (1-10)
   --max-workers <n>        Max concurrent workers (1-20)
@@ -415,6 +494,27 @@ beat orchestrate "<goal>" [options]
 beat orchestrate status <id>
 beat orchestrate list [--status <status>]
 beat orchestrate cancel <id> [reason]
+
+beat orchestrate init "<goal>" [options]
+  --working-directory, -w  Working directory
+  --agent, -a <name>       Agent for delegation
+  --model, -m <name>       Model for delegation
+  --max-depth <n>          Max delegation depth (1-10)
+  --max-workers <n>        Max concurrent workers (1-20)
+```
+
+### Dashboard Commands
+
+```
+beat dashboard               Terminal dashboard TUI
+beat dash                    Alias for dashboard
+```
+
+### List Commands
+
+```
+beat list [--status <status>]       List tasks
+beat ls [--status <status>]         Alias for list
 ```
 
 ### Setup Commands
@@ -426,5 +526,16 @@ beat init --install-skills             Install agent skills
 beat init --skills-agents <agents>     Comma-separated agents to install skills for (e.g. claude,codex)
 beat init --yes, -y                    Non-interactive: skip confirmations
 beat agents list                       Show agents with status
+beat agents check                      Check agent auth status
+beat agents config set <agent> [options]  Set agent config values
+beat agents config show <agent>           Show agent config
+beat agents config reset <agent>          Reset agent config
+beat agents refresh-base-prompt <agent>   Refresh Gemini base prompt
+
+beat config show                   Show configuration
+beat config set <key> <value>      Set configuration value
+beat config reset [key]            Reset config (all or specific key)
+beat config path                   Show config file path
+
 beat help                              Show help
 ```

--- a/skills/autobeat/references/capability-matrix.md
+++ b/skills/autobeat/references/capability-matrix.md
@@ -280,7 +280,7 @@ Schedule a recurring or one-time loop.
 | `priority` | string | No | — | Task priority |
 | `agent` | string | No | — | Agent for iterations |
 | `model` | string | No | — | Model override per iteration |
-| `systemPrompt` | string | No | — | System prompt injected into each iteration task agent on every trigger |
+| `systemPrompt` | string | No | — | System prompt injected into each iteration task agent (applied on every trigger) |
 | `scheduleType` | string | Yes | — | "cron" or "one_time" |
 | `cronExpression` | string | Cond. | — | 5-field cron expression |
 | `scheduledAt` | string | Cond. | — | ISO 8601 datetime |
@@ -299,7 +299,7 @@ Create and start an autonomous orchestration.
 | `workingDirectory` | string | No | — | Working directory for workers |
 | `agent` | string | No | configured default | Agent for the orchestrator |
 | `model` | string | No | — | Model override (overrides agent-config default) |
-| `systemPrompt` | string | No | — | Custom system prompt (replaces auto-generated role instructions when provided) |
+| `systemPrompt` | string | No | — | Custom system prompt (replaces auto-generated role instructions entirely) |
 | `maxDepth` | number | No | 3 | Max delegation depth (1-10) |
 | `maxWorkers` | number | No | 5 | Max concurrent workers (1-20) |
 | `maxIterations` | number | No | 50 | Max orchestrator iterations (1-200) |
@@ -362,7 +362,7 @@ Scaffold building blocks for a custom orchestrator (state file, exit script, ins
 | `maxWorkers` | number | No | 5 | Max concurrent workers (1-20) |
 | `maxDepth` | number | No | 3 | Max delegation depth (1-10) |
 
-Returns: stateFilePath, exitConditionScript, suggestedExitCondition, instruction snippets (delegation, stateManagement, constraints).
+Returns: `stateFilePath`, `exitConditionScript`, `suggestedExitCondition`, and instruction snippets (`delegation`, `stateManagement`, `constraints`).
 
 ### PipelineStatus
 

--- a/skills/autobeat/references/capability-matrix.md
+++ b/skills/autobeat/references/capability-matrix.md
@@ -10,10 +10,10 @@ Submit a task to a background AI agent instance.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `prompt` | string | Yes | — | Task prompt (1-4000 chars) |
+| `prompt` | string | Yes | — | Task prompt |
 | `priority` | string | No | P2 | P0 (critical), P1 (high), P2 (normal) |
 | `workingDirectory` | string | No | — | Absolute path for task execution |
-| `timeout` | number | No | 1800000 | Timeout in ms (1000-86400000) |
+| `timeout` | number | No | 0 (disabled) | Timeout in ms (1000-86400000); 0 means no timeout |
 | `maxOutputBuffer` | number | No | 10485760 | Max output buffer bytes (1024-1073741824) |
 | `dependsOn` | string[] | No | — | Task IDs this task depends on |
 | `continueFrom` | string | No | — | Task ID to receive checkpoint context from |
@@ -39,7 +39,7 @@ Retrieve execution logs from a delegated task.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `taskId` | string | Yes | — | Task ID to get logs for |
-| `tail` | number | No | 100 | Number of recent lines (1-1000) |
+| `tail` | number | No | 100 | Number of recent lines |
 
 ### CancelTask
 
@@ -48,7 +48,7 @@ Cancel a running delegated task.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `taskId` | string | Yes | — | Task ID to cancel |
-| `reason` | string | No | — | Cancellation reason (max 200 chars) |
+| `reason` | string | No | — | Cancellation reason |
 
 ### RetryTask
 
@@ -65,7 +65,7 @@ Resume a terminal task with enriched context from its checkpoint.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `taskId` | string | Yes | — | Task ID (must be completed, failed, or cancelled) |
-| `additionalContext` | string | No | — | Extra instructions for the resumed task (max 4000 chars) |
+| `additionalContext` | string | No | — | Extra instructions for the resumed task |
 
 ### CreatePipeline
 
@@ -74,7 +74,7 @@ Create a sequential pipeline of 2-20 tasks.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `steps` | object[] | Yes | — | Ordered pipeline steps (2-20) |
-| `steps[].prompt` | string | Yes | — | Task prompt for this step (1-4000 chars) |
+| `steps[].prompt` | string | Yes | — | Task prompt for this step |
 | `steps[].priority` | string | No | inherited | Priority override (P0, P1, P2) |
 | `steps[].workingDirectory` | string | No | inherited | Working directory override |
 | `steps[].agent` | string | No | inherited | Agent override |
@@ -160,7 +160,7 @@ Schedule a recurring or one-time pipeline.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `steps` | object[] | Yes | — | Ordered pipeline steps (2-20) |
-| `steps[].prompt` | string | Yes | — | Task prompt (1-4000 chars) |
+| `steps[].prompt` | string | Yes | — | Task prompt for this step |
 | `steps[].priority` | string | No | inherited | Priority override |
 | `steps[].workingDirectory` | string | No | inherited | Working directory override |
 | `steps[].agent` | string | No | inherited | Agent override |
@@ -186,11 +186,11 @@ Create an iterative loop.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `prompt` | string | No* | — | Task prompt per iteration (1-4000 chars) |
+| `prompt` | string | No* | — | Task prompt per iteration |
 | `strategy` | string | Yes | — | "retry" or "optimize" |
 | `exitCondition` | string | No | — | Shell command for eval (shell mode) |
 | `evalMode` | string | No | shell | "shell" or "agent" |
-| `evalPrompt` | string | No | — | Custom agent eval prompt (1-8000 chars) |
+| `evalPrompt` | string | No | — | Custom agent eval prompt (agent eval mode only) |
 | `evalDirection` | string | No | — | "minimize" or "maximize" (optimize only) |
 | `evalTimeout` | number | No | 60000 | Eval timeout ms (1000-600000) |
 | `workingDirectory` | string | No | — | Working directory |
@@ -285,7 +285,7 @@ Schedule a recurring or one-time loop.
 | `cronExpression` | string | Cond. | — | 5-field cron expression |
 | `scheduledAt` | string | Cond. | — | ISO 8601 datetime |
 | `timezone` | string | No | UTC | IANA timezone |
-| `missedRunPolicy` | string | No | — | skip, catchup, or fail |
+| `missedRunPolicy` | string | No | skip | skip, catchup, or fail |
 | `maxRuns` | number | No | — | Max cron loop runs |
 | `expiresAt` | string | No | — | ISO 8601 expiry |
 
@@ -295,7 +295,7 @@ Create and start an autonomous orchestration.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `goal` | string | Yes | — | High-level goal (1-8000 chars) |
+| `goal` | string | Yes | — | High-level goal for the orchestrator |
 | `workingDirectory` | string | No | — | Working directory for workers |
 | `agent` | string | No | configured default | Agent for the orchestrator |
 | `model` | string | No | — | Model override (overrides agent-config default) |

--- a/skills/autobeat/references/dependencies.md
+++ b/skills/autobeat/references/dependencies.md
@@ -250,8 +250,7 @@ Pipeline and scheduled pipeline steps support per-step configuration:
 
 - **Cycle detection**: DAG validation prevents cycles (A→B→A) using DFS algorithm
 - **TOCTOU protection**: Dependency addition uses synchronous SQLite transactions
-- **Task existence**: Referenced task IDs must exist
-- **Terminal state**: Dependencies can only be on existing tasks
+- **Task existence**: Referenced task IDs must exist at the time of dependency creation
 - **Max fan-out**: No hard limit, but keep practical (< 50 concurrent dependents)
 
 ## Recipes

--- a/skills/autobeat/references/dependencies.md
+++ b/skills/autobeat/references/dependencies.md
@@ -203,6 +203,13 @@ Wrap a pipeline in a schedule for recurring execution:
 
 Each trigger creates a fresh set of pipeline tasks with linear dependencies.
 
+### Pipeline Entity Management
+
+Pipelines are first-class entities with IDs (`pipeline-xxxx`) queryable via:
+- `PipelineStatus` — check step progress and failure details
+- `ListPipelines` — list by status (pending, running, completed, failed, cancelled)
+- `CancelPipeline` — cancel with optional task cancellation
+
 ### Schedule Chaining (`afterSchedule`)
 
 Chain schedules so one runs after another:
@@ -225,16 +232,18 @@ Pipeline and scheduled pipeline steps support per-step configuration:
     "steps": [
       { "prompt": "Lint", "priority": "P1" },
       { "prompt": "Test", "priority": "P0", "workingDirectory": "/path/to/test-repo" },
-      { "prompt": "Deploy", "agent": "codex" }
+      { "prompt": "Deploy", "agent": "codex", "model": "o3", "systemPrompt": "Follow deployment runbook strictly" }
     ],
     "priority": "P2",
     "workingDirectory": "/path/to/repo",
-    "agent": "claude"
+    "agent": "claude",
+    "model": "claude-sonnet-4-6",
+    "systemPrompt": "You are a CI/CD specialist"
   }
 }
 ```
 
-- Step-level `priority`, `workingDirectory`, `agent` override pipeline-level defaults
+- Step-level `priority`, `workingDirectory`, `agent`, `model`, `systemPrompt` override pipeline-level defaults
 - Unset step fields inherit from the pipeline-level value
 
 ## Validation Rules

--- a/skills/autobeat/references/loops.md
+++ b/skills/autobeat/references/loops.md
@@ -149,7 +149,7 @@ Use when the quality measure requires judgment. The same two-level hierarchy app
 |----------|----------|---------------|--------------|
 | `feedforward` (default) | Eval agent gathers findings, injects as context; score from output | Numeric score parsed from eval output | Works with any agent |
 | `judge` | Two-phase: eval generates findings, judge writes `{"continue": bool}` | File-based decision + score | Requires `evalPrompt` |
-| `schema` | Single-phase: agent responds with structured output including score | Deterministic structured output | Requires `agent: "claude"` only |
+| `schema` | Single-phase: agent responds `{"continue": bool, "score": number, "reasoning": string}` via --json-schema | Deterministic structured output | Requires `agent: "claude"` only |
 
 #### Feedforward (default)
 
@@ -193,7 +193,7 @@ Two-phase evaluation for optimize loops. The eval agent generates a score and fi
 
 #### Schema (Claude only)
 
-Deterministic structured scoring via Claude `--json-schema`. **Requires `agent: "claude"`**.
+Deterministic structured scoring via Claude `--json-schema`. The agent responds with `{"continue": bool, "score": number, "reasoning": string}`. **Requires `agent: "claude"`**.
 
 ```json
 {

--- a/skills/autobeat/references/loops.md
+++ b/skills/autobeat/references/loops.md
@@ -36,7 +36,21 @@ beat loop "Fix all failing tests" --until "npm test" -w /path/to/repo
 
 ### Agent Eval
 
-Use when the exit condition requires judgment (code quality, design correctness, etc.):
+Use when the exit condition requires judgment. Agent eval uses a two-level hierarchy:
+
+**Top level: `evalMode: agent`** — activates agent-based evaluation.
+
+**Sub-strategy: `evalType`** (only when evalMode is agent):
+
+| evalType | Behavior | Stop Decision | Requirements |
+|----------|----------|--------------|--------------|
+| `feedforward` (default) | Eval gathers findings, injects as context into next iteration | None — always runs to maxIterations | Works with any agent |
+| `judge` | Two-phase: eval agent generates findings, then judge agent writes `{"continue": bool}` to file | File-based + --json-schema fallback | Requires `evalPrompt` |
+| `schema` | Single-phase: agent responds `{"continue": bool, "reasoning": string}` via --json-schema | Deterministic structured output | Requires `agent: "claude"` only |
+
+#### Feedforward (default)
+
+Eval agent gathers findings per iteration, injects them as context into the next iteration. No stop/continue decision — always runs to `maxIterations`. If no `evalPrompt` is set, no eval agent is spawned.
 
 ```json
 {
@@ -45,7 +59,50 @@ Use when the exit condition requires judgment (code quality, design correctness,
     "prompt": "Refactor the auth module for better testability",
     "strategy": "retry",
     "evalMode": "agent",
-    "evalPrompt": "Review the refactoring. PASS if dependency injection is used correctly and all tests pass. FAIL with explanation otherwise.",
+    "evalType": "feedforward",
+    "evalPrompt": "Review the refactoring. List specific issues with dependency injection usage and test coverage.",
+    "workingDirectory": "/path/to/repo",
+    "maxIterations": 5
+  }
+}
+```
+
+#### Judge
+
+Two-phase evaluation: eval agent generates findings, then a separate judge agent writes a `{"continue": bool}` decision to `.autobeat-judge-task-{uuid}` file. Configure the judge phase independently with `judgeAgent` and `judgePrompt`.
+
+Fallback chain: file-based decision → Claude `--json-schema` fallback → defaults to continue if both fail.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Refactor the auth module for better testability",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalType": "judge",
+    "evalPrompt": "Review the refactoring quality. Focus on DI patterns and test coverage.",
+    "judgeAgent": "claude",
+    "judgePrompt": "Based on the evaluation, decide if the code meets production quality standards.",
+    "workingDirectory": "/path/to/repo"
+  }
+}
+```
+
+#### Schema (Claude only)
+
+Deterministic structured output via Claude `--json-schema`. The agent responds with `{"continue": bool, "reasoning": string}`. No separate judge agent. **Requires `agent: "claude"`** — only Claude supports `--json-schema`.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Refactor the auth module for better testability",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalType": "schema",
+    "evalPrompt": "Evaluate if DI is used correctly and all tests pass. Set continue=false when satisfied.",
+    "agent": "claude",
     "workingDirectory": "/path/to/repo"
   }
 }
@@ -56,12 +113,6 @@ CLI:
 beat loop "Refactor the auth module" --eval-mode agent --strategy retry \
   --eval-prompt "Review changes. PASS if DI is correct and tests pass, else FAIL."
 ```
-
-**Agent eval behavior (retry)**:
-- Evaluator agent reads the task output and git diff
-- Must output `PASS` or `FAIL` as the last line
-- Optional explanation before the verdict
-- `evalPrompt` customizes what the evaluator checks
 
 ## Optimize Strategy
 
@@ -92,7 +143,17 @@ beat loop "Optimize query performance" --eval "node scripts/benchmark.js" --mini
 
 ### Agent Eval
 
-The evaluator agent scores each iteration 0-100:
+Use when the quality measure requires judgment. The same two-level hierarchy applies (`evalMode: agent` + `evalType`):
+
+| evalType | Behavior | Score Decision | Requirements |
+|----------|----------|---------------|--------------|
+| `feedforward` (default) | Eval gathers findings, injects as context; score from output | Numeric score parsed from eval output | Works with any agent |
+| `judge` | Two-phase: eval generates findings, judge writes `{"continue": bool}` | File-based decision + score | Requires `evalPrompt` |
+| `schema` | Single-phase: agent responds with structured output including score | Deterministic structured output | Requires `agent: "claude"` only |
+
+#### Feedforward (default)
+
+The evaluator agent scores each iteration 0-100. Findings are injected as context into the next iteration for progressive improvement.
 
 ```json
 {
@@ -101,8 +162,50 @@ The evaluator agent scores each iteration 0-100:
     "prompt": "Improve test coverage for the payment module",
     "strategy": "optimize",
     "evalMode": "agent",
+    "evalType": "feedforward",
     "evalDirection": "maximize",
     "evalPrompt": "Score the test coverage quality 0-100. Consider: branch coverage, edge cases, error paths, integration vs unit balance.",
+    "workingDirectory": "/path/to/repo"
+  }
+}
+```
+
+#### Judge
+
+Two-phase evaluation for optimize loops. The eval agent generates a score and findings; the judge agent writes a `{"continue": bool}` decision.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Improve test coverage for the payment module",
+    "strategy": "optimize",
+    "evalMode": "agent",
+    "evalType": "judge",
+    "evalDirection": "maximize",
+    "evalPrompt": "Score test coverage quality 0-100 and list remaining gaps.",
+    "judgeAgent": "claude",
+    "judgePrompt": "Decide if coverage is sufficient for production. Output continue=false when score >= 90.",
+    "workingDirectory": "/path/to/repo"
+  }
+}
+```
+
+#### Schema (Claude only)
+
+Deterministic structured scoring via Claude `--json-schema`. **Requires `agent: "claude"`**.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Improve test coverage for the payment module",
+    "strategy": "optimize",
+    "evalMode": "agent",
+    "evalType": "schema",
+    "evalDirection": "maximize",
+    "evalPrompt": "Evaluate test coverage. Return a score 0-100 and set continue=false when coverage is satisfactory.",
+    "agent": "claude",
     "workingDirectory": "/path/to/repo"
   }
 }
@@ -131,9 +234,27 @@ beat loop "Improve test coverage" --eval-mode agent --strategy optimize --maximi
 | `freshContext` | true | boolean | Fresh agent context per iteration |
 | `evalMode` | shell | shell, agent | How to evaluate iterations |
 | `evalPrompt` | (default) | string | Custom eval instructions (agent mode) |
+| `evalType` | feedforward | feedforward, judge, schema | Agent eval sub-strategy (only when evalMode is agent) |
+| `judgeAgent` | loop agent | claude, codex, gemini | Agent for judge decisions (judge evalType only) |
+| `judgePrompt` | — | string | Custom judge instructions (judge evalType only) |
 | `evalDirection` | — | minimize, maximize | Score direction (optimize only) |
 | `gitBranch` | — | string | Git branch for iteration tracking |
 | `priority` | P2 | P0, P1, P2 | Task priority per iteration |
+| `model` | — | string | Model override per iteration |
+| `systemPrompt` | — | string | System prompt per iteration task |
+
+### Eval Type Decision Tree
+
+```
+Need iterative feedback but always run to maxIterations?
+  → evalType: feedforward (default)
+Need an AI judge to decide continue/stop?
+  → evalType: judge (optionally set judgeAgent for a separate judge)
+Need deterministic structured pass/fail (Claude only)?
+  → evalType: schema
+Only care about shell exit code / script score?
+  → evalMode: shell (evalType is ignored)
+```
 
 ### Fresh Context vs Checkpoint Continuation
 
@@ -276,6 +397,7 @@ RUNNING → CANCELLED (CancelLoop)
     "prompt": "Review the PR changes and improve code quality: reduce complexity, improve naming, add missing error handling.",
     "strategy": "optimize",
     "evalMode": "agent",
+    "evalType": "feedforward",
     "evalDirection": "maximize",
     "evalPrompt": "Score the code quality 0-100. Consider: readability, error handling, naming, complexity, test coverage. Output just the number.",
     "workingDirectory": "/path/to/repo",
@@ -320,6 +442,66 @@ RUNNING → CANCELLED (CancelLoop)
     "evalPrompt": "Score the test coverage improvement 0-100. Check: new branches covered, edge cases, no redundant tests.",
     "maxIterations": 5,
     "workingDirectory": "/path/to/repo"
+  }
+}
+```
+
+### Feedforward Findings Loop
+
+Accumulates findings across iterations — each iteration gets the previous eval's findings injected as context. Always runs to `maxIterations`.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Review and improve API error handling across all endpoints.",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalType": "feedforward",
+    "evalPrompt": "List specific endpoints still missing proper error handling. Include line numbers and what's missing.",
+    "workingDirectory": "/path/to/repo",
+    "maxIterations": 4
+  }
+}
+```
+
+### Judge Loop
+
+Separate evaluator and judge agents. The evaluator generates findings; the judge decides continue/stop.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Refactor the payment module to use Result types throughout.",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalType": "judge",
+    "evalPrompt": "Review the refactoring. Identify any remaining throw statements in business logic.",
+    "judgeAgent": "claude",
+    "judgePrompt": "Based on the evaluation, decide if all business logic now uses Result types. Output continue=false only when no throw statements remain in business logic.",
+    "workingDirectory": "/path/to/repo",
+    "maxIterations": 6
+  }
+}
+```
+
+### Schema Test Gate (Claude only)
+
+Deterministic structured pass/fail. Claude responds with `{"continue": bool, "reasoning": string}` via `--json-schema`.
+
+```json
+{
+  "tool": "CreateLoop",
+  "arguments": {
+    "prompt": "Fix all TypeScript type errors in src/. Do not use 'any' as a workaround.",
+    "strategy": "retry",
+    "evalMode": "agent",
+    "evalType": "schema",
+    "evalPrompt": "Run `npm run typecheck`. Evaluate if all type errors are resolved without using 'any'. Set continue=false only when typecheck passes cleanly.",
+    "agent": "claude",
+    "workingDirectory": "/path/to/repo",
+    "maxIterations": 5
   }
 }
 ```

--- a/skills/autobeat/references/loops.md
+++ b/skills/autobeat/references/loops.md
@@ -44,7 +44,7 @@ Use when the exit condition requires judgment. Agent eval uses a two-level hiera
 
 | evalType | Behavior | Stop Decision | Requirements |
 |----------|----------|--------------|--------------|
-| `feedforward` (default) | Eval gathers findings, injects as context into next iteration | None — always runs to maxIterations | Works with any agent |
+| `feedforward` (default) | Eval agent gathers findings, injects as context into next iteration | None — always runs to maxIterations | Works with any agent |
 | `judge` | Two-phase: eval agent generates findings, then judge agent writes `{"continue": bool}` to file | File-based + --json-schema fallback | Requires `evalPrompt` |
 | `schema` | Single-phase: agent responds `{"continue": bool, "reasoning": string}` via --json-schema | Deterministic structured output | Requires `agent: "claude"` only |
 
@@ -147,7 +147,7 @@ Use when the quality measure requires judgment. The same two-level hierarchy app
 
 | evalType | Behavior | Score Decision | Requirements |
 |----------|----------|---------------|--------------|
-| `feedforward` (default) | Eval gathers findings, injects as context; score from output | Numeric score parsed from eval output | Works with any agent |
+| `feedforward` (default) | Eval agent gathers findings, injects as context; score from output | Numeric score parsed from eval output | Works with any agent |
 | `judge` | Two-phase: eval generates findings, judge writes `{"continue": bool}` | File-based decision + score | Requires `evalPrompt` |
 | `schema` | Single-phase: agent responds with structured output including score | Deterministic structured output | Requires `agent: "claude"` only |
 

--- a/skills/autobeat/references/monitoring.md
+++ b/skills/autobeat/references/monitoring.md
@@ -222,9 +222,9 @@ The resumed task receives:
 ### List and Filter
 
 ```json
-{ "tool": "TaskStatus", "arguments": {} }  // All tasks
-{ "tool": "ListLoops", "arguments": { "status": "running" } }  // Running loops only
-{ "tool": "ListSchedules", "arguments": { "status": "active" } }  // Active schedules
+{ "tool": "TaskStatus", "arguments": {} }
+{ "tool": "ListLoops", "arguments": { "status": "running" } }
+{ "tool": "ListSchedules", "arguments": { "status": "active" } }
 { "tool": "ListOrchestrators", "arguments": { "status": "running", "limit": 10 } }
 ```
 

--- a/skills/autobeat/references/monitoring.md
+++ b/skills/autobeat/references/monitoring.md
@@ -54,6 +54,26 @@ CLI: `beat orchestrate status <id>`
 
 Returns: goal, status, guardrails, plan steps, iteration count.
 
+### Check Pipeline
+
+```json
+{ "tool": "PipelineStatus", "arguments": { "pipelineId": "pipeline-xxxx" } }
+```
+
+Returns: pipeline state, step count, completed steps, failed step details.
+
+### List Pipelines
+
+```json
+{ "tool": "ListPipelines", "arguments": { "status": "running", "limit": 20 } }
+```
+
+### Cancel Pipeline
+
+```json
+{ "tool": "CancelPipeline", "arguments": { "pipelineId": "pipeline-xxxx", "cancelTasks": true, "reason": "Superseded" } }
+```
+
 ## Task States
 
 | State | Meaning | Transitions To |
@@ -94,6 +114,16 @@ Returns: goal, status, guardrails, plan steps, iteration count.
 | `completed` | maxRuns reached or expired |
 | `cancelled` | Manually cancelled |
 | `expired` | Past expiresAt datetime |
+
+### Pipeline States
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Created, first step not yet started |
+| `running` | At least one step executing |
+| `completed` | All steps completed successfully |
+| `failed` | A step failed, downstream steps cancelled |
+| `cancelled` | Manually cancelled via CancelPipeline |
 
 ## Recovery Decision Tree
 
@@ -172,6 +202,13 @@ The resumed task receives:
 3. The orchestrator manages its own tasks — you monitor the orchestration level
 4. If stuck: `CancelOrchestrator` and try a different approach
 
+### For Pipelines
+
+1. Create: `CreatePipeline` → save pipelineId
+2. Check: `PipelineStatus` for overall progress
+3. If step failed: `TaskLogs` on the failed step's taskId
+4. If stuck: `CancelPipeline` to abort and investigate
+
 ### Polling Cadence
 
 - Simple tasks (< 5 min expected): check every 30s
@@ -242,3 +279,19 @@ There's no bulk cancel tool. Cancel individually:
 
 - **Cause**: Default timeout is 30 minutes
 - **Fix**: Set `timeout` on the task (max 24 hours = 86400000ms)
+
+### Pipeline Stuck in Pending
+
+- **Cause**: First step hasn't started, no available workers
+- **Check**: `PipelineStatus` to confirm step 0 status, check worker availability
+- **Fix**: Cancel lower-priority tasks or wait for workers to free up
+
+### Pipeline Step Failed
+
+- **Cause**: A step task failed
+- **Check**: `TaskLogs` on the failed step's taskId for error details
+- **Fix**: Downstream steps are auto-cancelled. Fix the issue and create a new pipeline
+
+### Dashboard
+
+`beat dashboard` (or `beat dash`) provides a terminal TUI for visual monitoring of tasks, loops, orchestrations, and pipelines. Agents don't interact with the dashboard directly — use the MCP tools above.

--- a/skills/autobeat/references/monitoring.md
+++ b/skills/autobeat/references/monitoring.md
@@ -30,7 +30,7 @@ CLI: `beat status task-abc...`
 
 CLI: `beat logs task-abc...`
 
-- `tail`: number of recent lines (default: 100, max: 1000)
+- `tail`: number of recent lines (default: 100)
 - Returns stdout and stderr combined
 - Output persists even after task completion
 
@@ -277,8 +277,8 @@ There's no bulk cancel tool. Cancel individually:
 
 ### Task Timeout
 
-- **Cause**: Default timeout is 30 minutes
-- **Fix**: Set `timeout` on the task (max 24 hours = 86400000ms)
+- **Cause**: Default timeout is 0 (disabled) — tasks run until completion or manual cancellation
+- **Fix**: Set `timeout` on the task to enforce a limit (max 24 hours = 86400000ms)
 
 ### Pipeline Stuck in Pending
 

--- a/skills/autobeat/references/orchestration.md
+++ b/skills/autobeat/references/orchestration.md
@@ -43,11 +43,11 @@ beat run "Run the test suite and report results" -w /path/to/repo --agent claude
 
 ### Key Parameters
 
-- `prompt` (required): What the agent should do (max 4000 chars)
+- `prompt` (required): What the agent should do
 - `workingDirectory`: Absolute path — always set this
 - `agent`: claude | codex | gemini (falls back to configured default)
 - `priority`: P0 (critical), P1 (high), P2 (normal, default)
-- `timeout`: ms, default 30min, max 24h
+- `timeout`: ms, default 0 (disabled), max 24h (86400000ms)
 - `maxOutputBuffer`: bytes, default 10MB, max 1GB
 
 ## Pipelines

--- a/skills/autobeat/references/orchestration.md
+++ b/skills/autobeat/references/orchestration.md
@@ -119,6 +119,10 @@ beat orchestrate "Migrate the Express API to Fastify" --foreground  # block and 
 | `maxDepth` | 3 | 1-10 | Max delegation depth |
 | `maxWorkers` | 5 | 1-20 | Max concurrent worker agents |
 | `maxIterations` | 50 | 1-200 | Max orchestrator loop iterations |
+| `model` | — | string | Model override (overrides agent-config default) |
+| `systemPrompt` | — | string | Custom system prompt (replaces auto-generated role instructions) |
+
+**Caveat**: `systemPrompt` replaces the auto-generated role instructions entirely — it does not append. This prevents conflicting ROLE sections.
 
 ### How It Works
 
@@ -139,6 +143,46 @@ beat orchestrate "Migrate the Express API to Fastify" --foreground  # block and 
 - Steps are known upfront → Pipeline
 - It's iterative improvement on one task → Loop
 - It's a single task → DelegateTask
+
+## Custom Orchestrators
+
+For orchestrations that need custom eval criteria, custom prompt structure, or multi-phase logic, use `InitCustomOrchestrator` to scaffold building blocks and compose them into a `CreateLoop`.
+
+### When to Use
+
+| | CreateOrchestrator | InitCustomOrchestrator + CreateLoop |
+|---|---|---|
+| Prompt | Auto-generated role instructions | You provide full systemPrompt |
+| Eval | Built-in state file polling | Your custom evalPrompt + evalType |
+| Control | Turnkey — autobeat manages everything | Full control — you compose the loop |
+| Best for | Standard goal execution | Custom eval, multi-phase, specialized prompts |
+
+### Workflow
+
+1. Call `InitCustomOrchestrator` with your goal → receive artifacts (state file, exit script, snippets)
+2. Compose a `CreateLoop` using the artifacts: set `systemPrompt` with delegation snippets, `exitCondition` with the exit script, `evalPrompt` for custom evaluation
+3. Monitor with `LoopStatus`
+
+### MCP
+
+```json
+{
+  "tool": "InitCustomOrchestrator",
+  "arguments": {
+    "goal": "Migrate Express API to Fastify with zero regression",
+    "workingDirectory": "/path/to/repo",
+    "agent": "claude",
+    "maxWorkers": 5,
+    "maxDepth": 3
+  }
+}
+```
+
+### CLI
+
+```bash
+beat orchestrate init "Migrate Express API to Fastify" -w /path/to/repo -a claude
+```
 
 ## Schedules
 
@@ -214,6 +258,18 @@ Wrap any primitive in a schedule for deferred or recurring execution.
 - **active** → **cancelled** (CancelSchedule)
 - **active** → **completed** (maxRuns reached or expired)
 - Concurrent execution prevented: overlapping triggers are skipped
+
+## Pipeline Management
+
+Pipelines are first-class entities with their own IDs (`pipeline-xxxx`).
+
+| Tool | Purpose |
+|------|---------|
+| `PipelineStatus` | Get pipeline status, step progress, failure details |
+| `ListPipelines` | List pipelines with optional status filter |
+| `CancelPipeline` | Cancel a pipeline and optionally all in-flight step tasks |
+
+Pipeline states: pending, running, completed, failed, cancelled.
 
 ## Composition Patterns
 

--- a/skills/autobeat/references/orchestration.md
+++ b/skills/autobeat/references/orchestration.md
@@ -150,7 +150,7 @@ For orchestrations that need custom eval criteria, custom prompt structure, or m
 
 ### When to Use
 
-| | CreateOrchestrator | InitCustomOrchestrator + CreateLoop |
+| | `CreateOrchestrator` | `InitCustomOrchestrator` + `CreateLoop` |
 |---|---|---|
 | Prompt | Auto-generated role instructions | You provide full systemPrompt |
 | Eval | Built-in state file polling | Your custom evalPrompt + evalType |


### PR DESCRIPTION
## Summary

- Update all 6 skill reference files (`skills/autobeat/`) to document v1.2.0–v1.4.0 features
- Add system prompts, model selection, translation proxy, Ollama runtime, custom orchestrators, pipeline management tools, and the eval redesign (feedforward/judge/schema)
- Fix accuracy issues: remove fabricated char limits not in Zod schemas, correct defaults (timeout, missedRunPolicy)

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run check` (biome lint) — pass
- [x] `npm run build` — pass
- [x] All parameters verified against Zod schemas in `src/adapters/mcp-adapter.ts`
- [x] Cross-reference integrity verified (tool names, links, evalType hierarchy consistent across files)
- [x] 45/45 plan requirements confirmed by Evaluator