### PR TITLE
fix: preserve RETRY iteration progress via progress status

### DIFF
--- a/src/cli/dashboard/format.ts
+++ b/src/cli/dashboard/format.ts
@@ -61,6 +61,7 @@ export function statusColor(status: string): string {
   switch (status) {
     case 'running':
     case 'planning':
+    case 'progress':
       return 'cyan';
     case 'active':
     case 'completed':

--- a/src/cli/dashboard/format.ts
+++ b/src/cli/dashboard/format.ts
@@ -91,7 +91,7 @@ const STATUS_ICONS: Record<string, string> = {
   paused: '⏸',
   blocked: '⊖', // gray — blocked by dependency
   expired: '○', // gray — schedule expired
-  progress: '◉', // RETRY: work committed, exit condition not yet met
+  progress: '◉', // work committed, exit condition not yet met
 };
 
 /**

--- a/src/cli/dashboard/format.ts
+++ b/src/cli/dashboard/format.ts
@@ -91,6 +91,7 @@ const STATUS_ICONS: Record<string, string> = {
   paused: '⏸',
   blocked: '⊖', // gray — blocked by dependency
   expired: '○', // gray — schedule expired
+  progress: '◉', // RETRY: work committed, exit condition not yet met
 };
 
 /**

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -29,6 +29,7 @@ function iterationStatusColor(status: string, isBest: boolean): string | undefin
   if (isBest) return 'green';
   if (status === 'pass' || status === 'keep') return 'green';
   if (status === 'fail' || status === 'crash') return 'red';
+  if (status === 'progress') return 'cyan'; // RETRY: work committed, exit condition not yet met
   return undefined;
 }
 

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -29,7 +29,7 @@ function iterationStatusColor(status: string, isBest: boolean): string | undefin
   if (isBest) return 'green';
   if (status === 'pass' || status === 'keep') return 'green';
   if (status === 'fail' || status === 'crash') return 'red';
-  if (status === 'progress') return 'cyan'; // RETRY: work committed, exit condition not yet met
+  if (status === 'progress') return 'cyan'; // work committed, exit condition not yet met
   return undefined;
 }
 

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -11,7 +11,7 @@
 
 import { Box, Text } from 'ink';
 import React from 'react';
-import type { Loop, LoopIteration } from '../../../core/domain.js';
+import type { IterationStatus, Loop, LoopIteration } from '../../../core/domain.js';
 import { Field, LongField, StatusField } from '../components/field.js';
 import { ScrollableList } from '../components/scrollable-list.js';
 import { StatusBadge } from '../components/status-badge.js';
@@ -25,7 +25,7 @@ interface LoopDetailProps {
 }
 
 /** Map an iteration status to its display color. Best iterations override to green. */
-function iterationStatusColor(status: string, isBest: boolean): string | undefined {
+function iterationStatusColor(status: IterationStatus, isBest: boolean): string | undefined {
   if (isBest) return 'green';
   if (status === 'pass' || status === 'keep') return 'green';
   if (status === 'fail' || status === 'crash') return 'red';

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -123,6 +123,7 @@ export function colorStatus(status: string): string {
     case 'active':
       return pc.green(status);
     case 'running':
+    case 'progress':
       return pc.cyan(status);
     case 'failed':
       return pc.red(status);
@@ -132,8 +133,6 @@ export function colorStatus(status: string): string {
     case 'cancelled':
     case 'paused':
       return pc.yellow(status);
-    case 'progress':
-      return pc.cyan(status);
     default:
       return status;
   }

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -132,6 +132,8 @@ export function colorStatus(status: string): string {
     case 'cancelled':
     case 'paused':
       return pc.yellow(status);
+    case 'progress':
+      return pc.cyan(status);
     default:
       return status;
   }

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -653,7 +653,7 @@ export interface LoopIteration {
   readonly iterationNumber: number;
   readonly taskId?: TaskId; // Optional: NULL after ON DELETE SET NULL when task is cleaned up
   readonly pipelineTaskIds?: readonly TaskId[];
-  readonly status: 'running' | 'pass' | 'fail' | 'keep' | 'discard' | 'crash' | 'cancelled';
+  readonly status: 'running' | 'pass' | 'fail' | 'keep' | 'discard' | 'crash' | 'cancelled' | 'progress';
   readonly score?: number;
   readonly exitCode?: number;
   readonly errorMessage?: string;

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -643,6 +643,17 @@ export interface Loop {
   readonly completedAt?: number;
 }
 
+/** All possible statuses for a single loop iteration lifecycle. */
+export type IterationStatus =
+  | 'running'
+  | 'pass'
+  | 'fail'
+  | 'keep'
+  | 'discard'
+  | 'crash'
+  | 'cancelled'
+  | 'progress';
+
 /**
  * Loop iteration record - tracks individual iteration execution
  * ARCHITECTURE: Immutable record of each iteration attempt and outcome
@@ -653,7 +664,7 @@ export interface LoopIteration {
   readonly iterationNumber: number;
   readonly taskId?: TaskId; // Optional: NULL after ON DELETE SET NULL when task is cleaned up
   readonly pipelineTaskIds?: readonly TaskId[];
-  readonly status: 'running' | 'pass' | 'fail' | 'keep' | 'discard' | 'crash' | 'cancelled' | 'progress';
+  readonly status: IterationStatus;
   readonly score?: number;
   readonly exitCode?: number;
   readonly errorMessage?: string;

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -644,15 +644,7 @@ export interface Loop {
 }
 
 /** All possible statuses for a single loop iteration lifecycle. */
-export type IterationStatus =
-  | 'running'
-  | 'pass'
-  | 'fail'
-  | 'keep'
-  | 'discard'
-  | 'crash'
-  | 'cancelled'
-  | 'progress';
+export type IterationStatus = 'running' | 'pass' | 'fail' | 'keep' | 'discard' | 'crash' | 'cancelled' | 'progress';
 
 /**
  * Loop iteration record - tracks individual iteration execution

--- a/src/implementations/database.ts
+++ b/src/implementations/database.ts
@@ -1000,6 +1000,63 @@ export class Database implements TransactionRunner {
           db.exec(`ALTER TABLE orchestrations ADD COLUMN pid INTEGER DEFAULT NULL`);
         },
       },
+      {
+        version: 26,
+        description:
+          "Add 'progress' to loop_iterations status CHECK constraint for RETRY loop accumulated-work preservation",
+        up: (db) => {
+          // DECISION: SQLite cannot ALTER a CHECK constraint in-place — must recreate the table.
+          // The 'progress' status represents a RETRY iteration that completed successfully but did
+          // not yet satisfy the exit condition; work is committed and preserved for the next iteration.
+          // PF-002: no backward-compat path — clean break is correct for a feature with zero users.
+
+          // 1. Create new table with updated CHECK constraint
+          db.exec(`
+            CREATE TABLE loop_iterations_new (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              loop_id TEXT NOT NULL REFERENCES loops(id) ON DELETE CASCADE,
+              iteration_number INTEGER NOT NULL,
+              task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+              pipeline_task_ids TEXT,
+              status TEXT NOT NULL CHECK(status IN ('running', 'pass', 'fail', 'keep', 'discard', 'crash', 'cancelled', 'progress')),
+              score REAL,
+              exit_code INTEGER,
+              error_message TEXT,
+              started_at INTEGER NOT NULL,
+              completed_at INTEGER,
+              git_branch TEXT,
+              git_diff_summary TEXT,
+              git_commit_sha TEXT,
+              pre_iteration_commit_sha TEXT,
+              eval_feedback TEXT,
+              eval_response TEXT,
+              UNIQUE(loop_id, iteration_number)
+            )
+          `);
+
+          // 2. Copy all existing data
+          db.exec(`
+            INSERT INTO loop_iterations_new SELECT
+              id, loop_id, iteration_number, task_id, pipeline_task_ids,
+              status, score, exit_code, error_message, started_at, completed_at,
+              git_branch, git_diff_summary, git_commit_sha, pre_iteration_commit_sha,
+              eval_feedback, eval_response
+            FROM loop_iterations
+          `);
+
+          // 3. Drop old table and rename new one
+          db.exec(`DROP TABLE loop_iterations`);
+          db.exec(`ALTER TABLE loop_iterations_new RENAME TO loop_iterations`);
+
+          // 4. Recreate all indexes
+          db.exec(`CREATE INDEX IF NOT EXISTS idx_loop_iterations_loop_id ON loop_iterations(loop_id)`);
+          db.exec(`CREATE INDEX IF NOT EXISTS idx_loop_iterations_task_id ON loop_iterations(task_id)`);
+          db.exec(`CREATE INDEX IF NOT EXISTS idx_loop_iterations_status ON loop_iterations(status)`);
+          db.exec(
+            `CREATE INDEX IF NOT EXISTS idx_loop_iterations_loop_iteration ON loop_iterations(loop_id, iteration_number DESC)`,
+          );
+        },
+      },
     ];
   }
 

--- a/src/implementations/loop-repository.ts
+++ b/src/implementations/loop-repository.ts
@@ -76,7 +76,7 @@ const LoopIterationRowSchema = z.object({
   iteration_number: z.number(),
   task_id: z.string().nullable(),
   pipeline_task_ids: z.string().nullable(),
-  status: z.enum(['running', 'pass', 'fail', 'keep', 'discard', 'crash', 'cancelled']),
+  status: z.enum(['running', 'pass', 'fail', 'keep', 'discard', 'crash', 'cancelled', 'progress']),
   score: z.number().nullable(),
   exit_code: z.number().nullable(),
   error_message: z.string().nullable(),

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -259,14 +259,9 @@ export class LoopHandler extends BaseEventHandler {
         // Task FAILED — record failure, check limits
         const newConsecutiveFailures = loop.consecutiveFailures + 1;
 
-        // Git reset: RETRY resets to preIterationCommitSha to preserve prior 'progress' commits.
-        // OPTIMIZE uses the loop's default reset target (bestIterationCommitSha or gitStartCommitSha).
-        await this.resetIterationGitState(
-          loop,
-          iteration,
-          'task failure',
-          loop.strategy === LoopStrategy.RETRY ? iteration.preIterationCommitSha : undefined,
-        );
+        // Git reset: strategy-aware via getResetTargetSha.
+        // RETRY resets to preIterationCommitSha; OPTIMIZE to best/start commit.
+        await this.resetIterationGitState(loop, iteration, 'task failure');
 
         // Atomic: iteration fail + consecutiveFailures in single transaction
         const updatedLoop = updateLoop(loop, { consecutiveFailures: newConsecutiveFailures });
@@ -1440,13 +1435,17 @@ export class LoopHandler extends BaseEventHandler {
   }
 
   /**
-   * Determine the default commit SHA to reset to after a failed/discarded iteration.
-   * Used when no overrideTarget is provided (i.e., OPTIMIZE strategy or iteration discard).
-   * - Optimize: reset to best iteration's gitCommitSha if available, fallback to gitStartCommitSha
-   * - Retry callers pass overrideTarget = preIterationCommitSha directly (bypasses this method)
+   * Determine the commit SHA to reset to after a failed/discarded iteration.
+   * Strategy-aware: each strategy has its own reset semantics.
+   * - RETRY: reset to preIterationCommitSha to preserve accumulated 'progress' commits
+   * - OPTIMIZE: reset to bestIterationCommitSha if available, fallback to gitStartCommitSha
+   * - Default: reset to gitStartCommitSha
    * @returns SHA to reset to, or undefined if no git tracking
    */
-  private getResetTargetSha(loop: Loop): string | undefined {
+  private getResetTargetSha(loop: Loop, iteration: LoopIteration): string | undefined {
+    if (loop.strategy === LoopStrategy.RETRY) {
+      return iteration.preIterationCommitSha ?? loop.gitStartCommitSha;
+    }
     if (loop.strategy === LoopStrategy.OPTIMIZE && loop.bestIterationCommitSha) {
       return loop.bestIterationCommitSha;
     }
@@ -1458,25 +1457,23 @@ export class LoopHandler extends BaseEventHandler {
    * No-op when the iteration has no preIterationCommitSha (non-git loop).
    * Logs warnings on failure but never throws — git reset is best-effort.
    *
-   * DECISION: RETRY task failures (hard crash/killed process) reset to preIterationCommitSha rather
-   * than gitStartCommitSha so that accumulated 'progress' commits from prior iterations are preserved.
-   * The overrideTarget parameter allows callers to specify the exact reset point.
+   * DECISION: Reset target is determined by strategy via getResetTargetSha:
+   * - RETRY: resets to preIterationCommitSha to preserve accumulated 'progress' commits
+   * - OPTIMIZE: resets to bestIterationCommitSha (or gitStartCommitSha as fallback)
    *
    * @param loop - The loop owning the iteration
    * @param iteration - The iteration that failed/was discarded
    * @param context - Human-readable label for log messages (e.g., "task failure", "pipeline step failure")
-   * @param overrideTarget - Optional SHA to reset to instead of the loop's default reset target
    */
   private async resetIterationGitState(
     loop: Loop,
     iteration: LoopIteration,
     context: string,
-    overrideTarget?: string,
   ): Promise<void> {
     if (!iteration.preIterationCommitSha) return;
 
     try {
-      const resetTarget = overrideTarget ?? this.getResetTargetSha(loop);
+      const resetTarget = this.getResetTargetSha(loop, iteration);
       if (!resetTarget) return;
 
       const resetResult = await resetToCommit(loop.workingDirectory, resetTarget);
@@ -1614,14 +1611,9 @@ export class LoopHandler extends BaseEventHandler {
 
     await this.cancelRemainingPipelineTasks(iteration.pipelineTaskIds, taskId, loopId);
 
-    // Git reset: for RETRY, reset to preIterationCommitSha to preserve prior progress commits.
-    // For OPTIMIZE, use the loop's default reset target (best iteration or gitStartCommitSha).
-    await this.resetIterationGitState(
-      loop,
-      iteration,
-      'pipeline step failure',
-      loop.strategy === LoopStrategy.RETRY ? iteration.preIterationCommitSha : undefined,
-    );
+    // Git reset: strategy-aware via getResetTargetSha.
+    // RETRY resets to preIterationCommitSha; OPTIMIZE to best/start commit.
+    await this.resetIterationGitState(loop, iteration, 'pipeline step failure');
 
     // Atomic: iteration fail + consecutiveFailures in single transaction
     const newConsecutiveFailures = loop.consecutiveFailures + 1;
@@ -1856,14 +1848,9 @@ export class LoopHandler extends BaseEventHandler {
     if (task.status === TaskStatus.FAILED) {
       const newConsecutiveFailures = loop.consecutiveFailures + 1;
 
-      // Git reset: for RETRY, reset to preIterationCommitSha to preserve prior progress commits.
-      // For OPTIMIZE, use the loop's default reset target.
-      await this.resetIterationGitState(
-        loop,
-        latestIteration,
-        'recovered task failure',
-        loop.strategy === LoopStrategy.RETRY ? latestIteration.preIterationCommitSha : undefined,
-      );
+      // Git reset: strategy-aware via getResetTargetSha.
+      // RETRY resets to preIterationCommitSha; OPTIMIZE to best/start commit.
+      await this.resetIterationGitState(loop, latestIteration, 'recovered task failure');
 
       // Atomic: iteration fail + consecutiveFailures in single transaction
       const updatedLoop = updateLoop(loop, { consecutiveFailures: newConsecutiveFailures });

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -1110,7 +1110,14 @@ export class LoopHandler extends BaseEventHandler {
   }
 
   /**
-   * Check termination conditions (maxIterations, maxConsecutiveFailures)
+   * Check termination conditions (maxIterations, maxConsecutiveFailures).
+   *
+   * DECISION: For RETRY loops, maxConsecutiveFailures only counts consecutive crashes
+   * (TaskFailed events). Successful task completions that don't satisfy the exit condition
+   * are 'progress' — they reset the crash counter to 0. This means maxIterations is the
+   * sole budget for how many attempts a RETRY loop gets; maxConsecutiveFailures guards
+   * against agent instability (repeated crashes), not slow convergence.
+   *
    * @returns true if loop was terminated, false if it should continue
    */
   private async checkTerminationConditions(loop: Loop, consecutiveFailures: number): Promise<boolean> {

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -868,7 +868,7 @@ export class LoopHandler extends BaseEventHandler {
         loop,
         iteration,
         'progress', // work preserved — exit condition not yet satisfied
-        loop.consecutiveFailures, // do NOT increment consecutive failures (task succeeded)
+        0, // task succeeded — consecutiveFailures reset to 0 (matches DB update below)
         { consecutiveFailures: 0 },
         {
           exitCode: evalResult.exitCode,

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -259,10 +259,14 @@ export class LoopHandler extends BaseEventHandler {
         // Task FAILED — record failure, check limits
         const newConsecutiveFailures = loop.consecutiveFailures + 1;
 
-        // Git reset: revert to preIterationCommitSha (not gitStartCommitSha) so accumulated
-        // 'progress' commits from prior successful-but-not-passing iterations are preserved.
-        // The failing task's own uncommitted changes are discarded, but prior iteration progress is kept.
-        await this.resetIterationGitState(loop, iteration, 'task failure', iteration.preIterationCommitSha);
+        // Git reset: RETRY resets to preIterationCommitSha to preserve prior 'progress' commits.
+        // OPTIMIZE uses the loop's default reset target (bestIterationCommitSha or gitStartCommitSha).
+        await this.resetIterationGitState(
+          loop,
+          iteration,
+          'task failure',
+          loop.strategy === LoopStrategy.RETRY ? iteration.preIterationCommitSha : undefined,
+        );
 
         // Atomic: iteration fail + consecutiveFailures in single transaction
         const updatedLoop = updateLoop(loop, { consecutiveFailures: newConsecutiveFailures });

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -259,8 +259,10 @@ export class LoopHandler extends BaseEventHandler {
         // Task FAILED — record failure, check limits
         const newConsecutiveFailures = loop.consecutiveFailures + 1;
 
-        // Git reset: revert working directory to pre-iteration state on failure (v0.8.1)
-        await this.resetIterationGitState(loop, iteration, 'task failure');
+        // Git reset: revert to preIterationCommitSha (not gitStartCommitSha) so accumulated
+        // 'progress' commits from prior successful-but-not-passing iterations are preserved.
+        // The failing task's own uncommitted changes are discarded, but prior iteration progress is kept.
+        await this.resetIterationGitState(loop, iteration, 'task failure', iteration.preIterationCommitSha);
 
         // Atomic: iteration fail + consecutiveFailures in single transaction
         const updatedLoop = updateLoop(loop, { consecutiveFailures: newConsecutiveFailures });
@@ -848,21 +850,26 @@ export class LoopHandler extends BaseEventHandler {
 
   /**
    * Handle retry strategy iteration result
-   * - decision='continue' → schedule next iteration WITHOUT incrementing consecutiveFailures
+   * - decision='continue' → commit work, schedule next iteration WITHOUT incrementing consecutiveFailures
    * - decision='stop' → complete loop (feedforward/judge modes)
    * - pass → complete loop with success (schema mode / backward compat)
-   * - fail → increment consecutiveFailures, check limits
+   * - exit condition not met → commit work as 'progress', reset consecutiveFailures to 0 (task succeeded, exit not met)
+   *
+   * DECISION: RETRY non-crash paths use 'progress' status to preserve accumulated work via git commit.
+   * 'fail' is reserved for TaskFailed (crash/hard failure) which resets to preIterationCommitSha.
+   * This fixes the bug where successful tasks that didn't satisfy the exit condition had their
+   * committed work wiped by a git reset to gitStartCommitSha.
    */
   private async handleRetryResult(loop: Loop, iteration: LoopIteration, evalResult: EvalResult): Promise<void> {
     // DECISION: Check explicit decision field first (feedforward/judge modes).
-    // This prevents consecutiveFailures from incrementing when feedforward just says "keep going".
+    // Uses 'progress' to commit accumulated work without incrementing consecutiveFailures.
     if (evalResult.decision === 'continue') {
       await this.recordAndContinue(
         loop,
         iteration,
-        'fail', // iteration "failed the exit condition" but loop should continue without penalty
-        loop.consecutiveFailures, // do NOT increment
-        {}, // no loop state update needed
+        'progress', // task completed, work preserved — exit condition not yet satisfied
+        loop.consecutiveFailures, // do NOT increment — reset crash counter on successful task completion
+        { consecutiveFailures: 0 }, // reset crash counter: successful task completion is not a failure
         {
           exitCode: evalResult.exitCode,
           evalFeedback: evalResult.feedback,
@@ -911,15 +918,14 @@ export class LoopHandler extends BaseEventHandler {
       return;
     }
 
-    // Exit condition failed — increment consecutiveFailures
-    const newConsecutiveFailures = loop.consecutiveFailures + 1;
-
+    // Exit condition not met — task succeeded but exit condition not satisfied.
+    // Use 'progress' to commit accumulated work; reset consecutiveFailures (not a crash).
     await this.recordAndContinue(
       loop,
       iteration,
-      'fail',
-      newConsecutiveFailures,
-      { consecutiveFailures: newConsecutiveFailures },
+      'progress', // task completed, work preserved — exit condition not yet satisfied
+      0, // reset crash counter: task completed successfully, only the exit condition was not met
+      { consecutiveFailures: 0 },
       {
         exitCode: evalResult.exitCode,
         errorMessage: evalResult.error,
@@ -1367,7 +1373,7 @@ export class LoopHandler extends BaseEventHandler {
     if (!iteration.preIterationCommitSha) return {};
 
     try {
-      const isCommitPath = iterationStatus === 'pass' || iterationStatus === 'keep';
+      const isCommitPath = iterationStatus === 'pass' || iterationStatus === 'keep' || iterationStatus === 'progress';
       if (isCommitPath) {
         return await this.commitAndCaptureDiff(loop, iteration, iterationStatus);
       }
@@ -1448,15 +1454,25 @@ export class LoopHandler extends BaseEventHandler {
    * No-op when the iteration has no preIterationCommitSha (non-git loop).
    * Logs warnings on failure but never throws — git reset is best-effort.
    *
+   * DECISION: RETRY task failures (hard crash/killed process) reset to preIterationCommitSha rather
+   * than gitStartCommitSha so that accumulated 'progress' commits from prior iterations are preserved.
+   * The overrideTarget parameter allows callers to specify the exact reset point.
+   *
    * @param loop - The loop owning the iteration
    * @param iteration - The iteration that failed/was discarded
    * @param context - Human-readable label for log messages (e.g., "task failure", "pipeline step failure")
+   * @param overrideTarget - Optional SHA to reset to instead of the loop's default reset target
    */
-  private async resetIterationGitState(loop: Loop, iteration: LoopIteration, context: string): Promise<void> {
+  private async resetIterationGitState(
+    loop: Loop,
+    iteration: LoopIteration,
+    context: string,
+    overrideTarget?: string,
+  ): Promise<void> {
     if (!iteration.preIterationCommitSha) return;
 
     try {
-      const resetTarget = this.getResetTargetSha(loop);
+      const resetTarget = overrideTarget ?? this.getResetTargetSha(loop);
       if (!resetTarget) return;
 
       const resetResult = await resetToCommit(loop.workingDirectory, resetTarget);
@@ -1594,8 +1610,14 @@ export class LoopHandler extends BaseEventHandler {
 
     await this.cancelRemainingPipelineTasks(iteration.pipelineTaskIds, taskId, loopId);
 
-    // Git reset: revert working directory to pre-iteration state on pipeline failure (v0.8.1)
-    await this.resetIterationGitState(loop, iteration, 'pipeline step failure');
+    // Git reset: for RETRY, reset to preIterationCommitSha to preserve prior progress commits.
+    // For OPTIMIZE, use the loop's default reset target (best iteration or gitStartCommitSha).
+    await this.resetIterationGitState(
+      loop,
+      iteration,
+      'pipeline step failure',
+      loop.strategy === LoopStrategy.RETRY ? iteration.preIterationCommitSha : undefined,
+    );
 
     // Atomic: iteration fail + consecutiveFailures in single transaction
     const newConsecutiveFailures = loop.consecutiveFailures + 1;
@@ -1830,8 +1852,14 @@ export class LoopHandler extends BaseEventHandler {
     if (task.status === TaskStatus.FAILED) {
       const newConsecutiveFailures = loop.consecutiveFailures + 1;
 
-      // Git reset: revert working directory to pre-iteration state on recovered failure (v0.8.1)
-      await this.resetIterationGitState(loop, latestIteration, 'recovered task failure');
+      // Git reset: for RETRY, reset to preIterationCommitSha to preserve prior progress commits.
+      // For OPTIMIZE, use the loop's default reset target.
+      await this.resetIterationGitState(
+        loop,
+        latestIteration,
+        'recovered task failure',
+        loop.strategy === LoopStrategy.RETRY ? latestIteration.preIterationCommitSha : undefined,
+      );
 
       // Atomic: iteration fail + consecutiveFailures in single transaction
       const updatedLoop = updateLoop(loop, { consecutiveFailures: newConsecutiveFailures });

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -1465,11 +1465,7 @@ export class LoopHandler extends BaseEventHandler {
    * @param iteration - The iteration that failed/was discarded
    * @param context - Human-readable label for log messages (e.g., "task failure", "pipeline step failure")
    */
-  private async resetIterationGitState(
-    loop: Loop,
-    iteration: LoopIteration,
-    context: string,
-  ): Promise<void> {
+  private async resetIterationGitState(loop: Loop, iteration: LoopIteration, context: string): Promise<void> {
     if (!iteration.preIterationCommitSha) return;
 
     try {

--- a/src/services/handlers/loop-handler.ts
+++ b/src/services/handlers/loop-handler.ts
@@ -867,9 +867,9 @@ export class LoopHandler extends BaseEventHandler {
       await this.recordAndContinue(
         loop,
         iteration,
-        'progress', // task completed, work preserved — exit condition not yet satisfied
-        loop.consecutiveFailures, // do NOT increment — reset crash counter on successful task completion
-        { consecutiveFailures: 0 }, // reset crash counter: successful task completion is not a failure
+        'progress', // work preserved — exit condition not yet satisfied
+        loop.consecutiveFailures, // do NOT increment consecutive failures (task succeeded)
+        { consecutiveFailures: 0 },
         {
           exitCode: evalResult.exitCode,
           evalFeedback: evalResult.feedback,
@@ -923,8 +923,8 @@ export class LoopHandler extends BaseEventHandler {
     await this.recordAndContinue(
       loop,
       iteration,
-      'progress', // task completed, work preserved — exit condition not yet satisfied
-      0, // reset crash counter: task completed successfully, only the exit condition was not met
+      'progress', // work preserved — exit condition not yet satisfied
+      0, // task succeeded — consecutiveFailures reset to 0
       { consecutiveFailures: 0 },
       {
         exitCode: evalResult.exitCode,
@@ -1359,11 +1359,11 @@ export class LoopHandler extends BaseEventHandler {
 
   /**
    * Handle git commit or revert based on iteration outcome.
-   * - pass/keep: commit all changes, capture diff summary
+   * - pass/keep/progress: commit all changes, capture diff summary
    * - fail/discard/crash: delegate to resetIterationGitState for clean revert
    *
    * Best-effort: logs warnings on failure, never throws.
-   * @returns { gitCommitSha, gitDiffSummary } — both undefined if non-git or on failure/discard
+   * @returns { gitCommitSha, gitDiffSummary } — both undefined if non-git or on revert path
    */
   private async handleIterationGitOutcome(
     loop: Loop,
@@ -1436,10 +1436,10 @@ export class LoopHandler extends BaseEventHandler {
   }
 
   /**
-   * Determine the commit SHA to reset to after a failed/discarded iteration.
-   * - Retry fail: reset to loop.gitStartCommitSha (start fresh)
-   * - Optimize discard/crash: reset to best iteration's gitCommitSha if available,
-   *   fallback to loop.gitStartCommitSha
+   * Determine the default commit SHA to reset to after a failed/discarded iteration.
+   * Used when no overrideTarget is provided (i.e., OPTIMIZE strategy or iteration discard).
+   * - Optimize: reset to best iteration's gitCommitSha if available, fallback to gitStartCommitSha
+   * - Retry callers pass overrideTarget = preIterationCommitSha directly (bypasses this method)
    * @returns SHA to reset to, or undefined if no git tracking
    */
   private getResetTargetSha(loop: Loop): string | undefined {
@@ -1801,7 +1801,7 @@ export class LoopHandler extends BaseEventHandler {
         return;
       }
 
-      // fail / discard / crash / keep / cancelled — check termination, then continue
+      // fail / discard / crash / keep / progress / cancelled — check termination, then continue
       // Loop's consecutiveFailures is already correct (committed atomically with iteration)
       if (await this.checkTerminationConditions(loop, loop.consecutiveFailures)) {
         return;

--- a/tests/integration/task-loops.test.ts
+++ b/tests/integration/task-loops.test.ts
@@ -365,9 +365,9 @@ describe('Integration: Task Loops - End-to-End Flow', () => {
       expect(loop!.consecutiveFailures).toBe(2);
     });
 
-    it('should keep incrementing consecutiveFailures when task succeeds but exit condition fails', async () => {
-      // Exit condition: `false` always fails (exit code 1) so loop continues
-      // consecutiveFailures tracks iteration outcome, not task outcome
+    it('should reset consecutiveFailures when task succeeds but exit condition is not met', async () => {
+      // Exit condition: `false` always returns non-zero so loop continues
+      // consecutiveFailures only tracks crashes (TaskFailed), not exit-condition-not-met
       const createResult = await service.createLoop({
         prompt: 'Fix the bug',
         strategy: LoopStrategy.RETRY,
@@ -382,21 +382,21 @@ describe('Integration: Task Loops - End-to-End Flow', () => {
       const loopId = createResult.value.id;
       await flushEventLoop();
 
-      // Fail first iteration (TaskFailed)
+      // Fail first iteration (TaskFailed — crash)
       const iter1 = await getLatestIteration(loopId);
       await eventBus.emit('TaskFailed', { taskId: iter1!.taskId, error: 'fail', exitCode: 1 });
       await flushEventLoop();
 
       expect((await getLoop(loopId))!.consecutiveFailures).toBe(1);
 
-      // Succeed second iteration task, but exit condition `false` fails
+      // Succeed second iteration task, but exit condition `false` is not met
       const iter2 = await getLatestIteration(loopId);
       await eventBus.emit('TaskCompleted', { taskId: iter2!.taskId, exitCode: 0, duration: 100 });
       await flushEventLoop();
 
-      // consecutiveFailures increments because exit condition failed
+      // consecutiveFailures resets to 0: task succeeded (not a crash), exit condition just wasn't met
       const loop = await getLoop(loopId);
-      expect(loop!.consecutiveFailures).toBe(2);
+      expect(loop!.consecutiveFailures).toBe(0);
       expect(loop!.status).toBe(LoopStatus.RUNNING);
     });
   });

--- a/tests/unit/interactive-orchestrator.test.ts
+++ b/tests/unit/interactive-orchestrator.test.ts
@@ -1000,9 +1000,9 @@ describe('migration v25 - mode and pid columns', () => {
     db.close();
   });
 
-  it('should be at schema version 25', () => {
+  it('should be at schema version 26', () => {
     const db = new Database(':memory:');
-    expect(db.getSchemaVersion()).toBe(25);
+    expect(db.getSchemaVersion()).toBe(26);
     db.close();
   });
 });

--- a/tests/unit/services/handlers/loop-handler.test.ts
+++ b/tests/unit/services/handlers/loop-handler.test.ts
@@ -1728,11 +1728,10 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(iter1!.status).toBe('fail');
     });
 
-    it('OPTIMIZE: TaskFailed resets to gitStartCommitSha (undefined overrideTarget path)', async () => {
-      // I4: Prove that OPTIMIZE TaskFailed still uses the loop's default reset target
-      // (gitStartCommitSha when no bestIterationCommitSha exists) via the undefined
-      // overrideTarget path in resetIterationGitState. The strategy-conditional at line 268
-      // passes undefined for OPTIMIZE, delegating to getResetTargetSha().
+    it('OPTIMIZE: TaskFailed resets to gitStartCommitSha when no bestIterationCommitSha', async () => {
+      // I4: Prove that OPTIMIZE TaskFailed uses gitStartCommitSha (not preIterationCommitSha)
+      // when no bestIterationCommitSha exists. getResetTargetSha() falls through to the default
+      // branch — preIterationCommitSha is the RETRY-only path.
       const loop = await createGitLoop({
         strategy: LoopStrategy.OPTIMIZE,
         evalDirection: OptimizeDirection.MAXIMIZE,
@@ -1756,7 +1755,7 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(iters.ok).toBe(true);
       const iteration = iters.value.find((i) => i.iterationNumber === 1);
       expect(iteration).toBeDefined();
-      // preIterationCommitSha must NOT have been used (that is the RETRY-only override path)
+      // preIterationCommitSha must NOT have been used — that is the RETRY-only path
       expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', iteration!.preIterationCommitSha);
       expect(iteration!.status).toBe('fail');
     });

--- a/tests/unit/services/handlers/loop-handler.test.ts
+++ b/tests/unit/services/handlers/loop-handler.test.ts
@@ -1173,6 +1173,33 @@ describe('LoopHandler - Behavioral Tests', () => {
 
       freshEventBus.dispose();
     });
+
+    it('should start next iteration when recovering progress iteration', async () => {
+      // I3: The 'progress' status (RETRY iteration that completed but did not pass the exit
+      // condition) should be handled identically to 'fail' and 'keep' during crash-window
+      // recovery — the handler must start the next iteration rather than stalling the loop.
+      const { loop } = await setupCrashWindowScenario({
+        iterationStatus: 'progress',
+        loopOverrides: { consecutiveFailures: 0 },
+      });
+
+      const freshEventBus = new InMemoryEventBus(createTestConfiguration(), new TestLogger());
+      await LoopHandler.create({
+        loopRepo,
+        taskRepo,
+        checkpointRepo: createMockCheckpointRepo(),
+        eventBus: freshEventBus,
+        database,
+        exitConditionEvaluator: mockEvaluator,
+        logger: new TestLogger(),
+      });
+
+      const recoveredLoop = await getLoop(loop.id);
+      expect(recoveredLoop!.status).toBe(LoopStatus.RUNNING);
+      expect(recoveredLoop!.currentIteration).toBe(2);
+
+      freshEventBus.dispose();
+    });
   });
 
   describe('Fix K — Retry pass path atomicity', () => {
@@ -1699,6 +1726,39 @@ describe('LoopHandler - Behavioral Tests', () => {
       const iter1 = allIters.value.find((i) => i.iterationNumber === 1);
       expect(iter1).toBeDefined();
       expect(iter1!.status).toBe('fail');
+    });
+
+    it('OPTIMIZE: TaskFailed resets to gitStartCommitSha (undefined overrideTarget path)', async () => {
+      // I4: Prove that OPTIMIZE TaskFailed still uses the loop's default reset target
+      // (gitStartCommitSha when no bestIterationCommitSha exists) via the undefined
+      // overrideTarget path in resetIterationGitState. The strategy-conditional at line 268
+      // passes undefined for OPTIMIZE, delegating to getResetTargetSha().
+      const loop = await createGitLoop({
+        strategy: LoopStrategy.OPTIMIZE,
+        evalDirection: OptimizeDirection.MAXIMIZE,
+        maxConsecutiveFailures: 5,
+      });
+      const taskId = await getLatestTaskId(loop.id);
+
+      vi.mocked(resetToCommit).mockClear();
+
+      await eventBus.emit('TaskFailed', {
+        taskId: taskId!,
+        error: { message: 'Task crashed', code: 'SYSTEM_ERROR' },
+        exitCode: 1,
+      });
+      await flushEventLoop();
+
+      // OPTIMIZE with no bestIterationCommitSha: reset target must be gitStartCommitSha
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iteration = iters.value.find((i) => i.iterationNumber === 1);
+      expect(iteration).toBeDefined();
+      // preIterationCommitSha must NOT have been used (that is the RETRY-only override path)
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', iteration!.preIterationCommitSha);
+      expect(iteration!.status).toBe('fail');
     });
 
     it('should use getCurrentCommitSha as fallback when commitAllChanges returns null (agent already committed)', async () => {

--- a/tests/unit/services/handlers/loop-handler.test.ts
+++ b/tests/unit/services/handlers/loop-handler.test.ts
@@ -1588,7 +1588,9 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(iter1!.gitCommitSha).toBe('commit_sha_after_keep_1234567890abcdef12345');
     });
 
-    it('should reset to gitStartCommitSha on retry fail', async () => {
+    it('RETRY: exit condition not met commits work as progress (no reset)', async () => {
+      // T1: The old behavior reset to gitStartCommitSha, wiping accumulated work.
+      // New behavior: commit work as 'progress' so next iteration builds on it.
       mockEvaluator.evaluate.mockResolvedValue({ passed: false, exitCode: 1, error: 'test failed' });
 
       const loop = await createGitLoop({ maxConsecutiveFailures: 5 });
@@ -1597,8 +1599,17 @@ describe('LoopHandler - Behavioral Tests', () => {
       await eventBus.emit('TaskCompleted', { taskId: taskId!, exitCode: 0, duration: 100 });
       await flushEventLoop();
 
-      // resetToCommit should have been called with the loop's gitStartCommitSha
-      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+      // commitAllChanges should have been called (work is preserved)
+      expect(vi.mocked(commitAllChanges)).toHaveBeenCalled();
+
+      // resetToCommit must NOT have been called (no work-wiping reset)
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalled();
+
+      // Iteration status must be 'progress' (not 'fail')
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter1 = iters.value.find((i) => i.iterationNumber === 1);
+      expect(iter1!.status).toBe('progress');
     });
 
     it('should reset to best iteration gitCommitSha on optimize discard', async () => {
@@ -1657,9 +1668,19 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(updatedLoop.value!.bestIterationCommitSha).toBe('cached_sha_1234567890abcdef1234567890abcdef12');
     });
 
-    it('should reset to gitStartCommitSha on task failure', async () => {
+    it('RETRY: task failure resets to preIterationCommitSha (preserves prior progress commits)', async () => {
+      // T2: Task failures (hard crash) reset to preIterationCommitSha, NOT gitStartCommitSha.
+      // This ensures prior successful 'progress' iteration commits are preserved.
       const loop = await createGitLoop({ maxConsecutiveFailures: 5 });
       const taskId = await getLatestTaskId(loop.id);
+
+      // Get the preIterationCommitSha captured for this iteration
+      const iteration = await getLatestIteration(loop.id);
+      expect(iteration).toBeDefined();
+      const preIterSha = iteration!.preIterationCommitSha;
+      expect(preIterSha).toBeDefined();
+
+      vi.mocked(resetToCommit).mockClear();
 
       await eventBus.emit('TaskFailed', {
         taskId: taskId!,
@@ -1668,9 +1689,11 @@ describe('LoopHandler - Behavioral Tests', () => {
       });
       await flushEventLoop();
 
-      // Task failure does NOT go through git commit/reset path
-      // (only exit condition evaluation triggers git operations)
-      // The iteration's preIterationCommitSha is still set though
+      // resetToCommit must have been called with preIterationCommitSha (not gitStartCommitSha)
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', preIterSha);
+      // gitStartCommitSha must NOT have been used for the reset
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+
       const allIters = await loopRepo.getIterations(loop.id, 10);
       expect(allIters.ok).toBe(true);
       const iter1 = allIters.value.find((i) => i.iterationNumber === 1);
@@ -1702,7 +1725,9 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(iteration!.gitCommitSha).toBe('agent_committed_sha_1234567890abcdef123456');
     });
 
-    it('should reset to gitStartCommitSha on pipeline intermediate step failure', async () => {
+    it('RETRY: pipeline intermediate step failure resets to preIterationCommitSha', async () => {
+      // RETRY pipeline failures now reset to preIterationCommitSha (not gitStartCommitSha),
+      // preserving accumulated progress commits from prior successful iterations.
       const loop = await createGitLoop({
         pipelineSteps: ['lint the code', 'run the tests', 'deploy'],
         prompt: undefined,
@@ -1714,6 +1739,8 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(iteration!.pipelineTaskIds).toBeDefined();
       expect(iteration!.pipelineTaskIds!.length).toBe(3);
       const taskIds = iteration!.pipelineTaskIds!;
+      const preIterSha = iteration!.preIterationCommitSha;
+      expect(preIterSha).toBeDefined();
 
       vi.mocked(resetToCommit).mockClear();
 
@@ -1725,8 +1752,9 @@ describe('LoopHandler - Behavioral Tests', () => {
       });
       await flushEventLoop();
 
-      // resetToCommit should have been called with the loop's gitStartCommitSha
-      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+      // resetToCommit should use preIterationCommitSha (not gitStartCommitSha) for RETRY
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', preIterSha);
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
 
       // Iteration should be marked as 'fail' with pipeline step failure message
       const allIters = await loopRepo.getIterations(loop.id, 10);
@@ -1763,6 +1791,219 @@ describe('LoopHandler - Behavioral Tests', () => {
       const iter1 = iters.value.find((i) => i.iterationNumber === 1);
       expect(iter1!.status).toBe('crash');
     });
+
+    // -----------------------------------------------------------------------
+    // T4–T9: RETRY progress status and git preservation tests
+    // -----------------------------------------------------------------------
+
+    it('T4: RETRY exit condition not met + git → progress status, commit called, consecutiveFailures=0', async () => {
+      // T4: When exit condition is not met (passed=false, no decision), work should be committed
+      // as 'progress' and consecutiveFailures should be reset to 0 (task succeeded).
+      mockEvaluator.evaluate.mockResolvedValue({ passed: false, exitCode: 1, error: 'not done yet' });
+
+      const loop = await createGitLoop({ maxConsecutiveFailures: 5 });
+      const taskId = await getLatestTaskId(loop.id);
+
+      await eventBus.emit('TaskCompleted', { taskId: taskId!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      // commitAllChanges should have been called (work preserved)
+      expect(vi.mocked(commitAllChanges)).toHaveBeenCalled();
+      // resetToCommit must NOT have been called
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalled();
+
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter1 = iters.value.find((i) => i.iterationNumber === 1);
+      expect(iter1!.status).toBe('progress');
+
+      const updatedLoop = await getLoop(loop.id);
+      expect(updatedLoop!.consecutiveFailures).toBe(0);
+    });
+
+    it('T5: RETRY decision=continue + git → progress status, commit called, consecutiveFailures=0', async () => {
+      // T5: decision=continue path (feedforward/judge mode) should also commit work and use 'progress'.
+      mockEvaluator.evaluate.mockResolvedValue({
+        passed: false,
+        decision: 'continue',
+        feedback: 'keep going',
+        exitCode: 0,
+      });
+
+      const loop = await createGitLoop({ maxConsecutiveFailures: 5 });
+      const taskId = await getLatestTaskId(loop.id);
+
+      await eventBus.emit('TaskCompleted', { taskId: taskId!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      // commitAllChanges should have been called (work preserved)
+      expect(vi.mocked(commitAllChanges)).toHaveBeenCalled();
+      // resetToCommit must NOT have been called
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalled();
+
+      // After 'progress', the loop starts iter 2 — look for iter 1 explicitly
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter1 = iters.value.find((i) => i.iterationNumber === 1);
+      expect(iter1!.status).toBe('progress');
+
+      const updatedLoop = await getLoop(loop.id);
+      expect(updatedLoop!.consecutiveFailures).toBe(0);
+    });
+
+    it('T6: RETRY TaskFailed after accumulated progress → fail status, reset to preIterationCommitSha', async () => {
+      // T6: After a successful progress iteration, a task failure should reset only to
+      // preIterationCommitSha (the start of THIS iteration), not gitStartCommitSha.
+      // This preserves work from prior progress iterations.
+      mockEvaluator.evaluate.mockResolvedValue({ passed: false, exitCode: 1, error: 'not done' });
+
+      const loop = await createGitLoop({ maxConsecutiveFailures: 5 });
+
+      // Iteration 1: exit condition not met → progress (work committed)
+      const taskId1 = await getLatestTaskId(loop.id);
+      await eventBus.emit('TaskCompleted', { taskId: taskId1!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      // Verify iteration 1 is progress (look by number since iter2 starts after)
+      const iters1 = await loopRepo.getIterations(loop.id, 10);
+      expect(iters1.ok).toBe(true);
+      const iter1 = iters1.value.find((i) => i.iterationNumber === 1);
+      expect(iter1!.status).toBe('progress');
+
+      // Iteration 2: task FAILS — should reset to iter2's preIterationCommitSha
+      const taskId2 = await getLatestTaskId(loop.id);
+      const iter2 = await getLatestIteration(loop.id);
+      expect(iter2).toBeDefined();
+      const iter2PreSha = iter2!.preIterationCommitSha;
+      expect(iter2PreSha).toBeDefined();
+
+      vi.mocked(resetToCommit).mockClear();
+
+      await eventBus.emit('TaskFailed', {
+        taskId: taskId2!,
+        error: { message: 'Crashed', code: 'SYSTEM_ERROR' },
+        exitCode: 1,
+      });
+      await flushEventLoop();
+
+      // resetToCommit should be called with iter2's preIterationCommitSha
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', iter2PreSha);
+      // gitStartCommitSha must NOT have been used
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter2Rec = iters.value.find((i) => i.iterationNumber === 2);
+      expect(iter2Rec!.status).toBe('fail');
+
+      const updatedLoop = await getLoop(loop.id);
+      expect(updatedLoop!.consecutiveFailures).toBe(1);
+    });
+
+    it('T7: RETRY multi-iteration crash isolation — each failure resets only to its own preIterationCommitSha', async () => {
+      // T7: When multiple iterations run, a crash should reset to that specific iteration's
+      // preIterationCommitSha, not the loop start or a prior iteration's SHA.
+      mockEvaluator.evaluate.mockResolvedValue({ passed: false, exitCode: 1, error: 'not done' });
+
+      const loop = await createGitLoop({ maxConsecutiveFailures: 10 });
+
+      // Iteration 1: progress
+      const taskId1 = await getLatestTaskId(loop.id);
+      await eventBus.emit('TaskCompleted', { taskId: taskId1!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      // Iteration 2: also progress
+      const taskId2 = await getLatestTaskId(loop.id);
+      await eventBus.emit('TaskCompleted', { taskId: taskId2!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      // Iteration 3: task FAILS — should reset to iter3's preIterationCommitSha specifically
+      const iter3 = await getLatestIteration(loop.id);
+      expect(iter3).toBeDefined();
+      const iter3PreSha = iter3!.preIterationCommitSha;
+      const taskId3 = await getLatestTaskId(loop.id);
+
+      vi.mocked(resetToCommit).mockClear();
+
+      await eventBus.emit('TaskFailed', {
+        taskId: taskId3!,
+        error: { message: 'Crashed on iter 3', code: 'SYSTEM_ERROR' },
+        exitCode: 1,
+      });
+      await flushEventLoop();
+
+      // Reset target must be iter3's own preIterationCommitSha (not iter1 or iter2's SHA)
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', iter3PreSha);
+
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter3Rec = iters.value.find((i) => i.iterationNumber === 3);
+      expect(iter3Rec!.status).toBe('fail');
+
+      const updatedLoop = await getLoop(loop.id);
+      expect(updatedLoop!.consecutiveFailures).toBe(1);
+    });
+
+    it('T8: RETRY pipeline step failure → fail status, reset to preIterationCommitSha', async () => {
+      // T8: Pipeline step failures in RETRY loops should also use preIterationCommitSha.
+      const loop = await createGitLoop({
+        pipelineSteps: ['lint', 'test', 'deploy'],
+        prompt: undefined,
+        maxConsecutiveFailures: 5,
+      });
+
+      const iteration = await getLatestIteration(loop.id);
+      expect(iteration).toBeDefined();
+      const preIterSha = iteration!.preIterationCommitSha;
+      expect(preIterSha).toBeDefined();
+      const taskIds = iteration!.pipelineTaskIds!;
+
+      vi.mocked(resetToCommit).mockClear();
+
+      await eventBus.emit('TaskFailed', {
+        taskId: taskIds[0],
+        error: { message: 'lint failed', code: 'SYSTEM_ERROR' },
+        exitCode: 1,
+      });
+      await flushEventLoop();
+
+      // resetToCommit should use preIterationCommitSha (not gitStartCommitSha)
+      expect(vi.mocked(resetToCommit)).toHaveBeenCalledWith('/tmp', preIterSha);
+      expect(vi.mocked(resetToCommit)).not.toHaveBeenCalledWith('/tmp', 'aaa1111222233334444555566667777888899990000');
+
+      const iters = await loopRepo.getIterations(loop.id, 10);
+      expect(iters.ok).toBe(true);
+      const iter1 = iters.value.find((i) => i.iterationNumber === 1);
+      expect(iter1!.status).toBe('fail');
+      expect(iter1!.errorMessage).toContain('Pipeline step failed');
+    });
+
+    it('T9: consecutiveFailures resets to 0 after progress iteration', async () => {
+      // T9: After a prior crash increments consecutiveFailures, a successful 'progress' iteration
+      // should reset consecutiveFailures back to 0.
+      // Iteration 1: task fails (hard crash)
+      const loop = await createGitLoop({ maxConsecutiveFailures: 10 });
+      const taskId1 = await getLatestTaskId(loop.id);
+
+      await eventBus.emit('TaskFailed', {
+        taskId: taskId1!,
+        error: { message: 'Crashed', code: 'SYSTEM_ERROR' },
+        exitCode: 1,
+      });
+      await flushEventLoop();
+
+      const loopAfterFail = await getLoop(loop.id);
+      expect(loopAfterFail!.consecutiveFailures).toBe(1);
+
+      // Iteration 2: task completes, exit condition not met → 'progress'
+      mockEvaluator.evaluate.mockResolvedValueOnce({ passed: false, exitCode: 0, error: 'not done' });
+      const taskId2 = await getLatestTaskId(loop.id);
+      await eventBus.emit('TaskCompleted', { taskId: taskId2!, exitCode: 0, duration: 100 });
+      await flushEventLoop();
+
+      const loopAfterProgress = await getLoop(loop.id);
+      expect(loopAfterProgress!.consecutiveFailures).toBe(0);
+    });
   });
 
   // ==========================================================================
@@ -1797,11 +2038,11 @@ describe('LoopHandler - Behavioral Tests', () => {
       // consecutiveFailures must NOT have been incremented
       expect(updatedLoop!.consecutiveFailures).toBe(0);
 
-      // Iteration 1 should be recorded as 'fail' (exit condition not met) but without penalty
+      // T3: Iteration 1 should be recorded as 'progress' (work committed, exit condition not met)
       const iters = await loopRepo.getIterations(loop.id, 10);
       expect(iters.ok).toBe(true);
       const iter1 = iters.value.find((i) => i.iterationNumber === 1);
-      expect(iter1!.status).toBe('fail');
+      expect(iter1!.status).toBe('progress');
     });
 
     it('decision: continue — does not fail loop even at maxConsecutiveFailures boundary', async () => {
@@ -1913,8 +2154,10 @@ describe('LoopHandler - Behavioral Tests', () => {
       expect(updatedLoop!.status).toBe(LoopStatus.COMPLETED);
     });
 
-    it('undefined decision — falls through to normal passed/failed logic (backward compat)', async () => {
-      // No decision field set — must behave identically to the pre-v1.3.0 retry path.
+    it('undefined decision — falls through to progress path (RETRY non-crash fix)', async () => {
+      // No decision field set — passed=false with no decision uses the 'progress' path (bug fix).
+      // The old behavior incremented consecutiveFailures; new behavior resets it to 0.
+      // This ensures successful task completions that miss the exit condition preserve their work.
       mockEvaluator.evaluate.mockResolvedValue({ passed: false, exitCode: 1, error: 'test failed' });
 
       const loop = await createAndEmitLoop({
@@ -1926,9 +2169,9 @@ describe('LoopHandler - Behavioral Tests', () => {
       await eventBus.emit('TaskCompleted', { taskId: taskId!, exitCode: 0, duration: 100 });
       await flushEventLoop();
 
-      // Normal fail path: consecutiveFailures incremented
+      // New behavior: consecutiveFailures reset to 0 (task succeeded, exit condition not met)
       const updatedLoop = await getLoop(loop.id);
-      expect(updatedLoop!.consecutiveFailures).toBe(1);
+      expect(updatedLoop!.consecutiveFailures).toBe(0);
       expect(updatedLoop!.status).toBe(LoopStatus.RUNNING);
     });
   });


### PR DESCRIPTION
## Problem

RETRY loop iterations that completed their task successfully but didn't pass the exit condition were resetting the working directory via `git reset --hard` to the loop start commit, destroying all accumulated progress.

This affected orchestrators (rebuilding from scratch each iteration), test coverage loops (losing written tests), and any multi-step retry workflow in a git repo.

## Solution

New `'progress'` iteration status for RETRY iterations that made progress; commit instead of reset. Crash recovery targets `preIterationCommitSha` instead of `gitStartCommitSha`.

- **domain.ts**: add `progress` to LoopIteration status union
- **loop-repository.ts**: add `progress` to Zod iteration status enum
- **database.ts**: migration v26 recreates `loop_iterations` with updated CHECK constraint
- **loop-handler.ts**:
  - `handleRetryResult` decision=continue and passed=false paths: use progress status
  - `resetIterationGitState`: add overrideTarget parameter for preIterationCommitSha
  - TaskFailed/recovery paths: reset to iteration's own preIterationCommitSha (preserves prior progress)
- **consecutiveFailures**: now only tracks actual crashes (TaskFailed), not exit-condition-not-met iterations
- **UI**: display progress status with cyan color and circle icon

## Breaking Changes

None — `'fail'` status remains valid for TaskFailed events. Migration v26 handles existing databases. OPTIMIZE strategy completely untouched.

## Testing

- Updated T1-T3, T8 to reflect new behavior
- Added T4-T9 covering:
  - progress commit path
  - preIterationCommitSha reset isolation
  - pipeline failures
  - consecutiveFailures reset semantics
- Integration test updated to match progress status semantics

## Review Focus

1. Migration v26 column list matches current schema
2. `handleRetryResult` status and consecutiveFailures changes
3. `resetIterationGitState` override parameter and call sites
4. Test coverage for all RETRY paths (progress, fail, reset isolation)