### PR TITLE
docs: align README and docs with v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add to your project's `.mcp.json`:
 }
 ```
 
-Restart your MCP client to connect. Autobeat works with Claude Code, Codex, Gemini, and any MCP-compatible agent.
+Restart your MCP client to connect. Autobeat works with Claude Code, Codex, Gemini, Ollama, and any MCP-compatible agent.
 
 ### Prerequisites
 
@@ -86,12 +86,24 @@ beat orchestrate "Set up a GraphQL API with subscriptions, pagination, and integ
 # Foreground -blocks and shows progress, Ctrl+C cancels
 beat orchestrate "Migrate the database schema" --foreground
 
+# Interactive -foreground TTY session with live output
+beat orchestrate -i "Build the auth system"
+
 # With options
 beat orchestrate "Redesign the dashboard" \
   --agent claude \
   --max-workers 5 \
   --max-iterations 50 \
-  --max-depth 3
+  --max-depth 3 \
+  --system-prompt "Use functional patterns, no classes"
+```
+
+### Custom Orchestrators
+
+Scaffold a custom orchestrator with state file, exit condition, and system prompt:
+
+```bash
+beat orchestrate init "Migrate payments to microservice"
 ```
 
 ### Monitor and Control
@@ -208,7 +220,7 @@ beat schedule cancel <id>
 
 ## Agent Configuration
 
-Three agents are supported: **Claude**, **Codex**, and **Gemini**. Each agent can be configured with an API key, base URL, and default model.
+Four agent runtimes are supported: **Claude**, **Codex**, **Gemini**, and **Ollama** (local LLMs). Each agent can be configured with an API key, base URL, default model, proxy, and runtime.
 
 ```bash
 beat agents list                    # Show available agents
@@ -267,6 +279,27 @@ Or via environment variables (takes precedence over config):
 
 **Note**: Claude's login-based auth does not work with a custom `baseUrl` — you must also set an `apiKey`. Autobeat warns if `baseUrl` is set without one.
 
+### API Translation Proxy
+
+Run Claude-targeting agents on any OpenAI-compatible backend (OpenRouter, Together, vLLM, etc.). The proxy translates Anthropic Messages API to OpenAI Chat Completions format transparently.
+
+```bash
+beat agents config set claude proxy openai
+beat agents config set claude baseUrl "https://openrouter.ai/api/v1"
+beat agents config set claude apiKey "sk-or-your-key"
+```
+
+### Ollama Runtime
+
+Wrap agent spawns with `ollama launch` for local LLM execution. The runtime manages the Ollama process lifecycle alongside the agent.
+
+```bash
+beat agents config set gemini runtime ollama
+beat agents config set gemini model "llama3:8b"
+```
+
+Proxy and runtime are mutually exclusive — setting one clears the other.
+
 ### Using Local LLMs
 
 Most local inference servers (Ollama, llama.cpp, vLLM, LM Studio) expose an OpenAI-compatible API. Point the codex agent at your local server:
@@ -276,7 +309,7 @@ beat agents config set codex baseUrl "http://localhost:11434/v1"
 beat agents config set codex apiKey "any-string"
 beat agents config set codex model "llama3"
 
-beat run --agent codex --prompt "Refactor the utils module" --dir ./project
+beat run --agent codex "Refactor the utils module"
 ```
 
 ### Manage Config
@@ -293,10 +326,11 @@ Config is stored in `~/.autobeat/config.json`.
 
 | Tool | What It Does |
 |------|-------------|
-| **Orchestrate** | Autonomous goal execution with worker management |
-| **OrchestrationStatus** | Orchestration plan, steps, and iteration state |
-| **ListOrchestrations** | List orchestrations with status filter |
-| **CancelOrchestration** | Cancel an orchestration and its workers |
+| **CreateOrchestrator** | Autonomous goal execution with worker management |
+| **OrchestratorStatus** | Orchestration plan, steps, and iteration state |
+| **ListOrchestrators** | List orchestrations with status filter |
+| **CancelOrchestrator** | Cancel an orchestration and its workers |
+| **InitCustomOrchestrator** | Scaffold a custom orchestrator (state file, exit condition, system prompt) |
 | **DelegateTask** | Spawn a background coding agent |
 | **TaskStatus** | Real-time task status |
 | **TaskLogs** | Execution logs |
@@ -310,18 +344,24 @@ Config is stored in `~/.autobeat/config.json`.
 | **PauseLoop** / **ResumeLoop** | Pause and resume loops |
 | **ScheduleLoop** | Schedule a recurring loop |
 | **CreatePipeline** | Sequential multi-step pipeline |
