### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [1.5.1] - 2026-05-09
+
+### Documentation
+- **CLI help text alignment**: Updated `beat --help` output to document orchestrate commands, `--model`/`--system-prompt` flags, loop pause/resume, and expanded agent config options (#161)
+
+---
+
 ## [1.5.0] - 2026-05-08
 
 ### Added

--- a/docs/releases/RELEASE_NOTES.md
+++ b/docs/releases/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## Latest Release
 
-- **[v1.5.0](./RELEASE_NOTES_v1.5.0.md)** — Cross-Platform Agents & Interactive Orchestration (2026-05-08)
+- **[v1.5.1](./RELEASE_NOTES_v1.5.1.md)** — Docs & Help Text Alignment (2026-05-09)
 
 ## Previous Releases
+- [v1.5.0](./RELEASE_NOTES_v1.5.0.md) — Cross-Platform Agents & Interactive Orchestration (2026-05-08)
 - [v1.4.0](./RELEASE_NOTES_v1.4.0.md) — System Prompts & Custom Orchestrators (2026-04-22)
 - [v1.3.1](./RELEASE_NOTES_v1.3.1.md) — Preflight Script Hardening (2026-04-16)
 - [v1.3.0](./RELEASE_NOTES_v1.3.0.md) — Dashboard Redesign, Eval Redesign & Reliability (2026-04-16)

--- a/docs/releases/RELEASE_NOTES_v1.5.1.md
+++ b/docs/releases/RELEASE_NOTES_v1.5.1.md
@@ -1,0 +1,51 @@
+# Autobeat v1.5.1 — Docs & Help Text Alignment
+
+Patch release aligning CLI help text and documentation with v1.5.0 features.
+
+---
+
+## Summary
+
+The v1.5.0 release introduced interactive orchestration, API translation proxy, Ollama runtime, and expanded agent configuration — but the CLI help output and top-level docs hadn't been updated to reflect them. This patch ships the aligned help text so `beat --help` documents all current capabilities.
+
+---
+
+## What's Changed Since v1.5.0
+
+- Aligned CLI help text with v1.5.0 features: orchestrate commands, `--model`/`--system-prompt` flags, loop pause/resume, expanded agent config options (#161)
+- Updated README and docs to match v1.5.0 feature set (#161)
+
+---
+
+## Migration Notes
+
+No migration required. Documentation-only patch — no changes to runtime behavior, database, or APIs.
+
+---
+
+## Installation
+
+```bash
+npm install -g autobeat@1.5.1
+```
+
+Or via npx in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "autobeat": {
+      "command": "npx",
+      "args": ["-y", "autobeat@1.5.1", "mcp", "start"]
+    }
+  }
+}
+```
+
+---
+
+## Links
+
+- [npm](https://www.npmjs.com/package/autobeat)
+- [Documentation](https://github.com/dean0x/autobeat)
+- [Issues](https://github.com/dean0x/autobeat/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autobeat",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autobeat",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autobeat",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/index.js",
   "bin": {
     "beat": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- Patch release shipping aligned CLI help text and docs to npm users
- Only change since v1.5.0: PR #161 (README, FEATURES, ROADMAP, help.ts updates)
- No functional code changes — documentation only

## Files
- `package.json` / `package-lock.json` — version bump to 1.5.1
- `CHANGELOG.md` — new v1.5.1 entry
- `docs/releases/RELEASE_NOTES_v1.5.1.md` — new release notes
- `docs/releases/RELEASE_NOTES.md` — index updated

## Validation
- typecheck + lint + build: clean
- 13/14 grouped test suites: all pass
- `test:services` (4 git auto-capture tests): pre-existing branch-dependent failures, pass on main
- Snyk: 2 medium pre-existing findings (unchanged code), no regressions

## Test plan
- [ ] CI passes on this branch
- [ ] Squash merge, trigger release workflow
- [ ] `npm view autobeat version` returns 1.5.1
- [ ] `gh release view v1.5.1` exists