### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.5.0] - 2026-05-08
+
+### Added
+- **API translation proxy**: HTTP proxy translating Anthropic Messages API to OpenAI Chat Completions; enables Claude on OpenAI-compatible backends. `beat agents config set <agent> proxy openai` (#152)
+- **Ollama runtime integration**: Wraps agent spawns with `ollama launch` for local LLM execution. `beat agents config set <agent> runtime ollama`. Translate → proxy rename (#157)
+- **Interactive orchestrator mode**: `beat orchestrate --interactive/-i "<goal>"` — foreground TTY with SIGINT coordination and PID tracking (#159)
+- **Dashboard layout overhaul**: Responsive 3-tile top row, full-width entity browser, full entity names, degraded modes (#153)
+- **Pipeline management MCP tools**: `PipelineStatus`, `ListPipelines`, `CancelPipeline` (#153)
+- **ConfigureAgent extensions**: `proxy` and `runtime` parameters (#152, #157)
+
+### Changed
+- **Model schema relaxed**: Model names accept `/`, `:`, `@` separators for Ollama-style identifiers (#157)
+
+### Documentation
+- Skills/docs alignment with v1.2.0–v1.4.0 features (#158)
+
+### Database
+- **Migration v24**: `pipelines` table — first-class pipeline entities with steps, status, FKs, indexes
+- **Migration v25**: `orchestrations.mode` (CHECK: standard/interactive) and `orchestrations.pid` columns
+
+---
+
 ## [1.4.0] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ npm run test:core && npm run test:handlers && npm run test:services && \
   npm run test:implementations && npm run test:cli && \
   npm run test:dashboard && npm run test:scheduling && \
   npm run test:checkpoints && npm run test:error-scenarios && \
-  npm run test:orchestration && npm run test:integration
+  npm run test:orchestration && npm run test:translation && \
+  npm run test:integration
 ```
 
 CI runs the full `npm run test:all` in the release workflow — do not attempt it from Claude Code.
@@ -246,6 +247,8 @@ Safety nets that exist in the codebase but are not part of the manual release st
 - `workers.last_heartbeat`, loops eval columns: `eval_type`, `judge_agent`, `judge_prompt`, `eval_prompt` (migration v21)
 - CHECK constraints on `eval_type` and `judge_agent` in loops table (migration v22)
 - `tasks.system_prompt` column: nullable TEXT for per-task system prompt injection (migration v23)
+- `pipelines` table: first-class pipeline entities with steps, status, FKs, indexes (migration v24)
+- `orchestrations.mode` and `orchestrations.pid` columns for interactive orchestrator mode (migration v25)
 
 ### Dependencies
 
@@ -256,7 +259,7 @@ When adding task dependencies:
 
 ### MCP Tools
 
-All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `RetryTask`, `ResumeTask`, `CreatePipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`, `ListSchedules`, `ScheduleStatus`, `PauseSchedule`, `ResumeSchedule`, `CancelSchedule`, `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`, `InitCustomOrchestrator`, `ListAgents`, `ConfigureAgent`
+All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `RetryTask`, `ResumeTask`, `CreatePipeline`, `PipelineStatus`, `ListPipelines`, `CancelPipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`, `ListSchedules`, `ScheduleStatus`, `PauseSchedule`, `ResumeSchedule`, `CancelSchedule`, `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`, `InitCustomOrchestrator`, `ListAgents`, `ConfigureAgent`
 
 `DelegateTask` accepts an optional `metadata.orchestratorId` field for orchestrator attribution. Long-running MCP servers should pass this so sub-tasks are attributed to the calling orchestration even when the process ID changes across restarts.
 
@@ -301,6 +304,12 @@ Quick reference for common operations:
 | Keyboard handlers | `src/cli/dashboard/keyboard/` |
 | Orchestrator prompt builder | `src/services/orchestrator-prompt.ts` |
 | Orchestrator scaffolding | `src/core/orchestrator-scaffold.ts` |
+| Translation proxy | `src/translation/proxy/` |
+| Translation codecs | `src/translation/codecs/` |
+| Translation middleware | `src/translation/middleware/` |
+| Pipeline repository | `src/implementations/pipeline-repository.ts` |
+| Pipeline handler | `src/services/handlers/pipeline-handler.ts` |
+| Interactive orchestrator | `src/cli/commands/orchestrate-interactive.ts` |
 
 ## Documentation Structure
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,25 @@
 
 This document lists all features that are **currently implemented and working** in Autobeat.
 
-Last Updated: April 2026 (2026-04-22)
+Last Updated: May 2026 (2026-05-08)
+
+## ✅ Cross-Platform Agents & Interactive Orchestration (v1.5.0)
+
+- **API translation proxy**: HTTP proxy translating Anthropic Messages API to OpenAI Chat Completions; enables Claude on any OpenAI-compatible backend (OpenRouter, Together, vLLM, etc.)
+- **Proxy configuration**: `beat agents config set <agent> proxy openai` CLI and `ConfigureAgent` MCP tool with `proxy` parameter
+- **Translation architecture**: Codecs (bidirectional format translation), middleware (streaming, errors, headers), IR (format-agnostic message passing)
+- **Ollama runtime integration**: Wraps agent spawns with `ollama launch` for local LLM execution; `beat agents config set <agent> runtime ollama`
+- **Proxy/runtime mutual exclusivity**: Setting proxy clears runtime and vice versa
+- **Model schema relaxed**: Model names accept `/`, `:`, `@` separators for Ollama-style identifiers (e.g., `llama3:8b`)
+- **Interactive orchestrator mode**: `beat orchestrate --interactive/-i "<goal>"` — foreground TTY with SIGINT coordination and PID tracking
+- **Dashboard layout overhaul**: Responsive 3-tile top row (Tasks, Workers, Orchestrations), full-width entity browser, full entity names, degraded modes for narrow terminals
+- **Pipeline management MCP tools**: `PipelineStatus`, `ListPipelines`, `CancelPipeline` for first-class pipeline entities
+- **Skills/docs alignment**: Skill content updated to cover v1.2.0–v1.4.0 features
+
+### Database (v1.5.0)
+
+- **Migration v24**: `pipelines` table — first-class pipeline entities with steps, status, foreign keys, and indexes
+- **Migration v25**: `orchestrations.mode` (CHECK: standard/interactive) and `orchestrations.pid` columns
 
 ## ✅ System Prompts & Custom Orchestrators (v1.4.0)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,17 @@
 # Autobeat Development Roadmap
 
-## Current Status: v1.4.0 RELEASED (2026-04-22)
+## Current Status: v1.5.0 RELEASED (2026-05-08)
 
-System prompt support across all three agent adapters (Claude, Codex, Gemini) and custom orchestrator scaffolding (`beat orchestrate init` + `InitCustomOrchestrator` MCP tool). Includes database migration v23.
+API translation proxy enables Claude on OpenAI-compatible backends. Ollama runtime wraps agent spawns for local LLM execution. Interactive orchestrator mode brings foreground TTY orchestration. Dashboard layout overhauled with 3-tile responsive design. Skills/docs aligned with v1.2.0–v1.4.0 features. Database migrations v24-v25.
 
 ---
 
 ## Released Versions
+
+### v1.5.0 - Cross-Platform Agents & Interactive Orchestration ✅
+**Status**: **RELEASED** (2026-05-08)
+
+API translation proxy (Anthropic→OpenAI Chat Completions), Ollama runtime integration, interactive orchestrator mode (`--interactive/-i`), dashboard layout overhaul (3-tile top row, entity browser), pipeline management MCP tools, skills/docs alignment. Database migrations v24-v25.
 
 ### v1.4.0 - System Prompts & Custom Orchestrators ✅
 **Status**: **RELEASED** (2026-04-22)

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## Latest Release
 
-- **[v1.4.0](./RELEASE_NOTES_v1.4.0.md)** — System Prompts & Custom Orchestrators (2026-04-22)
+- **[v1.5.0](./RELEASE_NOTES_v1.5.0.md)** — Cross-Platform Agents & Interactive Orchestration (2026-05-08)
 
 ## Previous Releases
+- [v1.4.0](./RELEASE_NOTES_v1.4.0.md) — System Prompts & Custom Orchestrators (2026-04-22)
 - [v1.3.1](./RELEASE_NOTES_v1.3.1.md) — Preflight Script Hardening (2026-04-16)
 - [v1.3.0](./RELEASE_NOTES_v1.3.0.md) — Dashboard Redesign, Eval Redesign & Reliability (2026-04-16)
 - [v1.2.0](./RELEASE_NOTES_v1.2.0.md) — Terminal Dashboard & Agent Config Passthrough (2026-04-10)

--- a/docs/releases/RELEASE_NOTES_v1.5.0.md
+++ b/docs/releases/RELEASE_NOTES_v1.5.0.md
@@ -1,0 +1,156 @@
+# Autobeat v1.5.0 — Cross-Platform Agents & Interactive Orchestration
+
+Three new features, a dashboard overhaul, and docs alignment. API translation proxy enables Claude on OpenAI-compatible backends. Ollama runtime wraps agent spawns for local LLM execution. Interactive orchestrator mode brings foreground TTY orchestration with SIGINT coordination.
+
+---
+
+## Highlights
+
+- **API translation proxy**: HTTP proxy translating Anthropic Messages API to OpenAI Chat Completions — run Claude-targeting agents on any OpenAI-compatible backend
+- **Ollama runtime integration**: Wrap agent spawns with `ollama launch` for local LLM execution; mutually exclusive with proxy
+- **Interactive orchestrator mode**: `beat orchestrate --interactive/-i` — foreground TTY with SIGINT coordination and PID tracking
+- **Dashboard layout overhaul**: Responsive 3-tile top row, full-width entity browser, full entity names, degraded modes
+- **Skills/docs alignment**: Skill content updated to cover v1.2.0–v1.4.0 features
+
+---
+
+## API Translation Proxy
+
+HTTP proxy that translates Anthropic Messages API requests to OpenAI Chat Completions format. Enables Claude-targeting agents to run on any OpenAI-compatible backend (OpenRouter, Together, local vLLM, etc.).
+
+### Architecture
+
+- **Codecs** (`src/translation/codecs/`): Bidirectional request/response translation between Anthropic and OpenAI formats
+- **Middleware** (`src/translation/middleware/`): Streaming adapter, error mapping, header normalization
+- **Proxy** (`src/translation/proxy/`): HTTP server with codec + middleware pipeline
+- **IR** (`src/translation/ir.ts`): Intermediate representation for format-agnostic message passing
+
+### Configuration
+
+```bash
+# Enable proxy for an agent
+beat agents config set claude proxy openai
+
+# Remove proxy
+beat agents config set claude proxy none
+```
+
+### MCP
+
+```json
+{
+  "tool": "ConfigureAgent",
+  "arguments": {
+    "agent": "claude",
+    "proxy": "openai"
+  }
+}
+```
+
+---
+
+## Ollama Runtime Integration
+
+Wraps agent spawns with `ollama launch` for local LLM execution. The runtime manages the Ollama process lifecycle alongside the agent.
+
+### Configuration
+
+```bash
+# Enable Ollama runtime for an agent
+beat agents config set gemini runtime ollama
+
+# Remove runtime
+beat agents config set gemini runtime none
+```
+
+Proxy and runtime are mutually exclusive — setting one clears the other.
+
+### Model Names
+
+Model schema relaxed to accept `/`, `:`, `@` separators for Ollama-style identifiers (e.g., `llama3:8b`, `mistral@latest`).
+
+---
+
+## Interactive Orchestrator Mode
+
+Foreground TTY orchestration with SIGINT coordination and PID tracking. The orchestrator runs in the current terminal session rather than as a background process.
+
+### CLI
+
+```bash
+# Start interactive orchestration
+beat orchestrate --interactive "Build auth system"
+beat orchestrate -i "Build auth system"
+```
+
+### Behavior
+
+- Runs in foreground — terminal attached to orchestrator output
+- SIGINT (Ctrl+C) gracefully stops the orchestration and all child tasks
+- PID tracked in `orchestrations.pid` column for process management
+- Mode stored in `orchestrations.mode` column (`standard` or `interactive`)
+
+---
+
+## Dashboard Layout Overhaul
+
+Responsive layout with 3-tile top row, full-width entity browser, and full entity names.
+
+- **3-tile top row**: Tasks, Workers, and Orchestrations summary tiles
+- **Full-width entity browser**: Expanded view with full entity names (no truncation)
+- **Degraded modes**: Graceful fallback for narrow terminals
+- **Pipeline management MCP tools**: `PipelineStatus`, `ListPipelines`, `CancelPipeline`
+
+---
+
+## Database
+
+- **Migration v24**: `pipelines` table — first-class pipeline entities with steps, status, foreign keys, and indexes
+- **Migration v25**: `orchestrations.mode` (CHECK: standard/interactive) and `orchestrations.pid` columns for interactive orchestrator mode
+
+---
+
+## What's Changed Since v1.4.0
+
+- API translation proxy — Anthropic Messages API to OpenAI Chat Completions (#152)
+- Dashboard layout overhaul — 3-tile responsive, full-width entity browser (#153)
+- Ollama runtime integration + translate → proxy rename (#157)
+- Skills/docs alignment with v1.2.0–v1.4.0 features (#158)
+- Interactive orchestrator mode — `--interactive/-i` flag (#159)
+
+---
+
+## Migration Notes
+
+- **Migrations v24 and v25** are auto-applied on first startup — no user action required
+- The `translate` command has been renamed to `proxy` in agent configuration — existing configs will continue to work but the new name is preferred
+- No breaking changes to CLI, MCP tools, or configuration
+
+---
+
+## Installation
+
+```bash
+npm install -g autobeat@1.5.0
+```
+
+Or via npx in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "autobeat": {
+      "command": "npx",
+      "args": ["-y", "autobeat@1.5.0", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- [npm](https://www.npmjs.com/package/autobeat)
+- [Documentation](https://github.com/dean0x/autobeat)
+- [Issues](https://github.com/dean0x/autobeat/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autobeat",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autobeat",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobeat",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"


### PR DESCRIPTION
## Summary
Release v1.5.0 — Cross-Platform Agents & Interactive Orchestration

- API translation proxy — Anthropic Messages API to OpenAI Chat Completions (#152)
- Dashboard layout overhaul — 3-tile responsive, full-width entity browser (#153)
- Ollama runtime + translate→proxy rename (#157)
- Skills/docs alignment (#158)
- Interactive orchestrator mode --interactive/-i (#159)

8 files updated (version bump, release notes, changelog, features, roadmap, CLAUDE.md)
2 new migrations (v24, v25); 3 new MCP tools (PipelineStatus, ListPipelines, CancelPipeline)

### Snyk (best-effort)
2 medium findings — both pre-existing:
- HTTP instead of HTTPS in translation-proxy.ts (by design: localhost proxy)
- Path traversal in orchestrate.ts (pre-existing code path, only imports changed)

## Test plan
- [x] typecheck + lint + build pass
- [x] All 14 grouped test suites pass (0 failures)
- [x] Release notes index matches files on disk (patch releases excluded by convention)
- [ ] CI passes