+| **PipelineStatus** | Pipeline details and step progress |
+| **ListPipelines** | List pipelines with status filter |
+| **CancelPipeline** | Cancel a pipeline and its in-flight tasks |
 | **ScheduleTask** | Cron or one-time task schedule |
 | **SchedulePipeline** | Scheduled pipeline |
 | **ListSchedules** / **ScheduleStatus** | Schedule management |
 | **PauseSchedule** / **ResumeSchedule** | Schedule lifecycle |
 | **CancelSchedule** | Cancel schedule and optionally in-flight tasks |
 | **ListAgents** | List agents with auth status and config |
-| **ConfigureAgent** | Check, set, or reset agent config (apiKey, baseUrl, model) |
+| **ConfigureAgent** | Check, set, or reset agent config (apiKey, baseUrl, model, proxy, runtime) |
 
 ## All CLI Commands
 
 ```
-beat orchestrate <goal> [options]     Autonomous orchestration
+beat orchestrate <goal> [options]     Autonomous orchestration (detached)
+beat orchestrate <goal> -f            Foreground orchestration
+beat orchestrate -i <goal>            Interactive TTY session
+beat orchestrate init <goal>          Scaffold custom orchestrator
 beat orchestrate status <id>          Orchestration details
 beat orchestrate list                 List orchestrations
 beat orchestrate cancel <id>          Cancel orchestration
@@ -338,6 +378,8 @@ beat loop <prompt> --until <cmd>      Retry loop
 beat loop <prompt> --eval <cmd>       Optimize loop
 beat loop list                        List loops
 beat loop status <id>                 Loop details
+beat loop pause <id>                  Pause loop
+beat loop resume <id>                 Resume loop
 beat loop cancel <id>                 Cancel loop
 
 beat schedule create <prompt>         Create schedule
@@ -353,6 +395,7 @@ beat agents config show [agent]       Show agent config
 beat agents config set <agent> <key> <value>  Set agent config
 beat agents config reset <agent>      Clear agent config
 
+beat dashboard                        Interactive terminal dashboard
 beat init                             Interactive setup
 beat config show|set|reset|path       Configuration
 beat help                             Help
@@ -382,7 +425,7 @@ Event-driven system with autoscaling workers and SQLite persistence. Components 
 
 **Task Lifecycle**: `Queued` → `Running` → `Completed` / `Failed` / `Cancelled`
 
-Three agents supported: Claude, Codex, Gemini. Per-task agent selection. Crash recovery restores all in-flight work on restart.
+Four agent runtimes: Claude, Codex, Gemini, and Ollama (local LLMs). API translation proxy enables cross-platform agent execution. Per-task agent selection. Crash recovery restores all in-flight work on restart.
 
 See **[Architecture Documentation](./docs/architecture/)** for details.
 
@@ -392,7 +435,7 @@ See **[Architecture Documentation](./docs/architecture/)** for details.
 npm run dev          # Development mode with auto-reload
 npm run build        # Build TypeScript
 npm run test:core    # Core tests (~3s)
-npm run test:all     # Full suite (1,500+ tests)
+npm run test:all     # Full suite (3,600+ tests)
 ```
 
 See **[FEATURES.md](./docs/FEATURES.md)** for the complete feature list and **[ROADMAP.md](./docs/ROADMAP.md)** for what's next.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -148,10 +148,13 @@ Last Updated: May 2026 (2026-05-08)
 - **OrchestratorStatus**: Get orchestration details including plan steps and state
 - **ListOrchestrators**: List orchestrations with status filter and pagination
 - **CancelOrchestrator**: Cancel an active orchestration with optional reason
+- **InitCustomOrchestrator**: Scaffold a custom orchestrator with state file, exit condition, and system prompt (v1.4.0)
 
 ### CLI Commands
 - `beat orchestrate "<goal>"`: Create and run an orchestration (detached by default)
 - `beat orchestrate "<goal>" --foreground`: Block and wait for completion (Ctrl+C to cancel)
+- `beat orchestrate -i "<goal>"`: Interactive foreground TTY session (v1.5.0)
+- `beat orchestrate init "<goal>"`: Scaffold custom orchestrator (state file, exit condition, system prompt) (v1.4.0)
 - `beat orchestrate status <id>`: Check orchestration status and plan progress
 - `beat orchestrate list [--status <status>]`: List orchestrations with optional status filter
 - `beat orchestrate cancel <id> [reason]`: Cancel an active orchestration
@@ -297,14 +300,42 @@ Last Updated: May 2026 (2026-05-08)
 - `beat schedule resume <id>`: Resume a paused schedule
 - `beat schedule cancel <id> [reason]`: Cancel a schedule with optional reason
 
+### Orchestrate Commands (v1.0.0+)
+- `beat orchestrate "<goal>"`: Create and run an orchestration (detached)
+- `beat orchestrate "<goal>" --foreground`: Block and wait for completion
+- `beat orchestrate -i "<goal>"`: Interactive foreground TTY session (v1.5.0)
+- `beat orchestrate init "<goal>"`: Scaffold custom orchestrator (v1.4.0)
+- `beat orchestrate status <id>`: Orchestration details
+- `beat orchestrate list [--status <s>]`: List orchestrations
+- `beat orchestrate cancel <id> [reason]`: Cancel orchestration
+
 ### Pipeline Commands (v0.4.0+)
-- `beat pipeline <prompt> [--delay Nm <prompt>]...`: Create chained one-time schedules with delays
+- `beat pipeline <prompt> [<prompt>]...`: Create chained one-time schedules
+
+### Loop Commands (v0.7.0+)
+- `beat loop <prompt> --until <cmd>`: Retry loop
+- `beat loop <prompt> --eval <cmd> --minimize|--maximize`: Optimize loop
+- `beat loop list [--status <s>]`: List loops
+- `beat loop status <id> [--history]`: Loop details
+- `beat loop pause <id>`: Pause loop (v0.8.0)
+- `beat loop resume <id>`: Resume loop (v0.8.0)
+- `beat loop cancel <id> [--cancel-tasks] [reason]`: Cancel loop
 
 ### Task Resumption Commands (v0.4.0+)
 - `beat resume <task-id>`: Resume a failed/completed task from its checkpoint
 - `beat resume <task-id> --context "..."`: Resume with additional instructions
 
-### Configuration Examples
+### Agent Commands (v0.5.0+)
+- `beat agents list`: List available agents with auth status
+- `beat agents check`: Auth status for all agents
+- `beat agents config show [agent]`: Show agent config
+- `beat agents config set <agent> <key> <value>`: Set agent config (apiKey, baseUrl, model, proxy, runtime)
+- `beat agents config reset <agent>`: Clear stored config
+
+### Dashboard (v1.2.0+)
+- `beat dashboard` / `beat dash`: Interactive terminal UI with metrics and workspace views
+
+### Configuration
 - **NPM Package**: Global installation support
 - **Local Development**: Source code execution
 - **Claude Desktop**: MCP server configuration

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,6 +28,11 @@ Two-view dashboard (Metrics + Workspace), live agent output streaming in workspa
 
 Interactive terminal dashboard (`beat dashboard`) with 4 panels, keyboard navigation, and detail views. Per-agent baseUrl/model configuration for custom API endpoints and model selection across Claude, Codex, and Gemini.
 
+### v1.1.0 - Agent Eval Mode & Skill System ✅
+**Status**: **RELEASED** (2026-04-01)
+
+Agent eval mode for loop exit conditions (AI judges pass/fail instead of shell commands). Agent orchestration skill with structured reference files. Skill installer via `beat init --install-skills`. MCP instructions and ConfigureAgent/ListAgents tools.
+
 ### v0.8.2 - Package Rename ✅
 **Status**: **RELEASED** (2026-03-26)
 
@@ -70,11 +75,6 @@ Autoscaling workers, event-driven architecture, SQLite persistence.
 
 ---
 
-### v1.1.0 - Agent Eval Mode & Skill System ✅
-**Status**: **RELEASED** (2026-04-01)
-
-Agent eval mode for loop exit conditions (AI judges pass/fail instead of shell commands). Agent orchestration skill with structured reference files. Skill installer via `beat init --install-skills`. MCP instructions and ConfigureAgent/ListAgents tools.
-
 ## v1.0.0 - Autonomous Orchestration
 
 **Status**: **RELEASED** (2026-03-28)
@@ -100,7 +100,7 @@ The orchestrator is a loop that runs a lead agent whose system prompt gives it a
 ### Features Delivered
 
 - **CLI**: `beat orchestrate`, `beat orchestrate status`, `beat orchestrate list`, `beat orchestrate cancel`
-- **MCP Tools**: `Orchestrate`, `OrchestrationStatus`, `ListOrchestrations`, `CancelOrchestration`
+- **MCP Tools**: `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`
 - **Detach Mode**: Fire-and-forget background orchestration with log polling
 - **Foreground Mode**: Blocking mode with SIGINT cancellation support
 - **State File**: Persistent JSON state file with plan, steps, iteration history
@@ -167,6 +167,8 @@ Multi-server support, shared state (Redis backend), fault tolerance, task affini
 | **v1.2.0** | ✅ Released | **Terminal Dashboard & Agent Config** |
 | **v1.3.0** | ✅ Released | **Dashboard Redesign, Eval Redesign & Reliability** |
 | **v1.4.0** | ✅ Released | **System Prompts & Custom Orchestrators** |
+| **v1.5.0** | ✅ Released | **Cross-Platform Agents & Interactive Orchestration** |
+
 
 ---
 

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -70,6 +70,24 @@ ${bold('Agent Commands:')}
   ${cyan('agents config show')} <agent>               Show stored config for an agent
   ${cyan('agents config reset')} <agent>              Remove stored config for an agent
 
+${bold('Orchestrate Commands:')}
+  ${cyan('orchestrate')} <goal> [options]       Start orchestration (detached by default)
+    -f, --foreground               Block and wait for completion
+    -i, --interactive              Launch interactive terminal session
+    -w, --working-directory DIR    Working directory for workers
+    -a, --agent AGENT              AI agent to use (claude, codex, gemini)
+    -m, --model MODEL              Model override (e.g. claude-opus-4-5)
+    --max-depth N                  Max delegation depth (1-10, default: 3)
+    --max-workers N                Max concurrent workers (1-20, default: 5)
+    --max-iterations N             Max orchestrator iterations (1-200, default: 50)
+    --system-prompt TEXT           Custom system prompt
+
+  ${cyan('orchestrate init')} <goal> [options]  Initialize custom orchestrator scaffolding
+    --template standard|interactive  Template type (default: standard)
+  ${cyan('orchestrate status')} <id>            Show orchestration details
+  ${cyan('orchestrate list')} [--status <s>]    List orchestrations
+  ${cyan('orchestrate cancel')} <id> [reason]   Cancel orchestration
+
 ${bold('Pipeline Commands:')}
   ${cyan('pipeline')} <prompt> [<prompt>]...   Create chained one-time schedules
     Example: pipeline "set up db" "run migrations" "seed data"
@@ -116,6 +134,12 @@ ${bold('Examples:')}
   beat schedule create "deploy" --at "2025-03-01T09:00:00Z"
   beat schedule list --status active
   beat schedule pause <id>
+
+  # Orchestration (multi-agent coordination)
+  beat orchestrate "refactor auth module"               # Detached
+  beat orchestrate "build feature X" --foreground       # Blocking
+  beat orchestrate -i "design API"                      # Interactive session
+  beat orchestrate init "migrate to v2"                 # Scaffold custom orchestrator
 
   # Pipeline (sequential chained tasks)
   beat pipeline "setup db" "run migrations" "seed data"

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -29,6 +29,8 @@ ${bold('Task Commands:')}
     -p, --priority P0|P1|P2    Task priority (P0=critical, P1=high, P2=normal)
     -w, --working-directory D  Working directory for task execution
     -a, --agent AGENT          AI agent to use (claude, codex, gemini)
+    -m, --model MODEL          Model override (e.g. claude-sonnet-4-5-20250514)
+    --system-prompt TEXT        System prompt to inject into the agent
     --deps TASK_IDS            Comma-separated task IDs this task depends on (alias: --depends-on)
     -c, --continue TASK_ID     Continue from a dependency's checkpoint (alias: --continue-from)
     -t, --timeout MS           Task timeout in milliseconds
@@ -66,7 +68,7 @@ ${bold('Schedule Commands:')}
 ${bold('Agent Commands:')}
   ${cyan('agents list')}                List available AI agents
   ${cyan('agents check')}               Check agent auth status and readiness
-  ${cyan('agents config set')} <agent> apiKey <key>   Store an API key for an agent
+  ${cyan('agents config set')} <agent> <key> <value>  Set agent config (apiKey, baseUrl, model, proxy, runtime)
   ${cyan('agents config show')} <agent>               Show stored config for an agent
   ${cyan('agents config reset')} <agent>              Remove stored config for an agent
 
@@ -106,6 +108,8 @@ ${bold('Loop Commands:')}
 
   ${cyan('loop list')} [--status running|completed|failed|cancelled]
   ${cyan('loop status')} <loop-id> [--history] [--history-limit N]
+  ${cyan('loop pause')} <loop-id>                Pause an active loop
+  ${cyan('loop resume')} <loop-id>               Resume a paused loop
   ${cyan('loop cancel')} <loop-id> [--cancel-tasks] [reason]
 
 ${bold('Configuration:')}


### PR DESCRIPTION
## Summary
- Add Orchestrate Commands section to `--help` (was entirely missing)
- Update README with interactive mode, translation proxy, Ollama runtime, custom orchestrators
- Fix MCP tool names, add missing tools to tables
- Add `--model`, `--system-prompt`, `loop pause/resume` to CLI help
- Fix orphaned v1.1.0 entry in ROADMAP, add v1.5.0 to version timeline

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:cli` — 299 tests pass
- [x] `node dist/cli.js orchestrate --help` shows orchestrate section