### PR TITLE
feat(dashboard): stream output in detail views + surface loop eval data (#165, #168)

### DIFF
--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -470,7 +470,11 @@ const LoopStatusSchema = z.object({
   includeSystemPrompt: z.boolean().optional().default(false).describe('Include system prompt in response'),
   // DECISION (#168): evalResponse is omitted by default — raw eval text can be large (up to 16KB).
   // Callers that need audit data for score analysis must explicitly opt in.
-  includeEvalResponse: z.boolean().optional().default(false).describe('Include raw eval response text per iteration (default: false)'),
+  includeEvalResponse: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Include raw eval response text per iteration (default: false)'),
 });
 
 const ListLoopsSchema = z.object({

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -468,6 +468,9 @@ const LoopStatusSchema = z.object({
   historyLimit: z.number().min(1).optional().default(20).describe('Max iterations to return'),
   // DECISION: System prompts can be up to 16KB. Default omission keeps status responses compact.
   includeSystemPrompt: z.boolean().optional().default(false).describe('Include system prompt in response'),
+  // DECISION (#168): evalResponse is omitted by default — raw eval text can be large (up to 16KB).
+  // Callers that need audit data for score analysis must explicitly opt in.
+  includeEvalResponse: z.boolean().optional().default(false).describe('Include raw eval response text per iteration (default: false)'),
 });
 
 const ListLoopsSchema = z.object({
@@ -1356,6 +1359,10 @@ export class MCPAdapter {
                   includeSystemPrompt: {
                     type: 'boolean',
                     description: 'Include system prompt in response (default: false)',
+                  },
+                  includeEvalResponse: {
+                    type: 'boolean',
+                    description: 'Include raw eval response text per iteration (default: false)',
                   },
                 },
                 required: ['loopId'],
@@ -2725,7 +2732,7 @@ export class MCPAdapter {
       };
     }
 
-    const { loopId, includeHistory, historyLimit, includeSystemPrompt } = parseResult.data;
+    const { loopId, includeHistory, historyLimit, includeSystemPrompt, includeEvalResponse } = parseResult.data;
 
     const result = await this.loopService.getLoop(LoopId(loopId), includeHistory, historyLimit);
 
@@ -2744,6 +2751,9 @@ export class MCPAdapter {
             bestScore: loop.bestScore,
             exitCondition: loop.exitCondition,
             evalDirection: loop.evalDirection,
+            evalType: loop.evalType ?? null,
+            judgeAgent: loop.judgeAgent ?? null,
+            judgePrompt: loop.judgePrompt ?? null,
             cooldownMs: loop.cooldownMs,
             freshContext: loop.freshContext,
             promptPreview: truncatePrompt(loop.taskTemplate.prompt, 50),
@@ -2782,6 +2792,7 @@ export class MCPAdapter {
             exitCode: iter.exitCode ?? null,
             errorMessage: iter.errorMessage ?? null,
             evalFeedback: iter.evalFeedback ?? null,
+            ...(includeEvalResponse ? { evalResponse: iter.evalResponse ?? null } : {}),
             gitBranch: iter.gitBranch ?? null,
             gitCommitSha: iter.gitCommitSha ?? null,
             preIterationCommitSha: iter.preIterationCommitSha ?? null,

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -56,6 +56,10 @@ const INITIAL_NAV: NavState = {
   scrollOffsets: { loops: 0, tasks: 0, schedules: 0, orchestrations: 0, pipelines: 0 },
   orchestrationChildSelectedTaskId: null,
   orchestrationChildPage: 0,
+  detailOutputVisible: true,
+  detailOutputAutoTail: true,
+  detailOutputScrollOffset: 0,
+  loopIterationSelectedNumber: null,
 };
 
 const INITIAL_DASHBOARD_STATE: DashboardState = {

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -28,6 +28,7 @@ import { useTerminalSize } from './use-terminal-size.js';
 import { DetailView } from './views/detail-view.js';
 import { MetricsView } from './views/metrics-view.js';
 import { OrchestrationDetail } from './views/orchestration-detail.js';
+import type { WorkspaceNavState } from './workspace-types.js';
 import { createInitialWorkspaceNavState } from './workspace-types.js';
 
 interface AppProps {
@@ -94,13 +95,7 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
     }
   }, []);
   const setWorkspaceNav = useCallback(
-    (
-      updaterOrValue:
-        | import('./workspace-types.js').WorkspaceNavState
-        | ((
-            prev: import('./workspace-types.js').WorkspaceNavState,
-          ) => import('./workspace-types.js').WorkspaceNavState),
-    ) => {
+    (updaterOrValue: WorkspaceNavState | ((prev: WorkspaceNavState) => WorkspaceNavState)) => {
       if (typeof updaterOrValue === 'function') {
         dispatch({ type: 'UPDATE_WORKSPACE_NAV', updater: updaterOrValue });
       } else {

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useEffect, useReducer } from 'react';
 import type { TaskId } from '../../core/domain.js';
 import type { OutputRepository, ResourceMonitor } from '../../core/interfaces.js';
 import type { ReadOnlyContext } from '../read-only-context.js';
+import type { DetailOutputConfig } from './components/detail-output-panel.js';
 import { Footer } from './components/footer.js';
 import { Header } from './components/header.js';
 import { computeMetricsLayout, computeWorkspaceLayout } from './layout.js';
@@ -165,7 +166,8 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
   // Workspace uses childTaskIds; detail uses a single-element array.
   const streamTaskIds =
     view.kind === 'workspace' ? childTaskIds : detailStreamTaskId !== null ? [detailStreamTaskId] : [];
-  const streamTaskStatuses: ReadonlyMap<TaskId, string> = view.kind === 'workspace' ? childTaskStatuses : EMPTY_STATUS_MAP;
+  const streamTaskStatuses: ReadonlyMap<TaskId, string> =
+    view.kind === 'workspace' ? childTaskStatuses : EMPTY_STATUS_MAP;
 
   const { streams } = useTaskOutputStream(
     outputRepository ?? ctx.outputRepository,
@@ -242,6 +244,12 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
     }
 
     if (view.kind === 'detail') {
+      const detailOutputConfig: DetailOutputConfig = {
+        visible: nav.detailOutputVisible,
+        autoTail: nav.detailOutputAutoTail,
+        scrollOffset: nav.detailOutputScrollOffset,
+        terminalRows: terminalSize.rows,
+      };
       return (
         <DetailView
           entityType={view.entityType}
@@ -254,10 +262,7 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
           orchestrationChildrenTotal={data?.orchestrationChildrenTotal}
           loopIterationSelectedNumber={nav.loopIterationSelectedNumber}
           taskStreams={streams}
-          detailOutputVisible={nav.detailOutputVisible}
-          detailOutputAutoTail={nav.detailOutputAutoTail}
-          detailOutputScrollOffset={nav.detailOutputScrollOffset}
-          terminalRows={terminalSize.rows}
+          detailOutputConfig={detailOutputConfig}
         />
       );
     }

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -134,16 +134,39 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
   const childTaskIds = data?.workspaceData?.childTaskIds ?? [];
   const childTaskStatuses = data?.workspaceData?.childTaskStatuses ?? new Map();
 
-  // Live output streaming — only enabled when in workspace view and outputRepository is available
-  // Phase C prep: a future `o` toggle in task detail would also enable streaming here.
-  // That requires keyboard handler changes (handle-detail-keys) deferred to a later phase.
-  // TODO: When grid/detail mode is fully wired via the 'v' toggle, also enable streaming
-  // for orchestration detail in grid mode (view.kind === 'detail' && view.entityType === 'orchestrations').
-  const streamingEnabled = view.kind === 'workspace' && outputRepository !== undefined;
+  // Resolve the task ID(s) to stream in detail mode (#165).
+  // Task detail: the task itself. Orchestration detail: the selected child (if any).
+  const detailStreamTaskId: import('../../core/domain.js').TaskId | null = (() => {
+    if (view.kind !== 'detail' || !outputRepository) return null;
+    if (view.entityType === 'tasks') return view.entityId as import('../../core/domain.js').TaskId;
+    if (view.entityType === 'orchestrations' && nav.orchestrationChildSelectedTaskId) {
+      return nav.orchestrationChildSelectedTaskId as import('../../core/domain.js').TaskId;
+    }
+    return null;
+  })();
+
+  // Live output streaming:
+  //  - Workspace: always enabled when outputRepository is present
+  //  - Task/orchestration detail: enabled when outputVisible flag is set and there is a task to stream
+  const streamingEnabled =
+    outputRepository !== undefined &&
+    (view.kind === 'workspace' ||
+      (view.kind === 'detail' &&
+        detailStreamTaskId !== null &&
+        nav.detailOutputVisible &&
+        (view.entityType === 'tasks' || view.entityType === 'orchestrations')));
+
+  // Build unified task ID and status arrays for the output stream hook.
+  // Workspace uses childTaskIds; detail uses a single-element array.
+  const streamTaskIds =
+    view.kind === 'workspace' ? childTaskIds : detailStreamTaskId !== null ? [detailStreamTaskId] : [];
+  const streamTaskStatuses: ReadonlyMap<import('../../core/domain.js').TaskId, string> =
+    view.kind === 'workspace' ? childTaskStatuses : new Map();
+
   const { streams } = useTaskOutputStream(
     outputRepository ?? ctx.outputRepository,
-    childTaskIds,
-    childTaskStatuses,
+    streamTaskIds,
+    streamTaskStatuses,
     streamingEnabled,
   );
 
@@ -226,6 +249,11 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
           orchestrationChildPage={nav.orchestrationChildPage}
           orchestrationChildrenTotal={data?.orchestrationChildrenTotal}
           loopIterationSelectedNumber={nav.loopIterationSelectedNumber}
+          taskStreams={streams}
+          detailOutputVisible={nav.detailOutputVisible}
+          detailOutputAutoTail={nav.detailOutputAutoTail}
+          detailOutputScrollOffset={nav.detailOutputScrollOffset}
+          terminalRows={terminalSize.rows}
         />
       );
     }

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -70,6 +70,9 @@ const INITIAL_DASHBOARD_STATE: DashboardState = {
   animFrame: 0,
 };
 
+/** Stable empty map used in detail mode to avoid allocating a new Map on every render. */
+const EMPTY_STATUS_MAP: ReadonlyMap<TaskId, string> = new Map();
+
 /**
  * Root dashboard component.
  * Renders to stderr via the render() call in index.tsx.
@@ -162,7 +165,7 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
   // Workspace uses childTaskIds; detail uses a single-element array.
   const streamTaskIds =
     view.kind === 'workspace' ? childTaskIds : detailStreamTaskId !== null ? [detailStreamTaskId] : [];
-  const streamTaskStatuses: ReadonlyMap<TaskId, string> = view.kind === 'workspace' ? childTaskStatuses : new Map();
+  const streamTaskStatuses: ReadonlyMap<TaskId, string> = view.kind === 'workspace' ? childTaskStatuses : EMPTY_STATUS_MAP;
 
   const { streams } = useTaskOutputStream(
     outputRepository ?? ctx.outputRepository,

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -11,6 +11,7 @@
 
 import { Box, useApp } from 'ink';
 import React, { useCallback, useEffect, useReducer } from 'react';
+import type { TaskId } from '../../core/domain.js';
 import type { OutputRepository, ResourceMonitor } from '../../core/interfaces.js';
 import type { ReadOnlyContext } from '../read-only-context.js';
 import { Footer } from './components/footer.js';
@@ -136,14 +137,15 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
 
   // Resolve the task ID(s) to stream in detail mode (#165).
   // Task detail: the task itself. Orchestration detail: the selected child (if any).
-  const detailStreamTaskId: import('../../core/domain.js').TaskId | null = (() => {
+  function resolveDetailStreamTaskId(): TaskId | null {
     if (view.kind !== 'detail' || !outputRepository) return null;
-    if (view.entityType === 'tasks') return view.entityId as import('../../core/domain.js').TaskId;
+    if (view.entityType === 'tasks') return view.entityId as TaskId;
     if (view.entityType === 'orchestrations' && nav.orchestrationChildSelectedTaskId) {
-      return nav.orchestrationChildSelectedTaskId as import('../../core/domain.js').TaskId;
+      return nav.orchestrationChildSelectedTaskId as TaskId;
     }
     return null;
-  })();
+  }
+  const detailStreamTaskId = resolveDetailStreamTaskId();
 
   // Live output streaming:
   //  - Workspace: always enabled when outputRepository is present
@@ -160,8 +162,7 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
   // Workspace uses childTaskIds; detail uses a single-element array.
   const streamTaskIds =
     view.kind === 'workspace' ? childTaskIds : detailStreamTaskId !== null ? [detailStreamTaskId] : [];
-  const streamTaskStatuses: ReadonlyMap<import('../../core/domain.js').TaskId, string> =
-    view.kind === 'workspace' ? childTaskStatuses : new Map();
+  const streamTaskStatuses: ReadonlyMap<TaskId, string> = view.kind === 'workspace' ? childTaskStatuses : new Map();
 
   const { streams } = useTaskOutputStream(
     outputRepository ?? ctx.outputRepository,

--- a/src/cli/dashboard/app.tsx
+++ b/src/cli/dashboard/app.tsx
@@ -225,6 +225,7 @@ export const App: React.FC<AppProps> = React.memo(({ ctx, version, mutations, re
           orchestrationChildSelectedTaskId={nav.orchestrationChildSelectedTaskId}
           orchestrationChildPage={nav.orchestrationChildPage}
           orchestrationChildrenTotal={data?.orchestrationChildrenTotal}
+          loopIterationSelectedNumber={nav.loopIterationSelectedNumber}
         />
       );
     }

--- a/src/cli/dashboard/components/detail-output-panel.tsx
+++ b/src/cli/dashboard/components/detail-output-panel.tsx
@@ -1,0 +1,135 @@
+/**
+ * DetailOutputPanel — shared output-stream panel for task and orchestration detail views
+ * ARCHITECTURE: Pure component — all data passed as props, no side effects
+ * Pattern: Extracts duplicated output rendering logic from task-detail and orchestration-detail
+ *
+ * Exports:
+ *  - DetailOutputConfig: grouped output-related props (visible, autoTail, scrollOffset, terminalRows)
+ *  - useElementHeight: Ink-specific ref-based height measurement hook
+ *  - DetailOutputPanel: separator + empty states + tooSmall guard + OutputStreamView
+ */
+
+import type { DOMElement } from 'ink';
+import { Box, measureElement, Text } from 'ink';
+import React, { useEffect, useRef, useState } from 'react';
+import { computeDetailOutputLayout } from '../layout.js';
+import type { OutputStreamState } from '../use-task-output-stream.js';
+import { OutputStreamView } from './output-stream-view.js';
+
+// ============================================================================
+// DetailOutputConfig — grouped output prop interface
+// ============================================================================
+
+/**
+ * Grouped output-related configuration props for detail views.
+ * Applied to TaskDetailProps, OrchestrationDetailProps, and DetailViewProps
+ * to eliminate scattered individual output props.
+ */
+export interface DetailOutputConfig {
+  /** Whether the output panel is visible */
+  readonly visible: boolean;
+  /** Whether the output auto-tails (follows latest output) */
+  readonly autoTail: boolean;
+  /** Scroll offset when in paused (non-auto-tail) mode */
+  readonly scrollOffset: number;
+  /** Terminal row count for layout computation */
+  readonly terminalRows: number;
+}
+
+// ============================================================================
+// useElementHeight — Ink-specific layout measurement hook
+// ============================================================================
+
+/**
+ * Measures the rendered height of an Ink DOM element after every Yoga layout pass.
+ *
+ * DECISION: No dependency array is intentional. Ink has no useLayoutEffect equivalent;
+ * measureElement() must run after every render so it captures layout changes caused
+ * by polling-driven prop updates (new fields appearing, text reflow). Adding a
+ * dependency array would cause stale heights after data refreshes, breaking the
+ * adaptive output viewport calculation in computeDetailOutputLayout().
+ */
+export function useElementHeight(): [React.RefObject<DOMElement | null>, number] {
+  const ref = useRef<DOMElement>(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (ref.current) {
+      const measured = measureElement(ref.current);
+      if (measured.height !== height) {
+        setHeight(measured.height);
+      }
+    }
+  });
+
+  return [ref, height];
+}
+
+// ============================================================================
+// DetailOutputPanel — shared output section
+// ============================================================================
+
+interface DetailOutputPanelProps {
+  /** The output stream to render */
+  readonly stream: OutputStreamState;
+  /** Task status — drives the "Waiting for output..." vs "No output captured" empty state */
+  readonly taskStatus: string;
+  /** Whether this stream belongs to a queued or running task */
+  readonly isActive: boolean;
+  /** Terminal rows available (used in tooSmall guard) */
+  readonly terminalRows: number;
+  /** Height of the metadata section above this panel (measured via useElementHeight) */
+  readonly metadataHeight: number;
+  /** Scroll offset for paused output mode */
+  readonly scrollOffset: number;
+  /** Whether to auto-tail (follow latest output) */
+  readonly autoTail: boolean;
+  /**
+   * Optional label for the separator line.
+   * - Omit (or pass undefined) for plain ruler: "────────────────────"
+   * - Provide for labelled ruler: "─── Output: <label> ────────"
+   */
+  readonly separatorLabel?: string;
+}
+
+export const DetailOutputPanel: React.FC<DetailOutputPanelProps> = React.memo(
+  ({ stream, isActive, terminalRows, metadataHeight, scrollOffset, autoTail, separatorLabel }) => {
+    const outputLayout = computeDetailOutputLayout({ rows: terminalRows, metadataHeight });
+
+    if (outputLayout.tooSmall) {
+      return (
+        <Box marginTop={0}>
+          <Text dimColor>(terminal too small for output)</Text>
+        </Box>
+      );
+    }
+
+    const separator = separatorLabel !== undefined ? `─── Output: ${separatorLabel} ${'─'.repeat(8)}` : '─'.repeat(20);
+
+    return (
+      <Box flexDirection="column" marginTop={0}>
+        <Text dimColor>{separator}</Text>
+        {stream.lines.length === 0 ? (
+          <Box height={Math.min(3, outputLayout.outputViewportHeight)}>
+            <Text dimColor>
+              {isActive
+                ? 'Waiting for output...'
+                : stream.totalBytes === 0
+                  ? 'No output captured'
+                  : 'Loading output...'}
+            </Text>
+          </Box>
+        ) : (
+          <OutputStreamView
+            stream={stream}
+            viewportHeight={outputLayout.outputViewportHeight}
+            scrollOffset={scrollOffset}
+            autoTail={autoTail}
+          />
+        )}
+      </Box>
+    );
+  },
+);
+
+DetailOutputPanel.displayName = 'DetailOutputPanel';

--- a/src/cli/dashboard/components/detail-output-panel.tsx
+++ b/src/cli/dashboard/components/detail-output-panel.tsx
@@ -72,8 +72,6 @@ export function useElementHeight(): [React.RefObject<DOMElement | null>, number]
 interface DetailOutputPanelProps {
   /** The output stream to render */
   readonly stream: OutputStreamState;
-  /** Task status — drives the "Waiting for output..." vs "No output captured" empty state */
-  readonly taskStatus: string;
   /** Whether this stream belongs to a queued or running task */
   readonly isActive: boolean;
   /** Terminal rows available (used in tooSmall guard) */

--- a/src/cli/dashboard/keyboard/handle-detail-keys.ts
+++ b/src/cli/dashboard/keyboard/handle-detail-keys.ts
@@ -7,236 +7,262 @@
  * output stream controls (o/[/]/g/G), and scroll for non-orchestration detail content.
  */
 
-import type { TaskId } from '../../../core/domain.js';
 import { ORCHESTRATION_CHILDREN_PAGE_SIZE } from '../views/orchestration-detail.js';
 import { resolveChildIndex, resolveIterationIndex } from './helpers.js';
 import type { InkKey, KeyHandlerParams } from './types.js';
 
+// ─── Section handlers ────────────────────────────────────────────────────────
+
 /**
- * Handle key input while in the detail view.
- * Returns true if the key was consumed.
+ * 1. Esc/Backspace — return to the view that opened this detail.
  *
- * D3 drill-through (v1.3.0):
- *  - Orchestration detail: ↑/↓/j/k move child row selection (by taskId)
- *  - Enter: drill into selected child's task detail (returnTo = orchestration object)
- *  - PgUp/PgDn: navigate pages of children (resets selection to first row on page)
- *  - Esc/Backspace: returns to the view encoded in returnTo (main, workspace, or orchestration)
+ * D3 drill-through Esc: return to the parent orchestration or loop detail.
+ * Otherwise: return to workspace or main.
+ */
+function handleEscReturn(key: InkKey, params: KeyHandlerParams): boolean {
+  const { view, setView } = params;
+  if (view.kind !== 'detail') return false;
+  if (!key.escape && !key.backspace) return false;
+
+  const returnTo = view.returnTo ?? 'main';
+  if (typeof returnTo === 'object' && returnTo.kind === 'orchestrations') {
+    // D3 drill-through Esc: return to the parent orchestration detail
+    setView({
+      kind: 'detail',
+      entityType: 'orchestrations',
+      entityId: returnTo.entityId,
+      returnTo: returnTo.originalReturnTo,
+    });
+  } else if (typeof returnTo === 'object' && returnTo.kind === 'loops') {
+    // #168: loop drill-through Esc: return to the parent loop detail
+    setView({
+      kind: 'detail',
+      entityType: 'loops',
+      entityId: returnTo.entityId,
+      returnTo: returnTo.originalReturnTo,
+    });
+  } else if (returnTo === 'workspace') {
+    setView({ kind: 'workspace' });
+  } else {
+    setView({ kind: 'main' });
+  }
+  return true;
+}
+
+/**
+ * 2. Output stream controls — guarded to task/orchestration entity types (#165).
  *
- * Loop iteration navigation (#168):
- *  - Loop detail: ↑/↓/j/k move iteration selection (by iterationNumber)
- *  - Enter: drill into selected iteration's task detail (returnTo = loop object)
- *  - Esc: returns to the view encoded in returnTo (main, workspace, or loop)
- *
- * Output controls (#165 — task/orchestration only):
  *  - o: toggle output stream panel visibility
  *  - [: scroll output up (enters paused mode)
- *  - ]: scroll output down
+ *  - ]: scroll output down (enters paused mode)
  *  - g: jump to top of output (paused mode)
  *  - G: jump to tail (re-engages auto-tail)
  *
- * For non-orchestration/non-loop detail views, ↑/↓ scroll the detail content as before.
- *
- * Key handler ordering:
- *  1. Esc/Backspace → return to previous view
- *  2. Output controls (o/[/]/g/G) → guarded to task/orchestration only
- *  3. Loop entity type → iteration navigation (↑/↓/Enter)
- *  4. Orchestration entity type → child navigation (existing D3 pattern)
- *  5. Generic scroll (↑/↓) → non-orchestration/non-loop detail (schedules, pipelines)
+ * OutputStreamView clamps the visual offset internally; the upper bound is not
+ * tracked here because the key handler has no access to the live line count.
  */
-export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerParams): boolean {
-  const { view, nav, setView, setNav, detailContentLength, refreshNow } = params;
+function handleOutputControls(input: string, params: KeyHandlerParams): boolean {
+  const { view, setNav } = params;
+  if (view.kind !== 'detail') return false;
+  if (view.entityType !== 'tasks' && view.entityType !== 'orchestrations') return false;
+
+  if (input === 'o') {
+    setNav((prev) => ({ ...prev, detailOutputVisible: !prev.detailOutputVisible }));
+    return true;
+  }
+  if (input === '[') {
+    setNav((prev) => ({
+      ...prev,
+      detailOutputScrollOffset: Math.max(0, prev.detailOutputScrollOffset - 1),
+      detailOutputAutoTail: false,
+    }));
+    return true;
+  }
+  if (input === ']') {
+    setNav((prev) => ({
+      ...prev,
+      detailOutputScrollOffset: prev.detailOutputScrollOffset + 1,
+      detailOutputAutoTail: false,
+    }));
+    return true;
+  }
+  if (input === 'G') {
+    setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: true }));
+    return true;
+  }
+  if (input === 'g') {
+    setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: false }));
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * 3. Loop detail: iteration row navigation (#168).
+ *
+ *  - ↑/k: move selection up
+ *  - ↓/j: move selection down
+ *  - Enter: drill into the selected iteration's task detail (returnTo = loop object)
+ *  - Any other key: swallowed (no fallthrough)
+ */
+function handleLoopNavigation(input: string, key: InkKey, params: KeyHandlerParams): boolean {
+  const { view, nav, setView, setNav } = params;
+  if (view.kind !== 'detail') return false;
+  if (view.entityType !== 'loops') return false;
+
+  const iterations = params.dataRef.current?.iterations ?? [];
+
+  if (key.upArrow || input === 'k') {
+    if (iterations.length === 0) return true;
+    setNav((prev) => {
+      const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
+      const nextIdx = Math.max(0, currentIdx - 1);
+      return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
+    });
+    return true;
+  }
+
+  if (key.downArrow || input === 'j') {
+    if (iterations.length === 0) return true;
+    setNav((prev) => {
+      const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
+      const nextIdx = Math.min(iterations.length - 1, currentIdx + 1);
+      return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
+    });
+    return true;
+  }
+
+  if (key.return) {
+    // Enter: drill into the selected iteration's task detail
+    if (iterations.length === 0) return true;
+    const selectedIdx = resolveIterationIndex(nav.loopIterationSelectedNumber, iterations);
+    const iter = iterations[selectedIdx];
+    if (!iter || !iter.taskId) return true; // guard: no taskId means nothing to drill into
+    const originalReturnTo: 'main' | 'workspace' = view.returnTo === 'workspace' ? 'workspace' : 'main';
+    setView({
+      kind: 'detail',
+      entityType: 'tasks',
+      entityId: iter.taskId,
+      returnTo: {
+        kind: 'loops',
+        entityId: view.entityId,
+        originalReturnTo,
+      },
+    });
+    return true;
+  }
+
+  // Any other key in loop detail is swallowed (no fallthrough to main handler)
+  return true;
+}
+
+/**
+ * 4. D3 orchestration detail: child row navigation + drill-through.
+ *
+ *  - ↑/k: move child selection up
+ *  - ↓/j: move child selection down
+ *  - Enter: drill into the selected child task detail (returnTo = orchestration object)
+ *  - PgUp/PgDn: navigate pages of children (resets selection to first row on page)
+ *  - Any other key: swallowed (no fallthrough)
+ */
+function handleOrchestrationNavigation(input: string, key: InkKey, params: KeyHandlerParams): boolean {
+  const { view, nav, setView, setNav, refreshNow } = params;
+  if (view.kind !== 'detail') return false;
+  if (view.entityType !== 'orchestrations') return false;
+
+  const children = params.dataRef.current?.orchestrationChildren ?? [];
+  const childrenTotal = params.dataRef.current?.orchestrationChildrenTotal;
+
+  if (key.upArrow || input === 'k') {
+    if (children.length === 0) return true;
+    setNav((prev) => {
+      const nextIdx = Math.max(0, resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) - 1);
+      return {
+        ...prev,
+        orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
+        detailOutputAutoTail: true,
+        detailOutputScrollOffset: 0,
+      };
+    });
+    return true;
+  }
+
+  if (key.downArrow || input === 'j') {
+    if (children.length === 0) return true;
+    setNav((prev) => {
+      const nextIdx = Math.min(
+        children.length - 1,
+        resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) + 1,
+      );
+      return {
+        ...prev,
+        orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
+        detailOutputAutoTail: true,
+        detailOutputScrollOffset: 0,
+      };
+    });
+    return true;
+  }
+
+  if (key.return) {
+    // Enter: drill into the selected child task detail
+    if (children.length === 0) return true;
+    const child = children[resolveChildIndex(nav.orchestrationChildSelectedTaskId, children)];
+    if (!child) return true;
+    const originalReturnTo: 'main' | 'workspace' = view.returnTo === 'workspace' ? 'workspace' : 'main';
+    setView({
+      kind: 'detail',
+      entityType: 'tasks',
+      entityId: child.taskId,
+      returnTo: {
+        kind: 'orchestrations',
+        entityId: view.entityId,
+        originalReturnTo,
+      },
+    });
+    return true;
+  }
+
+  if (key.pageUp) {
+    setNav((prev) => {
+      const newPage = Math.max(0, prev.orchestrationChildPage - 1);
+      if (newPage === prev.orchestrationChildPage) return prev;
+      return { ...prev, orchestrationChildPage: newPage, orchestrationChildSelectedTaskId: null };
+    });
+    // The useDashboardData effect auto-refetches when orchestrationChildPage
+    // changes; refreshNow() is called as a belt-and-braces signal so any
+    // listener (telemetry, manual indicator) also sees the page-change event.
+    refreshNow();
+    return true;
+  }
+
+  if (key.pageDown) {
+    const totalPages = childrenTotal !== undefined ? Math.ceil(childrenTotal / ORCHESTRATION_CHILDREN_PAGE_SIZE) : 1;
+    setNav((prev) => {
+      const newPage = Math.min(totalPages - 1, prev.orchestrationChildPage + 1);
+      if (newPage === prev.orchestrationChildPage) return prev;
+      return { ...prev, orchestrationChildPage: newPage, orchestrationChildSelectedTaskId: null };
+    });
+    refreshNow();
+    return true;
+  }
+
+  // Any other key in orchestration detail is swallowed
+  return true;
+}
+
+/**
+ * 5. Generic scroll for non-orchestration/non-loop detail views (schedules, pipelines).
+ *
+ *  - ↑/k: scroll detail content up
+ *  - ↓/j: scroll detail content down (clamped to detailContentLength - 1)
+ *  - Any other key: swallowed (no fallthrough to main handler)
+ */
+function handleGenericScroll(input: string, key: InkKey, params: KeyHandlerParams): boolean {
+  const { view, setNav, detailContentLength } = params;
   if (view.kind !== 'detail') return false;
 
-  // 1. Esc/Backspace — return to the view that opened this detail
-  if (key.escape || key.backspace) {
-    const returnTo = view.returnTo ?? 'main';
-    if (typeof returnTo === 'object' && returnTo.kind === 'orchestrations') {
-      // D3 drill-through Esc: return to the parent orchestration detail
-      setView({
-        kind: 'detail',
-        entityType: 'orchestrations',
-        entityId: returnTo.entityId,
-        returnTo: returnTo.originalReturnTo,
-      });
-    } else if (typeof returnTo === 'object' && returnTo.kind === 'loops') {
-      // #168: loop drill-through Esc: return to the parent loop detail
-      setView({
-        kind: 'detail',
-        entityType: 'loops',
-        entityId: returnTo.entityId,
-        returnTo: returnTo.originalReturnTo,
-      });
-    } else if (returnTo === 'workspace') {
-      setView({ kind: 'workspace' });
-    } else {
-      setView({ kind: 'main' });
-    }
-    return true;
-  }
-
-  // 2. Output controls — guarded to task/orchestration only (#165)
-  if (view.entityType === 'tasks' || view.entityType === 'orchestrations') {
-    if (input === 'o') {
-      setNav((prev) => ({ ...prev, detailOutputVisible: !prev.detailOutputVisible }));
-      return true;
-    }
-    if (input === '[') {
-      setNav((prev) => ({
-        ...prev,
-        detailOutputScrollOffset: Math.max(0, prev.detailOutputScrollOffset - 1),
-        detailOutputAutoTail: false,
-      }));
-      return true;
-    }
-    if (input === ']') {
-      setNav((prev) => ({
-        ...prev,
-        detailOutputScrollOffset: prev.detailOutputScrollOffset + 1,
-      }));
-      return true;
-    }
-    if (input === 'G') {
-      setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: true }));
-      return true;
-    }
-    if (input === 'g') {
-      setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: false }));
-      return true;
-    }
-  }
-
-  // 3. Loop detail: iteration navigation (#168)
-  if (view.entityType === 'loops') {
-    const iterations = params.dataRef.current?.iterations ?? [];
-
-    if (key.upArrow || input === 'k') {
-      if (iterations.length === 0) return true;
-      setNav((prev) => {
-        const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
-        const nextIdx = Math.max(0, currentIdx - 1);
-        return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
-      });
-      return true;
-    }
-
-    if (key.downArrow || input === 'j') {
-      if (iterations.length === 0) return true;
-      setNav((prev) => {
-        const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
-        const nextIdx = Math.min(iterations.length - 1, currentIdx + 1);
-        return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
-      });
-      return true;
-    }
-
-    if (key.return) {
-      // Enter: drill into the selected iteration's task detail
-      if (iterations.length === 0) return true;
-      const selectedIdx = resolveIterationIndex(nav.loopIterationSelectedNumber, iterations);
-      const iter = iterations[selectedIdx];
-      if (!iter || !iter.taskId) return true; // guard: no taskId means nothing to drill into
-      const originalReturnTo: 'main' | 'workspace' = view.returnTo === 'workspace' ? 'workspace' : 'main';
-      setView({
-        kind: 'detail',
-        entityType: 'tasks',
-        entityId: iter.taskId as TaskId,
-        returnTo: {
-          kind: 'loops',
-          entityId: view.entityId,
-          originalReturnTo,
-        },
-      });
-      return true;
-    }
-
-    // Any other key in loop detail is swallowed
-    return true;
-  }
-
-  // 4. D3 orchestration detail: child row navigation + drill-through
-  if (view.entityType === 'orchestrations') {
-    const children = params.dataRef.current?.orchestrationChildren ?? [];
-    const childrenTotal = params.dataRef.current?.orchestrationChildrenTotal;
-
-    if (key.upArrow || input === 'k') {
-      if (children.length === 0) return true;
-      setNav((prev) => {
-        const nextIdx = Math.max(0, resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) - 1);
-        return {
-          ...prev,
-          orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
-          detailOutputAutoTail: true,
-          detailOutputScrollOffset: 0,
-        };
-      });
-      return true;
-    }
-
-    if (key.downArrow || input === 'j') {
-      if (children.length === 0) return true;
-      setNav((prev) => {
-        const nextIdx = Math.min(
-          children.length - 1,
-          resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) + 1,
-        );
-        return {
-          ...prev,
-          orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
-          detailOutputAutoTail: true,
-          detailOutputScrollOffset: 0,
-        };
-      });
-      return true;
-    }
-
-    if (key.return) {
-      // Enter: drill into the selected child task detail
-      if (children.length === 0) return true;
-      const child = children[resolveChildIndex(nav.orchestrationChildSelectedTaskId, children)];
-      if (!child) return true;
-      const originalReturnTo: 'main' | 'workspace' = view.returnTo === 'workspace' ? 'workspace' : 'main';
-      setView({
-        kind: 'detail',
-        entityType: 'tasks',
-        entityId: child.taskId as TaskId,
-        returnTo: {
-          kind: 'orchestrations',
-          entityId: view.entityId,
-          originalReturnTo,
-        },
-      });
-      return true;
-    }
-
-    if (key.pageUp) {
-      setNav((prev) => {
-        const newPage = Math.max(0, prev.orchestrationChildPage - 1);
-        if (newPage === prev.orchestrationChildPage) return prev;
-        return { ...prev, orchestrationChildPage: newPage, orchestrationChildSelectedTaskId: null };
-      });
-      // The useDashboardData effect auto-refetches when orchestrationChildPage
-      // changes; refreshNow() is called as a belt-and-braces signal so any
-      // listener (telemetry, manual indicator) also sees the page-change event.
-      refreshNow();
-      return true;
-    }
-
-    if (key.pageDown) {
-      const totalPages = childrenTotal !== undefined ? Math.ceil(childrenTotal / ORCHESTRATION_CHILDREN_PAGE_SIZE) : 1;
-      setNav((prev) => {
-        const newPage = Math.min(totalPages - 1, prev.orchestrationChildPage + 1);
-        if (newPage === prev.orchestrationChildPage) return prev;
-        return { ...prev, orchestrationChildPage: newPage, orchestrationChildSelectedTaskId: null };
-      });
-      refreshNow();
-      return true;
-    }
-
-    // Any other key in orchestration detail is swallowed
-    return true;
-  }
-
-  // 5. Non-orchestration/non-loop detail: ↑/↓ scroll the content
   if (key.upArrow || input === 'k') {
     setNav((prev) => ({
       ...prev,
@@ -263,4 +289,49 @@ export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerP
 
   // Any other key in detail view is swallowed (no fallthrough to main handler)
   return true;
+}
+
+// ─── Main dispatcher ─────────────────────────────────────────────────────────
+
+/**
+ * Handle key input while in the detail view.
+ * Returns true if the key was consumed.
+ *
+ * D3 drill-through (v1.3.0):
+ *  - Orchestration detail: ↑/↓/j/k move child row selection (by taskId)
+ *  - Enter: drill into selected child's task detail (returnTo = orchestration object)
+ *  - PgUp/PgDn: navigate pages of children (resets selection to first row on page)
+ *  - Esc/Backspace: returns to the view encoded in returnTo (main, workspace, or orchestration)
+ *
+ * Loop iteration navigation (#168):
+ *  - Loop detail: ↑/↓/j/k move iteration selection (by iterationNumber)
+ *  - Enter: drill into selected iteration's task detail (returnTo = loop object)
+ *  - Esc: returns to the view encoded in returnTo (main, workspace, or loop)
+ *
+ * Output controls (#165 — task/orchestration only):
+ *  - o: toggle output stream panel visibility
+ *  - [: scroll output up (enters paused mode)
+ *  - ]: scroll output down (enters paused mode)
+ *  - g: jump to top of output (paused mode)
+ *  - G: jump to tail (re-engages auto-tail)
+ *
+ * For non-orchestration/non-loop detail views, ↑/↓ scroll the detail content as before.
+ *
+ * Key handler ordering:
+ *  1. Esc/Backspace → return to previous view
+ *  2. Output controls (o/[/]/g/G) → guarded to task/orchestration only
+ *  3. Loop entity type → iteration navigation (↑/↓/Enter)
+ *  4. Orchestration entity type → child navigation (existing D3 pattern)
+ *  5. Generic scroll (↑/↓) → non-orchestration/non-loop detail (schedules, pipelines)
+ */
+export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerParams): boolean {
+  if (params.view.kind !== 'detail') return false;
+
+  return (
+    handleEscReturn(key, params) ||
+    handleOutputControls(input, params) ||
+    handleLoopNavigation(input, key, params) ||
+    handleOrchestrationNavigation(input, key, params) ||
+    handleGenericScroll(input, key, params)
+  );
 }

--- a/src/cli/dashboard/keyboard/handle-detail-keys.ts
+++ b/src/cli/dashboard/keyboard/handle-detail-keys.ts
@@ -3,12 +3,13 @@
  *
  * Scope: view.kind === 'detail'. Handles Esc/Backspace to return to the
  * previous view, D3 orchestration drill-through child row navigation
- * (↑/↓/Enter/PgUp/PgDn), and scroll for non-orchestration detail content.
+ * (↑/↓/Enter/PgUp/PgDn), loop iteration navigation (↑/↓/Enter),
+ * output stream controls (o/[/]/g/G), and scroll for non-orchestration detail content.
  */
 
 import type { TaskId } from '../../../core/domain.js';
 import { ORCHESTRATION_CHILDREN_PAGE_SIZE } from '../views/orchestration-detail.js';
-import { resolveChildIndex } from './helpers.js';
+import { resolveChildIndex, resolveIterationIndex } from './helpers.js';
 import type { InkKey, KeyHandlerParams } from './types.js';
 
 /**
@@ -21,20 +22,47 @@ import type { InkKey, KeyHandlerParams } from './types.js';
  *  - PgUp/PgDn: navigate pages of children (resets selection to first row on page)
  *  - Esc/Backspace: returns to the view encoded in returnTo (main, workspace, or orchestration)
  *
- * For non-orchestration detail views, ↑/↓ scroll the detail content as before.
+ * Loop iteration navigation (#168):
+ *  - Loop detail: ↑/↓/j/k move iteration selection (by iterationNumber)
+ *  - Enter: drill into selected iteration's task detail (returnTo = loop object)
+ *  - Esc: returns to the view encoded in returnTo (main, workspace, or loop)
+ *
+ * Output controls (#165 — task/orchestration only):
+ *  - o: toggle output stream panel visibility
+ *  - [: scroll output up (enters paused mode)
+ *  - ]: scroll output down
+ *  - g: jump to top of output (paused mode)
+ *  - G: jump to tail (re-engages auto-tail)
+ *
+ * For non-orchestration/non-loop detail views, ↑/↓ scroll the detail content as before.
+ *
+ * Key handler ordering:
+ *  1. Esc/Backspace → return to previous view
+ *  2. Output controls (o/[/]/g/G) → guarded to task/orchestration only
+ *  3. Loop entity type → iteration navigation (↑/↓/Enter)
+ *  4. Orchestration entity type → child navigation (existing D3 pattern)
+ *  5. Generic scroll (↑/↓) → non-orchestration/non-loop detail (schedules, pipelines)
  */
 export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerParams): boolean {
   const { view, nav, setView, setNav, detailContentLength, refreshNow } = params;
   if (view.kind !== 'detail') return false;
 
+  // 1. Esc/Backspace — return to the view that opened this detail
   if (key.escape || key.backspace) {
-    // Return to the view that opened this detail (returnTo defaults to 'main')
     const returnTo = view.returnTo ?? 'main';
     if (typeof returnTo === 'object' && returnTo.kind === 'orchestrations') {
       // D3 drill-through Esc: return to the parent orchestration detail
       setView({
         kind: 'detail',
         entityType: 'orchestrations',
+        entityId: returnTo.entityId,
+        returnTo: returnTo.originalReturnTo,
+      });
+    } else if (typeof returnTo === 'object' && returnTo.kind === 'loops') {
+      // #168: loop drill-through Esc: return to the parent loop detail
+      setView({
+        kind: 'detail',
+        entityType: 'loops',
         entityId: returnTo.entityId,
         returnTo: returnTo.originalReturnTo,
       });
@@ -46,7 +74,86 @@ export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerP
     return true;
   }
 
-  // D3 orchestration detail: child row navigation + drill-through
+  // 2. Output controls — guarded to task/orchestration only (#165)
+  if (view.entityType === 'tasks' || view.entityType === 'orchestrations') {
+    if (input === 'o') {
+      setNav((prev) => ({ ...prev, detailOutputVisible: !prev.detailOutputVisible }));
+      return true;
+    }
+    if (input === '[') {
+      setNav((prev) => ({
+        ...prev,
+        detailOutputScrollOffset: Math.max(0, prev.detailOutputScrollOffset - 1),
+        detailOutputAutoTail: false,
+      }));
+      return true;
+    }
+    if (input === ']') {
+      setNav((prev) => ({
+        ...prev,
+        detailOutputScrollOffset: prev.detailOutputScrollOffset + 1,
+      }));
+      return true;
+    }
+    if (input === 'G') {
+      setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: true }));
+      return true;
+    }
+    if (input === 'g') {
+      setNav((prev) => ({ ...prev, detailOutputScrollOffset: 0, detailOutputAutoTail: false }));
+      return true;
+    }
+  }
+
+  // 3. Loop detail: iteration navigation (#168)
+  if (view.entityType === 'loops') {
+    const iterations = params.dataRef.current?.iterations ?? [];
+
+    if (key.upArrow || input === 'k') {
+      if (iterations.length === 0) return true;
+      setNav((prev) => {
+        const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
+        const nextIdx = Math.max(0, currentIdx - 1);
+        return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
+      });
+      return true;
+    }
+
+    if (key.downArrow || input === 'j') {
+      if (iterations.length === 0) return true;
+      setNav((prev) => {
+        const currentIdx = resolveIterationIndex(prev.loopIterationSelectedNumber, iterations);
+        const nextIdx = Math.min(iterations.length - 1, currentIdx + 1);
+        return { ...prev, loopIterationSelectedNumber: iterations[nextIdx]?.iterationNumber ?? null };
+      });
+      return true;
+    }
+
+    if (key.return) {
+      // Enter: drill into the selected iteration's task detail
+      if (iterations.length === 0) return true;
+      const selectedIdx = resolveIterationIndex(nav.loopIterationSelectedNumber, iterations);
+      const iter = iterations[selectedIdx];
+      if (!iter || !iter.taskId) return true; // guard: no taskId means nothing to drill into
+      const originalReturnTo: 'main' | 'workspace' = view.returnTo === 'workspace' ? 'workspace' : 'main';
+      setView({
+        kind: 'detail',
+        entityType: 'tasks',
+        entityId: iter.taskId as TaskId,
+        returnTo: {
+          kind: 'loops',
+          entityId: view.entityId,
+          originalReturnTo,
+        },
+      });
+      return true;
+    }
+
+    // Any other key in loop detail is swallowed
+    return true;
+  }
+
+  // 4. D3 orchestration detail: child row navigation + drill-through
   if (view.entityType === 'orchestrations') {
     const children = params.dataRef.current?.orchestrationChildren ?? [];
     const childrenTotal = params.dataRef.current?.orchestrationChildrenTotal;
@@ -55,7 +162,12 @@ export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerP
       if (children.length === 0) return true;
       setNav((prev) => {
         const nextIdx = Math.max(0, resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) - 1);
-        return { ...prev, orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null };
+        return {
+          ...prev,
+          orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
+          detailOutputAutoTail: true,
+          detailOutputScrollOffset: 0,
+        };
       });
       return true;
     }
@@ -67,7 +179,12 @@ export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerP
           children.length - 1,
           resolveChildIndex(prev.orchestrationChildSelectedTaskId, children) + 1,
         );
-        return { ...prev, orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null };
+        return {
+          ...prev,
+          orchestrationChildSelectedTaskId: children[nextIdx]?.taskId ?? null,
+          detailOutputAutoTail: true,
+          detailOutputScrollOffset: 0,
+        };
       });
       return true;
     }
@@ -119,7 +236,7 @@ export function handleDetailKeys(input: string, key: InkKey, params: KeyHandlerP
     return true;
   }
 
-  // Non-orchestration detail: ↑/↓ scroll the content
+  // 5. Non-orchestration/non-loop detail: ↑/↓ scroll the content
   if (key.upArrow || input === 'k') {
     setNav((prev) => ({
       ...prev,

--- a/src/cli/dashboard/keyboard/handle-main-keys.ts
+++ b/src/cli/dashboard/keyboard/handle-main-keys.ts
@@ -100,10 +100,19 @@ export function handleMainKeys(input: string, key: InkKey, params: KeyHandlerPar
     const filteredItems = filter !== null ? allItems.filter((item) => item.status === filter) : allItems;
     const selectedItem = filteredItems[nav.selectedIndices[panel]];
     if (selectedItem === undefined) return true;
-    // Reset scroll offset for detail view so it starts at top, not at the main-list position
+    // Reset scroll offset and output/iteration state when drilling into a detail view.
+    // DECISION (#165/#168): Only reset here (main→detail transition), not in SET_VIEW reducer,
+    // because the reducer fires on ALL view transitions including Esc returns. Resetting here
+    // ensures each new entity opens with a clean output/iteration state while returning to a
+    // detail (Esc from a drilled-through task) preserves the user's previous state.
     setNav((prev) => ({
       ...prev,
       scrollOffsets: { ...prev.scrollOffsets, [panel]: 0 },
+      // Output stream: visible for task detail, hidden for all others (no output concept)
+      detailOutputVisible: panel === 'tasks',
+      detailOutputAutoTail: true,
+      detailOutputScrollOffset: 0,
+      loopIterationSelectedNumber: null,
     }));
     // Cast id back to the branded type for the discriminated ViewState union.
     // The id originates from the domain entity — the cast is safe at this boundary.

--- a/src/cli/dashboard/keyboard/helpers.ts
+++ b/src/cli/dashboard/keyboard/helpers.ts
@@ -83,6 +83,24 @@ export function panelToEntityKind(panelId: PanelId): EntityKind {
 }
 
 /**
+ * Resolve the currently selected iteration index from an iterationNumber.
+ * Returns 0 when no number is set, when the number is not found, or when the
+ * iterations array is empty. Mirrors resolveChildIndex but for loop iterations.
+ *
+ * DECISION (#168): Loop iteration selection mirrors the D3 orchestration
+ * drill-through pattern — selection is tracked by iterationNumber (stable
+ * domain key) rather than array index (changes when new iterations arrive).
+ */
+export function resolveIterationIndex(
+  selectedNumber: number | null,
+  iterations: readonly { iterationNumber: number }[],
+): number {
+  if (selectedNumber === null) return 0;
+  const idx = iterations.findIndex((i) => i.iterationNumber === selectedNumber);
+  return idx >= 0 ? idx : 0;
+}
+
+/**
  * Return the currently selected item in the focused panel, or null if data is absent.
  * Applies the active filter before resolving the selection index.
  * Used by the 'c' (cancel) and 'd' (delete) handlers in the main panel.

--- a/src/cli/dashboard/keyboard/hints.ts
+++ b/src/cli/dashboard/keyboard/hints.ts
@@ -28,9 +28,10 @@ export function workspaceHints(): string {
 
 /**
  * Return the footer hint string for the detail view.
+ * Output controls (o/[/]/g/G) apply to task and orchestration detail only.
  */
 export function detailHints(): string {
-  return 'Esc back · ↑↓ scroll · r refresh · q quit';
+  return 'Esc back · ↑↓ select · Enter detail · o output · [/] scroll · G tail · r refresh · q quit';
 }
 
 /**

--- a/src/cli/dashboard/layout.ts
+++ b/src/cli/dashboard/layout.ts
@@ -95,6 +95,38 @@ export function computeMetricsLayout(args: { columns: number; rows: number }): M
 }
 
 // ============================================================================
+// computeDetailOutputLayout
+// ============================================================================
+
+export interface DetailOutputLayout {
+  /** Number of terminal rows available for the output viewport */
+  readonly outputViewportHeight: number;
+  /** True when there is insufficient space to show output meaningfully (< 5 rows) */
+  readonly tooSmall: boolean;
+}
+
+/**
+ * Compute the output viewport height for a task or orchestration detail view.
+ *
+ * Layout structure (chrome = 4 rows):
+ *   - header: 2 rows
+ *   - footer: 1 row
+ *   - separator between metadata and output: 1 row
+ *
+ * Available rows = rows - metadataHeight - chrome.
+ * When available < 5, the terminal is too small to render the output usefully.
+ *
+ * DECISION (#165): Pure function so it can be tested without React mounting.
+ * The metadataHeight is measured via Ink's measureElement() in the view components.
+ */
+export function computeDetailOutputLayout(args: { rows: number; metadataHeight: number }): DetailOutputLayout {
+  const chrome = 4; // header(2) + footer(1) + separator(1)
+  const available = args.rows - args.metadataHeight - chrome;
+  if (available < 5) return { outputViewportHeight: 0, tooSmall: true };
+  return { outputViewportHeight: available, tooSmall: false };
+}
+
+// ============================================================================
 // computeWorkspaceLayout
 // ============================================================================
 

--- a/src/cli/dashboard/types.ts
+++ b/src/cli/dashboard/types.ts
@@ -72,6 +72,11 @@ export type DetailReturnTarget =
       readonly kind: 'orchestrations';
       readonly entityId: OrchestratorId;
       readonly originalReturnTo: 'main' | 'workspace';
+    }
+  | {
+      readonly kind: 'loops';
+      readonly entityId: LoopId;
+      readonly originalReturnTo: 'main' | 'workspace';
     };
 
 /**
@@ -138,6 +143,14 @@ export interface NavState {
   readonly orchestrationChildSelectedTaskId: string | null;
   /** 0-based page number within the orchestration detail children list */
   readonly orchestrationChildPage: number;
+  /** Whether the output stream panel is visible in task/orchestration detail (#165) */
+  readonly detailOutputVisible: boolean;
+  /** Whether output auto-tails (true) or is paused for manual scrolling (false) (#165) */
+  readonly detailOutputAutoTail: boolean;
+  /** Scroll offset when output is in paused mode (#165) */
+  readonly detailOutputScrollOffset: number;
+  /** iterationNumber of the highlighted row in loop detail (null = first row) (#168) */
+  readonly loopIterationSelectedNumber: number | null;
 }
 
 /**

--- a/src/cli/dashboard/views/detail-view.tsx
+++ b/src/cli/dashboard/views/detail-view.tsx
@@ -39,10 +39,10 @@ function resolveTaskDependencyInfo(
         })
       : undefined;
 
-  const rawDependents = allTasks
+  const dependentsList = allTasks
     ?.filter((t) => t.dependsOn?.includes(taskId as TaskId))
     .map((t) => ({ taskId: t.id, status: t.status }));
-  const dependents = rawDependents && rawDependents.length > 0 ? rawDependents : undefined;
+  const dependents = dependentsList && dependentsList.length > 0 ? dependentsList : undefined;
 
   return { dependencies, dependents };
 }

--- a/src/cli/dashboard/views/detail-view.tsx
+++ b/src/cli/dashboard/views/detail-view.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from 'ink';
 import React from 'react';
 import type { Task, TaskId } from '../../../core/domain.js';
+import type { DetailOutputConfig } from '../components/detail-output-panel.js';
 import type { DashboardData, PanelId } from '../types.js';
 import type { OutputStreamState } from '../use-task-output-stream.js';
 import { LoopDetail } from './loop-detail.js';
@@ -62,14 +63,8 @@ interface DetailViewProps {
   readonly loopIterationSelectedNumber?: number | null;
   /** #165: live output streams map — keyed by TaskId */
   readonly taskStreams?: ReadonlyMap<TaskId, OutputStreamState>;
-  /** #165: whether the output panel is visible */
-  readonly detailOutputVisible?: boolean;
-  /** #165: whether output auto-tails */
-  readonly detailOutputAutoTail?: boolean;
-  /** #165: scroll offset for paused output mode */
-  readonly detailOutputScrollOffset?: number;
-  /** #165: terminal row count for output layout computation */
-  readonly terminalRows?: number;
+  /** #165: grouped output panel configuration — required; app.tsx always provides explicit values */
+  readonly detailOutputConfig: DetailOutputConfig;
 }
 
 const NotFound: React.FC<{ entityType: PanelId; entityId: string }> = ({ entityType, entityId }) => (
@@ -90,10 +85,7 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
     orchestrationChildrenTotal,
     loopIterationSelectedNumber = null,
     taskStreams,
-    detailOutputVisible = true,
-    detailOutputAutoTail = true,
-    detailOutputScrollOffset = 0,
-    terminalRows = 24,
+    detailOutputConfig,
   }) => {
     switch (entityType) {
       case 'loops': {
@@ -124,10 +116,7 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
             dependencies={dependencies}
             dependents={dependents}
             stream={taskStream}
-            outputVisible={detailOutputVisible}
-            outputAutoTail={detailOutputAutoTail}
-            outputScrollOffset={detailOutputScrollOffset}
-            terminalRows={terminalRows}
+            outputConfig={detailOutputConfig}
           />
         );
       }
@@ -156,10 +145,7 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
             currentPage={orchestrationChildPage}
             childrenTotal={orchestrationChildrenTotal}
             taskStreams={taskStreams}
-            childOutputVisible={detailOutputVisible}
-            childOutputAutoTail={detailOutputAutoTail}
-            childOutputScrollOffset={detailOutputScrollOffset}
-            terminalRows={terminalRows}
+            childOutputConfig={detailOutputConfig}
           />
         );
       }

--- a/src/cli/dashboard/views/detail-view.tsx
+++ b/src/cli/dashboard/views/detail-view.tsx
@@ -57,6 +57,8 @@ interface DetailViewProps {
   readonly orchestrationChildPage?: number;
   /** D3 drill-through: total count of children for pagination footer */
   readonly orchestrationChildrenTotal?: number;
+  /** #168: iterationNumber of the highlighted row in loop detail */
+  readonly loopIterationSelectedNumber?: number | null;
 }
 
 const NotFound: React.FC<{ entityType: PanelId; entityId: string }> = ({ entityType, entityId }) => (
@@ -75,13 +77,20 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
     orchestrationChildSelectedTaskId,
     orchestrationChildPage = 0,
     orchestrationChildrenTotal,
+    loopIterationSelectedNumber = null,
   }) => {
     switch (entityType) {
       case 'loops': {
         const loop = data?.loops.find((l) => l.id === entityId);
         if (loop === undefined) return <NotFound entityType={entityType} entityId={entityId} />;
         return (
-          <LoopDetail loop={loop} iterations={data?.iterations} scrollOffset={scrollOffset} animFrame={animFrame} />
+          <LoopDetail
+            loop={loop}
+            iterations={data?.iterations}
+            scrollOffset={scrollOffset}
+            animFrame={animFrame}
+            selectedIterationNumber={loopIterationSelectedNumber}
+          />
         );
       }
       case 'tasks': {

--- a/src/cli/dashboard/views/detail-view.tsx
+++ b/src/cli/dashboard/views/detail-view.tsx
@@ -8,6 +8,7 @@ import { Box, Text } from 'ink';
 import React from 'react';
 import type { Task, TaskId } from '../../../core/domain.js';
 import type { DashboardData, PanelId } from '../types.js';
+import type { OutputStreamState } from '../use-task-output-stream.js';
 import { LoopDetail } from './loop-detail.js';
 import { OrchestrationDetail } from './orchestration-detail.js';
 import { PipelineDetail } from './pipeline-detail.js';
@@ -59,6 +60,16 @@ interface DetailViewProps {
   readonly orchestrationChildrenTotal?: number;
   /** #168: iterationNumber of the highlighted row in loop detail */
   readonly loopIterationSelectedNumber?: number | null;
+  /** #165: live output streams map — keyed by TaskId */
+  readonly taskStreams?: ReadonlyMap<TaskId, OutputStreamState>;
+  /** #165: whether the output panel is visible */
+  readonly detailOutputVisible?: boolean;
+  /** #165: whether output auto-tails */
+  readonly detailOutputAutoTail?: boolean;
+  /** #165: scroll offset for paused output mode */
+  readonly detailOutputScrollOffset?: number;
+  /** #165: terminal row count for output layout computation */
+  readonly terminalRows?: number;
 }
 
 const NotFound: React.FC<{ entityType: PanelId; entityId: string }> = ({ entityType, entityId }) => (
@@ -78,6 +89,11 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
     orchestrationChildPage = 0,
     orchestrationChildrenTotal,
     loopIterationSelectedNumber = null,
+    taskStreams,
+    detailOutputVisible = true,
+    detailOutputAutoTail = true,
+    detailOutputScrollOffset = 0,
+    terminalRows = 24,
   }) => {
     switch (entityType) {
       case 'loops': {
@@ -100,7 +116,20 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
         // TODO(Phase C): usage data requires a dedicated TaskUsage lookup by taskId —
         // DashboardData does not carry per-task usage; fetch from UsageRepository when
         // detail-view extras are extended (similar to orchestrationCostAggregate pattern).
-        return <TaskDetail task={task} animFrame={animFrame} dependencies={dependencies} dependents={dependents} />;
+        const taskStream = taskStreams?.get(entityId as TaskId);
+        return (
+          <TaskDetail
+            task={task}
+            animFrame={animFrame}
+            dependencies={dependencies}
+            dependents={dependents}
+            stream={taskStream}
+            outputVisible={detailOutputVisible}
+            outputAutoTail={detailOutputAutoTail}
+            outputScrollOffset={detailOutputScrollOffset}
+            terminalRows={terminalRows}
+          />
+        );
       }
       case 'schedules': {
         const schedule = data?.schedules.find((s) => s.id === entityId);
@@ -126,6 +155,11 @@ export const DetailView: React.FC<DetailViewProps> = React.memo(
             childSelectedTaskId={orchestrationChildSelectedTaskId ?? null}
             currentPage={orchestrationChildPage}
             childrenTotal={orchestrationChildrenTotal}
+            taskStreams={taskStreams}
+            childOutputVisible={detailOutputVisible}
+            childOutputAutoTail={detailOutputAutoTail}
+            childOutputScrollOffset={detailOutputScrollOffset}
+            terminalRows={terminalRows}
           />
         );
       }

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -174,10 +174,10 @@ export function renderConvergenceLine(
  * Try to parse evalResponse as JSON and extract structured fields.
  * Returns null if not JSON or missing expected fields.
  */
-function parseEvalResponseJson(raw: string): { decision?: string; score?: number; reasoning?: string } | null {
+export function parseEvalResponseJson(raw: string): { decision?: string; score?: number; reasoning?: string } | null {
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
     const obj = parsed as Record<string, unknown>;
     return {
       decision: typeof obj.decision === 'string' ? obj.decision : undefined,

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -273,10 +273,13 @@ export const LoopDetail: React.FC<LoopDetailProps> = React.memo(
     const selectedIteration = iterations !== undefined && iterations.length > 0 ? iterations[selectedIndex] : undefined;
 
     // Convergence trend — only for optimize loops with 2+ scored iterations
-    const scoredIterations = iterations?.filter((i) => i.score !== undefined && i.status !== 'progress') ?? [];
-    const showTrend = loop.strategy === 'optimize' && scoredIterations.length >= 2;
-    const convergenceLine =
-      showTrend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
+    // Memoized to avoid re-running the filter + renderConvergenceLine on every animFrame tick
+    const { showTrend, convergenceLine } = React.useMemo(() => {
+      const scoredIterations = iterations?.filter((i) => i.score !== undefined && i.status !== 'progress') ?? [];
+      const trend = loop.strategy === 'optimize' && scoredIterations.length >= 2;
+      const line = trend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
+      return { showTrend: trend, convergenceLine: line };
+    }, [iterations, loop.strategy, loop.evalDirection]);
 
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -57,7 +57,7 @@ function makeRenderIterationRow(
     const feedbackRaw = iter.evalFeedback ?? '';
     const hasEvalResponse = Boolean(iter.evalResponse);
     const feedbackDisplay =
-      (iter.status === 'fail' || iter.status === 'crash')
+      iter.status === 'fail' || iter.status === 'crash'
         ? truncateCell(iter.errorMessage ?? '—', 30)
         : truncateCell(feedbackRaw || '—', 30);
     const evalBadge = hasEvalResponse ? ' [eval]' : '';
@@ -88,7 +88,11 @@ function makeRenderIterationRow(
           <Text dimColor>{duration.padEnd(8, ' ')}</Text>
           <Text> </Text>
           <Text dimColor>{feedbackDisplay}</Text>
-          {hasEvalResponse && <Text dimColor color="cyan">{evalBadge}</Text>}
+          {hasEvalResponse && (
+            <Text dimColor color="cyan">
+              {evalBadge}
+            </Text>
+          )}
         </Box>
         {/* Git diff summary — shown as dimColor line below the row when present */}
         {iter.gitDiffSummary !== undefined && (
@@ -170,9 +174,7 @@ export function renderConvergenceLine(
  * Try to parse evalResponse as JSON and extract structured fields.
  * Returns null if not JSON or missing expected fields.
  */
-function parseEvalResponseJson(
-  raw: string,
-): { decision?: string; score?: number; reasoning?: string } | null {
+function parseEvalResponseJson(raw: string): { decision?: string; score?: number; reasoning?: string } | null {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== 'object' || parsed === null) return null;
@@ -202,11 +204,7 @@ interface SelectedIterationEvalProps {
  */
 function SelectedIterationEval({ iter }: SelectedIterationEvalProps): React.ReactElement | null {
   const hasContent =
-    iter.evalFeedback ||
-    iter.evalResponse ||
-    iter.exitCode !== undefined ||
-    iter.errorMessage ||
-    iter.gitDiffSummary;
+    iter.evalFeedback || iter.evalResponse || iter.exitCode !== undefined || iter.errorMessage || iter.gitDiffSummary;
 
   if (!hasContent) return null;
 
@@ -280,7 +278,8 @@ export const LoopDetail: React.FC<LoopDetailProps> = React.memo(
       iterations !== undefined &&
       iterations.filter((i) => i.score !== undefined && i.status !== 'progress').length >= 2;
 
-    const convergenceLine = showTrend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
+    const convergenceLine =
+      showTrend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
 
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
@@ -319,7 +318,9 @@ export const LoopDetail: React.FC<LoopDetailProps> = React.memo(
         {/* Convergence trend — between config fields and iteration table (#168) */}
         {showTrend && convergenceLine !== '' ? (
           <Box marginTop={0}>
-            <Text dimColor bold>Score Trend  </Text>
+            <Text dimColor bold>
+              Score Trend{' '}
+            </Text>
             <Text dimColor>{convergenceLine}</Text>
           </Box>
         ) : null}

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -7,6 +7,11 @@
  *  - Full eval config fields: evalType, judgeAgent, judgePrompt (LongField)
  *  - Best score highlight: iteration matching bestIterationId shown in bold green
  *  - Git diff summary: per-iteration dimColor line when gitDiffSummary present
+ *
+ * #168 additions:
+ *  - Iteration table selection wiring via selectedIterationNumber prop
+ *  - Expanded eval section below the table for the selected iteration
+ *  - Convergence trend for optimize loops (renderConvergenceLine, exported for tests)
  */
 
 import { Box, Text } from 'ink';
@@ -16,12 +21,15 @@ import { Field, LongField, StatusField } from '../components/field.js';
 import { ScrollableList } from '../components/scrollable-list.js';
 import { StatusBadge } from '../components/status-badge.js';
 import { formatDuration, formatRunProgress, relativeTime, statusIcon, truncateCell } from '../format.js';
+import { resolveIterationIndex } from '../keyboard/helpers.js';
 
 interface LoopDetailProps {
   readonly loop: Loop;
   readonly iterations: readonly LoopIteration[] | undefined;
   readonly scrollOffset: number;
   readonly animFrame: number;
+  /** iterationNumber of the highlighted row (null = first row) — #168 */
+  readonly selectedIterationNumber?: number | null;
 }
 
 /** Map an iteration status to its display color. Best iterations override to green. */
@@ -45,8 +53,14 @@ function makeRenderIterationRow(
     const score = iter.score !== undefined ? iter.score.toFixed(2) : '—';
     const taskId = iter.taskId ? truncateCell(iter.taskId, 12) : '—';
     const sha = iter.gitCommitSha ? iter.gitCommitSha.slice(0, 8) : '—';
-    const feedback = iter.evalFeedback ? truncateCell(iter.evalFeedback, 18) : '—';
-    const errorMsg = iter.errorMessage ? truncateCell(iter.errorMessage, 18) : '—';
+    // Increased truncation from 18→30 chars; also show [eval] badge when evalResponse present
+    const feedbackRaw = iter.evalFeedback ?? '';
+    const hasEvalResponse = Boolean(iter.evalResponse);
+    const feedbackDisplay =
+      (iter.status === 'fail' || iter.status === 'crash')
+        ? truncateCell(iter.errorMessage ?? '—', 30)
+        : truncateCell(feedbackRaw || '—', 30);
+    const evalBadge = hasEvalResponse ? ' [eval]' : '';
 
     const duration = formatDuration(iter.startedAt, iter.completedAt);
 
@@ -73,7 +87,8 @@ function makeRenderIterationRow(
           <Text> </Text>
           <Text dimColor>{duration.padEnd(8, ' ')}</Text>
           <Text> </Text>
-          <Text dimColor>{iter.status === 'fail' || iter.status === 'crash' ? errorMsg : feedback}</Text>
+          <Text dimColor>{feedbackDisplay}</Text>
+          {hasEvalResponse && <Text dimColor color="cyan">{evalBadge}</Text>}
         </Box>
         {/* Git diff summary — shown as dimColor line below the row when present */}
         {iter.gitDiffSummary !== undefined && (
@@ -86,84 +101,260 @@ function makeRenderIterationRow(
   };
 }
 
-const ITERATION_VIEWPORT_HEIGHT = 12;
+/**
+ * Render the convergence trend for optimize loops.
+ * Returns a string like: "Score Trend  3.2→ 4.1↑ 3.8↓ 5.2↑"
+ *
+ * DECISION (#168): Exported for unit testability. Pure function — no side effects.
+ *
+ * Algorithm:
+ *  1. Reverse DESC-ordered iterations to chronological order
+ *  2. Filter to scored iterations only (skip null scores and `progress` status)
+ *  3. Take last 20 scored iterations
+ *  4. Track running best; emit ↑ (improved), → (same), ↓ (regressed)
+ *     respecting evalDirection ('maximize' default = higher is better)
+ */
+export function renderConvergenceLine(
+  iterations: readonly LoopIteration[],
+  evalDirection: 'maximize' | 'minimize' | undefined,
+): string {
+  const direction = evalDirection ?? 'maximize';
 
-export const LoopDetail: React.FC<LoopDetailProps> = React.memo(({ loop, iterations, scrollOffset, animFrame }) => {
-  const iterProgress = formatRunProgress(loop.currentIteration, loop.maxIterations);
-  const bestScore = loop.bestScore !== undefined ? loop.bestScore.toFixed(2) : '—';
-  const bestIterationIdDisplay = loop.bestIterationId !== undefined ? String(loop.bestIterationId) : '—';
+  // iterations arrive DESC (latest first) — reverse to chronological
+  const chronological = [...iterations].reverse();
 
-  // Create renderer that closes over bestIterationId for best-score highlighting
-  const renderIterationRow = React.useMemo(() => makeRenderIterationRow(loop.bestIterationId), [loop.bestIterationId]);
+  // Filter to scored, non-progress iterations, take last 20
+  const scored = chronological
+    .filter((i) => i.score !== undefined && i.status !== 'progress')
+    .slice(-20) as readonly (LoopIteration & { score: number })[];
+
+  if (scored.length === 0) return '';
+
+  let runningBest: number = scored[0].score;
+  const parts: string[] = [];
+
+  for (const iter of scored) {
+    const s = iter.score.toFixed(1);
+    let arrow: string;
+    if (direction === 'maximize') {
+      if (iter.score > runningBest) {
+        arrow = '↑';
+        runningBest = iter.score;
+      } else if (iter.score < runningBest) {
+        arrow = '↓';
+      } else {
+        arrow = '→';
+      }
+    } else {
+      // minimize: lower is better
+      if (iter.score < runningBest) {
+        arrow = '↑';
+        runningBest = iter.score;
+      } else if (iter.score > runningBest) {
+        arrow = '↓';
+      } else {
+        arrow = '→';
+      }
+    }
+    parts.push(`${s}${arrow}`);
+  }
+
+  return parts.join(' ');
+}
+
+// ============================================================================
+// Expanded eval section for selected iteration
+// ============================================================================
+
+/**
+ * Try to parse evalResponse as JSON and extract structured fields.
+ * Returns null if not JSON or missing expected fields.
+ */
+function parseEvalResponseJson(
+  raw: string,
+): { decision?: string; score?: number; reasoning?: string } | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    const obj = parsed as Record<string, unknown>;
+    return {
+      decision: typeof obj.decision === 'string' ? obj.decision : undefined,
+      score:
+        typeof obj.score === 'number'
+          ? obj.score
+          : typeof obj.score === 'string' && !Number.isNaN(Number(obj.score))
+            ? Number(obj.score)
+            : undefined,
+      reasoning: typeof obj.reasoning === 'string' ? obj.reasoning : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+interface SelectedIterationEvalProps {
+  readonly iter: LoopIteration;
+}
+
+/**
+ * Expanded eval section — shown below the iteration table for the selected iteration.
+ * Renders full evalFeedback, structured evalResponse (if JSON), or raw evalResponse.
+ */
+function SelectedIterationEval({ iter }: SelectedIterationEvalProps): React.ReactElement | null {
+  const hasContent =
+    iter.evalFeedback ||
+    iter.evalResponse ||
+    iter.exitCode !== undefined ||
+    iter.errorMessage ||
+    iter.gitDiffSummary;
+
+  if (!hasContent) return null;
+
+  const parsed = iter.evalResponse ? parseEvalResponseJson(iter.evalResponse) : null;
 
   return (
-    <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
-      {/* Header section */}
-      <Box marginBottom={1}>
-        <Text bold>Loop Detail</Text>
-      </Box>
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold dimColor>
+        {`Iteration #${iter.iterationNumber} Detail`}
+      </Text>
 
-      <Field label="ID">{truncateCell(loop.id, 60)}</Field>
-      <StatusField>
-        <StatusBadge status={loop.status} animFrame={animFrame} />
-      </StatusField>
-      <Field label="Strategy">{loop.strategy}</Field>
-      <Field label="Eval Mode">{loop.evalMode}</Field>
-      {/* Full eval config — Phase C */}
-      {loop.evalType !== undefined ? <Field label="Eval Type">{loop.evalType}</Field> : null}
-      {loop.judgeAgent !== undefined ? <Field label="Judge Agent">{loop.judgeAgent}</Field> : null}
-      {loop.judgePrompt !== undefined ? <LongField label="Judge Prompt" value={loop.judgePrompt} /> : null}
-      {loop.evalPrompt !== undefined ? <LongField label="Eval Prompt" value={loop.evalPrompt} /> : null}
-      <Field label="Iteration Progress">{iterProgress}</Field>
-      <Field label="Best Score">{bestScore}</Field>
-      <Field label="Best Iteration ID">{bestIterationIdDisplay}</Field>
-      {loop.bestIterationCommitSha ? (
-        <Field label="Best Commit SHA">{loop.bestIterationCommitSha.slice(0, 16)}</Field>
+      {/* Full evalFeedback */}
+      {iter.evalFeedback ? <LongField label="Eval Feedback" value={iter.evalFeedback} /> : null}
+
+      {/* Structured evalResponse — JSON path */}
+      {iter.evalResponse && parsed !== null ? (
+        <Box flexDirection="column">
+          <Text bold dimColor>
+            Eval Response
+          </Text>
+          {parsed.decision !== undefined ? <Field label="Decision">{parsed.decision}</Field> : null}
+          {parsed.score !== undefined ? <Field label="Score">{String(parsed.score)}</Field> : null}
+          {parsed.reasoning !== undefined ? <LongField label="Reasoning" value={parsed.reasoning} /> : null}
+        </Box>
+      ) : iter.evalResponse ? (
+        // Raw evalResponse — non-JSON path, cap at 512 chars
+        <LongField label="Eval Response (raw)" value={iter.evalResponse.slice(0, 512)} />
       ) : null}
-      <Field label="Consecutive Failures">{String(loop.consecutiveFailures)}</Field>
-      <Field label="Cooldown">{`${loop.cooldownMs}ms`}</Field>
-      {loop.gitBranch ? <Field label="Git Branch">{loop.gitBranch}</Field> : null}
-      {loop.gitStartCommitSha ? <Field label="Git Start Commit">{loop.gitStartCommitSha.slice(0, 16)}</Field> : null}
-      <Field label="Working Directory">{truncateCell(loop.workingDirectory, 50)}</Field>
-      <Field label="Exit Condition">{truncateCell(loop.exitCondition, 50)}</Field>
-      <Field label="Created">{relativeTime(loop.createdAt)}</Field>
-      <Field label="Updated">{relativeTime(loop.updatedAt)}</Field>
-      {loop.completedAt ? <Field label="Completed">{relativeTime(loop.completedAt)}</Field> : null}
 
-      {/* Iteration history */}
-      <Box marginTop={1} marginBottom={0}>
-        <Text bold>Iteration History</Text>
-        <Text dimColor>{` (${iterations?.length ?? 0} total)`}</Text>
-      </Box>
+      {/* Exit info */}
+      {iter.exitCode !== undefined ? <Field label="Exit Code">{String(iter.exitCode)}</Field> : null}
+      {iter.errorMessage ? <LongField label="Error Message" value={iter.errorMessage} /> : null}
+      {iter.gitDiffSummary ? <LongField label="Git Diff Summary" value={iter.gitDiffSummary} /> : null}
 
-      {/* Table header */}
-      <Box flexDirection="row">
-        <Text dimColor bold>
-          {'  # STATUS    SCORE  TASK ID       SHA       DUR      FEEDBACK/ERROR'}
-        </Text>
-      </Box>
-
-      {/* TODO: Iteration row selection — selectedIndex is fixed at -1 (no keyboard selection).
-           To enable Enter-to-drill-through on iteration rows, this would require:
-           1. Adding iterationSelectedIndex to NavState in types.ts
-           2. Updating handleDetailKeys (keyboard/handle-detail-keys.ts) to handle ↑/↓/Enter for loops,
-              mirroring the orchestration drill-through pattern (D3 detail Enter → task detail)
-           3. Wiring Enter on a selected iteration row to push a task-detail view using iter.taskId
-           This is deferred as a future enhancement — requires changes across 3+ files. */}
-      {iterations === undefined || iterations.length === 0 ? (
-        <Text dimColor>No iterations yet</Text>
-      ) : (
-        <ScrollableList
-          items={iterations}
-          selectedIndex={-1}
-          scrollOffset={scrollOffset}
-          viewportHeight={ITERATION_VIEWPORT_HEIGHT}
-          renderItem={renderIterationRow}
-          keyExtractor={(item) => String(item.id)}
-        />
-      )}
+      {/* Drill hint */}
+      {iter.taskId ? (
+        <Box marginTop={0}>
+          <Text dimColor>Enter to drill into task detail</Text>
+        </Box>
+      ) : null}
     </Box>
   );
-});
+}
+
+const ITERATION_VIEWPORT_HEIGHT = 12;
+
+export const LoopDetail: React.FC<LoopDetailProps> = React.memo(
+  ({ loop, iterations, scrollOffset, animFrame, selectedIterationNumber = null }) => {
+    const iterProgress = formatRunProgress(loop.currentIteration, loop.maxIterations);
+    const bestScore = loop.bestScore !== undefined ? loop.bestScore.toFixed(2) : '—';
+    const bestIterationIdDisplay = loop.bestIterationId !== undefined ? String(loop.bestIterationId) : '—';
+
+    // Create renderer that closes over bestIterationId for best-score highlighting
+    const renderIterationRow = React.useMemo(
+      () => makeRenderIterationRow(loop.bestIterationId),
+      [loop.bestIterationId],
+    );
+
+    // Resolve selected index for the ScrollableList
+    const selectedIndex = React.useMemo(
+      () => resolveIterationIndex(selectedIterationNumber, iterations ?? []),
+      [selectedIterationNumber, iterations],
+    );
+
+    // The selected iteration object (for expanded eval section)
+    const selectedIteration = iterations !== undefined && iterations.length > 0 ? iterations[selectedIndex] : undefined;
+
+    // Convergence trend — only for optimize loops with 2+ scored iterations
+    const showTrend =
+      loop.strategy === 'optimize' &&
+      iterations !== undefined &&
+      iterations.filter((i) => i.score !== undefined && i.status !== 'progress').length >= 2;
+
+    const convergenceLine = showTrend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
+
+    return (
+      <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
+        {/* Header section */}
+        <Box marginBottom={1}>
+          <Text bold>Loop Detail</Text>
+        </Box>
+
+        <Field label="ID">{truncateCell(loop.id, 60)}</Field>
+        <StatusField>
+          <StatusBadge status={loop.status} animFrame={animFrame} />
+        </StatusField>
+        <Field label="Strategy">{loop.strategy}</Field>
+        <Field label="Eval Mode">{loop.evalMode}</Field>
+        {/* Full eval config — Phase C */}
+        {loop.evalType !== undefined ? <Field label="Eval Type">{loop.evalType}</Field> : null}
+        {loop.judgeAgent !== undefined ? <Field label="Judge Agent">{loop.judgeAgent}</Field> : null}
+        {loop.judgePrompt !== undefined ? <LongField label="Judge Prompt" value={loop.judgePrompt} /> : null}
+        {loop.evalPrompt !== undefined ? <LongField label="Eval Prompt" value={loop.evalPrompt} /> : null}
+        <Field label="Iteration Progress">{iterProgress}</Field>
+        <Field label="Best Score">{bestScore}</Field>
+        <Field label="Best Iteration ID">{bestIterationIdDisplay}</Field>
+        {loop.bestIterationCommitSha ? (
+          <Field label="Best Commit SHA">{loop.bestIterationCommitSha.slice(0, 16)}</Field>
+        ) : null}
+        <Field label="Consecutive Failures">{String(loop.consecutiveFailures)}</Field>
+        <Field label="Cooldown">{`${loop.cooldownMs}ms`}</Field>
+        {loop.gitBranch ? <Field label="Git Branch">{loop.gitBranch}</Field> : null}
+        {loop.gitStartCommitSha ? <Field label="Git Start Commit">{loop.gitStartCommitSha.slice(0, 16)}</Field> : null}
+        <Field label="Working Directory">{truncateCell(loop.workingDirectory, 50)}</Field>
+        <Field label="Exit Condition">{truncateCell(loop.exitCondition, 50)}</Field>
+        <Field label="Created">{relativeTime(loop.createdAt)}</Field>
+        <Field label="Updated">{relativeTime(loop.updatedAt)}</Field>
+        {loop.completedAt ? <Field label="Completed">{relativeTime(loop.completedAt)}</Field> : null}
+
+        {/* Convergence trend — between config fields and iteration table (#168) */}
+        {showTrend && convergenceLine !== '' ? (
+          <Box marginTop={0}>
+            <Text dimColor bold>Score Trend  </Text>
+            <Text dimColor>{convergenceLine}</Text>
+          </Box>
+        ) : null}
+
+        {/* Iteration history */}
+        <Box marginTop={1} marginBottom={0}>
+          <Text bold>Iteration History</Text>
+          <Text dimColor>{` (${iterations?.length ?? 0} total)`}</Text>
+        </Box>
+
+        {/* Table header */}
+        <Box flexDirection="row">
+          <Text dimColor bold>
+            {'  # STATUS    SCORE  TASK ID       SHA       DUR      FEEDBACK/ERROR'}
+          </Text>
+        </Box>
+
+        {iterations === undefined || iterations.length === 0 ? (
+          <Text dimColor>No iterations yet</Text>
+        ) : (
+          <ScrollableList
+            items={iterations}
+            selectedIndex={selectedIndex}
+            scrollOffset={scrollOffset}
+            viewportHeight={ITERATION_VIEWPORT_HEIGHT}
+            renderItem={renderIterationRow}
+            keyExtractor={(item) => String(item.id)}
+          />
+        )}
+
+        {/* Expanded eval section for selected iteration (#168) */}
+        {selectedIteration !== undefined ? <SelectedIterationEval iter={selectedIteration} /> : null}
+      </Box>
+    );
+  },
+);
 
 LoopDetail.displayName = 'LoopDetail';

--- a/src/cli/dashboard/views/loop-detail.tsx
+++ b/src/cli/dashboard/views/loop-detail.tsx
@@ -273,11 +273,8 @@ export const LoopDetail: React.FC<LoopDetailProps> = React.memo(
     const selectedIteration = iterations !== undefined && iterations.length > 0 ? iterations[selectedIndex] : undefined;
 
     // Convergence trend — only for optimize loops with 2+ scored iterations
-    const showTrend =
-      loop.strategy === 'optimize' &&
-      iterations !== undefined &&
-      iterations.filter((i) => i.score !== undefined && i.status !== 'progress').length >= 2;
-
+    const scoredIterations = iterations?.filter((i) => i.score !== undefined && i.status !== 'progress') ?? [];
+    const showTrend = loop.strategy === 'optimize' && scoredIterations.length >= 2;
     const convergenceLine =
       showTrend && iterations !== undefined ? renderConvergenceLine(iterations, loop.evalDirection) : '';
 

--- a/src/cli/dashboard/views/orchestration-detail.tsx
+++ b/src/cli/dashboard/views/orchestration-detail.tsx
@@ -476,7 +476,6 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
         {childOutputConfig?.visible && selectedChildStream !== undefined && metadataHeight > 0 ? (
           <DetailOutputPanel
             stream={selectedChildStream}
-            taskStatus={selectedChild?.status ?? ''}
             isActive={selectedChild?.status === TaskStatus.QUEUED || selectedChild?.status === TaskStatus.RUNNING}
             terminalRows={childOutputConfig.terminalRows}
             metadataHeight={metadataHeight}

--- a/src/cli/dashboard/views/orchestration-detail.tsx
+++ b/src/cli/dashboard/views/orchestration-detail.tsx
@@ -20,23 +20,27 @@
  * so the workspace is an enriched orchestration detail, not a separate view.
  * When viewMode='grid', orchestration is determined from orchestrations[committedOrchestratorIndex]
  * and the TaskPanel grid is rendered inline with OrchestratorNav.
+ *
+ * #165 additions:
+ *  - Ref-based metadata height measurement via useElementHeight() (shared hook)
+ *  - Selected child output stream via DetailOutputPanel (shared component)
+ *  - Output config grouped via DetailOutputConfig interface
  */
 
-import type { DOMElement } from 'ink';
-import { Box, measureElement, Text } from 'ink';
-import React, { useEffect, useRef, useState } from 'react';
+import { Box, Text } from 'ink';
+import React from 'react';
 import type { Orchestration, OrchestratorChild, TaskId, TaskUsage } from '../../../core/domain.js';
 import { TaskStatus } from '../../../core/domain.js';
+import type { DetailOutputConfig } from '../components/detail-output-panel.js';
+import { DetailOutputPanel, useElementHeight } from '../components/detail-output-panel.js';
 import { EmptyWorkspace } from '../components/empty-workspace.js';
 import { Field, LongField, StatusField } from '../components/field.js';
 import { OrchestratorNav } from '../components/orchestrator-nav.js';
-import { OutputStreamView } from '../components/output-stream-view.js';
 import { ScrollableList } from '../components/scrollable-list.js';
 import { StatusBadge } from '../components/status-badge.js';
 import { TaskPanel } from '../components/task-panel.js';
 import { relativeTime, truncateCell } from '../format.js';
 import type { WorkspaceLayout } from '../layout.js';
-import { computeDetailOutputLayout } from '../layout.js';
 import type { OutputStreamState } from '../use-task-output-stream.js';
 import type { WorkspaceNavState } from '../workspace-types.js';
 
@@ -71,14 +75,8 @@ interface OrchestrationDetailProps {
   readonly taskStreams?: ReadonlyMap<TaskId, OutputStreamState>;
   /** Workspace layout — required for grid mode */
   readonly workspaceLayout?: WorkspaceLayout;
-  /** #165: whether to show the selected child's output stream in list mode */
-  readonly childOutputVisible?: boolean;
-  /** #165: whether the output auto-tails */
-  readonly childOutputAutoTail?: boolean;
-  /** #165: scroll offset for paused output mode */
-  readonly childOutputScrollOffset?: number;
-  /** #165: terminal row count for layout computation */
-  readonly terminalRows?: number;
+  /** #165: grouped output panel configuration for the selected child stream */
+  readonly childOutputConfig?: DetailOutputConfig;
 }
 
 // ============================================================================
@@ -363,10 +361,7 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
     workspaceNav,
     taskStreams,
     workspaceLayout,
-    childOutputVisible = false,
-    childOutputAutoTail = true,
-    childOutputScrollOffset = 0,
-    terminalRows = 24,
+    childOutputConfig,
   }) => {
     // Grid mode: render workspace panel layout
     if (
@@ -398,24 +393,15 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
     const totalPages = childrenTotal !== undefined ? Math.ceil(childrenTotal / ORCHESTRATION_CHILDREN_PAGE_SIZE) : 1;
 
     // Ref-based metadata height measurement for adaptive output viewport (#165)
-    const metadataRef = useRef<DOMElement>(null);
-    const [metadataHeight, setMetadataHeight] = useState(0);
-
-    useEffect(() => {
-      if (metadataRef.current) {
-        const { height } = measureElement(metadataRef.current);
-        if (height !== metadataHeight) {
-          setMetadataHeight(height);
-        }
-      }
-    });
-
-    const outputLayout = computeDetailOutputLayout({ rows: terminalRows, metadataHeight });
+    // DECISION: useElementHeight intentionally omits a dependency array — see detail-output-panel.tsx
+    const [metadataRef, metadataHeight] = useElementHeight();
 
     // Resolve the selected child's stream for output rendering
     const selectedChild = children[selectedIndex];
     const selectedChildStream =
-      childOutputVisible && selectedChild && taskStreams ? taskStreams.get(selectedChild.taskId as TaskId) : undefined;
+      childOutputConfig?.visible && selectedChild && taskStreams
+        ? taskStreams.get(selectedChild.taskId as TaskId)
+        : undefined;
 
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
@@ -487,34 +473,17 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
         </Box>
 
         {/* Selected child output stream (#165) */}
-        {childOutputVisible && selectedChildStream !== undefined && metadataHeight > 0 ? (
-          outputLayout.tooSmall ? (
-            <Box marginTop={0}>
-              <Text dimColor>(terminal too small for output)</Text>
-            </Box>
-          ) : (
-            <Box flexDirection="column" marginTop={0}>
-              <Text dimColor>{`─── Output: ${selectedChild?.taskId.slice(0, 12) ?? ''} ${'─'.repeat(8)}`}</Text>
-              {selectedChildStream.lines.length === 0 ? (
-                <Box height={Math.min(3, outputLayout.outputViewportHeight)}>
-                  <Text dimColor>
-                    {selectedChild?.status === TaskStatus.QUEUED || selectedChild?.status === TaskStatus.RUNNING
-                      ? 'Waiting for output...'
-                      : selectedChildStream.totalBytes === 0
-                        ? 'No output captured'
-                        : 'Loading output...'}
-                  </Text>
-                </Box>
-              ) : (
-                <OutputStreamView
-                  stream={selectedChildStream}
-                  viewportHeight={outputLayout.outputViewportHeight}
-                  scrollOffset={childOutputScrollOffset}
-                  autoTail={childOutputAutoTail}
-                />
-              )}
-            </Box>
-          )
+        {childOutputConfig?.visible && selectedChildStream !== undefined && metadataHeight > 0 ? (
+          <DetailOutputPanel
+            stream={selectedChildStream}
+            taskStatus={selectedChild?.status ?? ''}
+            isActive={selectedChild?.status === TaskStatus.QUEUED || selectedChild?.status === TaskStatus.RUNNING}
+            terminalRows={childOutputConfig.terminalRows}
+            metadataHeight={metadataHeight}
+            scrollOffset={childOutputConfig.scrollOffset}
+            autoTail={childOutputConfig.autoTail}
+            separatorLabel={selectedChild?.taskId.slice(0, 12)}
+          />
         ) : null}
       </Box>
     );

--- a/src/cli/dashboard/views/orchestration-detail.tsx
+++ b/src/cli/dashboard/views/orchestration-detail.tsx
@@ -22,17 +22,21 @@
  * and the TaskPanel grid is rendered inline with OrchestratorNav.
  */
 
-import { Box, Text } from 'ink';
-import React from 'react';
+import type { DOMElement } from 'ink';
+import { Box, measureElement, Text } from 'ink';
+import React, { useEffect, useRef, useState } from 'react';
 import type { Orchestration, OrchestratorChild, TaskId, TaskUsage } from '../../../core/domain.js';
+import { TaskStatus } from '../../../core/domain.js';
 import { EmptyWorkspace } from '../components/empty-workspace.js';
 import { Field, LongField, StatusField } from '../components/field.js';
 import { OrchestratorNav } from '../components/orchestrator-nav.js';
+import { OutputStreamView } from '../components/output-stream-view.js';
 import { ScrollableList } from '../components/scrollable-list.js';
 import { StatusBadge } from '../components/status-badge.js';
 import { TaskPanel } from '../components/task-panel.js';
 import { relativeTime, truncateCell } from '../format.js';
 import type { WorkspaceLayout } from '../layout.js';
+import { computeDetailOutputLayout } from '../layout.js';
 import type { OutputStreamState } from '../use-task-output-stream.js';
 import type { WorkspaceNavState } from '../workspace-types.js';
 
@@ -63,10 +67,18 @@ interface OrchestrationDetailProps {
   readonly orchestrations?: readonly Orchestration[];
   /** Workspace nav state — required for grid mode (panel focus, page, scroll offsets) */
   readonly workspaceNav?: WorkspaceNavState;
-  /** Live output streams — required for grid mode */
+  /** Live output streams — required for grid mode and selected-child output in list mode (#165) */
   readonly taskStreams?: ReadonlyMap<TaskId, OutputStreamState>;
   /** Workspace layout — required for grid mode */
   readonly workspaceLayout?: WorkspaceLayout;
+  /** #165: whether to show the selected child's output stream in list mode */
+  readonly childOutputVisible?: boolean;
+  /** #165: whether the output auto-tails */
+  readonly childOutputAutoTail?: boolean;
+  /** #165: scroll offset for paused output mode */
+  readonly childOutputScrollOffset?: number;
+  /** #165: terminal row count for layout computation */
+  readonly terminalRows?: number;
 }
 
 // ============================================================================
@@ -351,6 +363,10 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
     workspaceNav,
     taskStreams,
     workspaceLayout,
+    childOutputVisible = false,
+    childOutputAutoTail = true,
+    childOutputScrollOffset = 0,
+    terminalRows = 24,
   }) => {
     // Grid mode: render workspace panel layout
     if (
@@ -381,71 +397,125 @@ export const OrchestrationDetail: React.FC<OrchestrationDetailProps> = React.mem
     const showPaginationFooter = childrenTotal !== undefined && childrenTotal > children.length && children.length > 0;
     const totalPages = childrenTotal !== undefined ? Math.ceil(childrenTotal / ORCHESTRATION_CHILDREN_PAGE_SIZE) : 1;
 
+    // Ref-based metadata height measurement for adaptive output viewport (#165)
+    const metadataRef = useRef<DOMElement>(null);
+    const [metadataHeight, setMetadataHeight] = useState(0);
+
+    useEffect(() => {
+      if (metadataRef.current) {
+        const { height } = measureElement(metadataRef.current);
+        if (height !== metadataHeight) {
+          setMetadataHeight(height);
+        }
+      }
+    });
+
+    const outputLayout = computeDetailOutputLayout({ rows: terminalRows, metadataHeight });
+
+    // Resolve the selected child's stream for output rendering
+    const selectedChild = children[selectedIndex];
+    const selectedChildStream =
+      childOutputVisible && selectedChild && taskStreams ? taskStreams.get(selectedChild.taskId as TaskId) : undefined;
+
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
-        {/* Header */}
-        <Box marginBottom={1}>
-          <Text bold>Orchestration Detail</Text>
+        {/* Metadata section — measured for adaptive output viewport */}
+        <Box ref={metadataRef} flexDirection="column">
+          {/* Header */}
+          <Box marginBottom={1}>
+            <Text bold>Orchestration Detail</Text>
+          </Box>
+
+          <Field label="ID">{truncateCell(orchestration.id, 60)}</Field>
+          <StatusField>
+            <StatusBadge status={orchestration.status} animFrame={animFrame} />
+          </StatusField>
+
+          {/* Goal (full, wrapped) */}
+          <LongField label="Goal" value={orchestration.goal} />
+
+          {orchestration.agent ? <Field label="Agent">{orchestration.agent}</Field> : null}
+          {orchestration.model ? <Field label="Model">{orchestration.model}</Field> : null}
+          {orchestration.loopId ? <Field label="Loop ID">{truncateCell(orchestration.loopId, 50)}</Field> : null}
+          <Field label="Max Depth">{String(orchestration.maxDepth)}</Field>
+          <Field label="Max Workers">{String(orchestration.maxWorkers)}</Field>
+          <Field label="Max Iterations">{String(orchestration.maxIterations)}</Field>
+          <Field label="Working Directory">{truncateCell(orchestration.workingDirectory, 50)}</Field>
+          <Field label="State File">{truncateCell(orchestration.stateFilePath, 50)}</Field>
+          <Field label="Created">{relativeTime(orchestration.createdAt)}</Field>
+          <Field label="Updated">{relativeTime(orchestration.updatedAt)}</Field>
+          {orchestration.completedAt !== undefined ? (
+            <Field label="Completed">{relativeTime(orchestration.completedAt)}</Field>
+          ) : null}
+
+          {/* Cost aggregate — only shown when there is actual usage data */}
+          <CostSection costAggregate={costAggregate} />
+
+          {/* Progress indicators — only shown when the orchestration has configuration limits */}
+          <ProgressSection orchestration={orchestration} children={children} childrenTotal={childrenTotal} />
+
+          {/* Children section — only shown when the orchestration has attributed tasks */}
+          {children.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold dimColor>
+                {`Children (${childrenTotal ?? children.length})`}
+              </Text>
+              <ScrollableList
+                items={children}
+                selectedIndex={selectedIndex}
+                scrollOffset={0}
+                viewportHeight={ORCHESTRATION_CHILDREN_PAGE_SIZE}
+                renderItem={renderChildRow}
+                keyExtractor={(child) => child.taskId}
+              />
+              {/* Pagination footer — only shown when multiple pages exist */}
+              {showPaginationFooter && (
+                <Box marginTop={1}>
+                  <Text dimColor>
+                    {`Page ${currentPage + 1} of ${totalPages} · PgUp/PgDn to navigate · ${childrenTotal} total · Enter to drill in`}
+                  </Text>
+                </Box>
+              )}
+              {/* Drill hint on single page */}
+              {!showPaginationFooter && children.length > 0 && (
+                <Box marginTop={1}>
+                  <Text dimColor>Enter to drill into child task detail</Text>
+                </Box>
+              )}
+            </Box>
+          )}
         </Box>
 
-        <Field label="ID">{truncateCell(orchestration.id, 60)}</Field>
-        <StatusField>
-          <StatusBadge status={orchestration.status} animFrame={animFrame} />
-        </StatusField>
-
-        {/* Goal (full, wrapped) */}
-        <LongField label="Goal" value={orchestration.goal} />
-
-        {orchestration.agent ? <Field label="Agent">{orchestration.agent}</Field> : null}
-        {orchestration.model ? <Field label="Model">{orchestration.model}</Field> : null}
-        {orchestration.loopId ? <Field label="Loop ID">{truncateCell(orchestration.loopId, 50)}</Field> : null}
-        <Field label="Max Depth">{String(orchestration.maxDepth)}</Field>
-        <Field label="Max Workers">{String(orchestration.maxWorkers)}</Field>
-        <Field label="Max Iterations">{String(orchestration.maxIterations)}</Field>
-        <Field label="Working Directory">{truncateCell(orchestration.workingDirectory, 50)}</Field>
-        <Field label="State File">{truncateCell(orchestration.stateFilePath, 50)}</Field>
-        <Field label="Created">{relativeTime(orchestration.createdAt)}</Field>
-        <Field label="Updated">{relativeTime(orchestration.updatedAt)}</Field>
-        {orchestration.completedAt !== undefined ? (
-          <Field label="Completed">{relativeTime(orchestration.completedAt)}</Field>
+        {/* Selected child output stream (#165) */}
+        {childOutputVisible && selectedChildStream !== undefined && metadataHeight > 0 ? (
+          outputLayout.tooSmall ? (
+            <Box marginTop={0}>
+              <Text dimColor>(terminal too small for output)</Text>
+            </Box>
+          ) : (
+            <Box flexDirection="column" marginTop={0}>
+              <Text dimColor>{`─── Output: ${selectedChild?.taskId.slice(0, 12) ?? ''} ${'─'.repeat(8)}`}</Text>
+              {selectedChildStream.lines.length === 0 ? (
+                <Box height={Math.min(3, outputLayout.outputViewportHeight)}>
+                  <Text dimColor>
+                    {selectedChild?.status === TaskStatus.QUEUED || selectedChild?.status === TaskStatus.RUNNING
+                      ? 'Waiting for output...'
+                      : selectedChildStream.totalBytes === 0
+                        ? 'No output captured'
+                        : 'Loading output...'}
+                  </Text>
+                </Box>
+              ) : (
+                <OutputStreamView
+                  stream={selectedChildStream}
+                  viewportHeight={outputLayout.outputViewportHeight}
+                  scrollOffset={childOutputScrollOffset}
+                  autoTail={childOutputAutoTail}
+                />
+              )}
+            </Box>
+          )
         ) : null}
-
-        {/* Cost aggregate — only shown when there is actual usage data */}
-        <CostSection costAggregate={costAggregate} />
-
-        {/* Progress indicators — only shown when the orchestration has configuration limits */}
-        <ProgressSection orchestration={orchestration} children={children} childrenTotal={childrenTotal} />
-
-        {/* Children section — only shown when the orchestration has attributed tasks */}
-        {children.length > 0 && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>
-              {`Children (${childrenTotal ?? children.length})`}
-            </Text>
-            <ScrollableList
-              items={children}
-              selectedIndex={selectedIndex}
-              scrollOffset={0}
-              viewportHeight={ORCHESTRATION_CHILDREN_PAGE_SIZE}
-              renderItem={renderChildRow}
-              keyExtractor={(child) => child.taskId}
-            />
-            {/* Pagination footer — only shown when multiple pages exist */}
-            {showPaginationFooter && (
-              <Box marginTop={1}>
-                <Text dimColor>
-                  {`Page ${currentPage + 1} of ${totalPages} · PgUp/PgDn to navigate · ${childrenTotal} total · Enter to drill in`}
-                </Text>
-              </Box>
-            )}
-            {/* Drill hint on single page */}
-            {!showPaginationFooter && children.length > 0 && (
-              <Box marginTop={1}>
-                <Text dimColor>Enter to drill into child task detail</Text>
-              </Box>
-            )}
-          </Box>
-        )}
       </Box>
     );
   },

--- a/src/cli/dashboard/views/task-detail.tsx
+++ b/src/cli/dashboard/views/task-detail.tsx
@@ -171,7 +171,6 @@ export const TaskDetail: React.FC<TaskDetailProps> = React.memo(
         {outputConfig?.visible && stream !== undefined && metadataHeight > 0 ? (
           <DetailOutputPanel
             stream={stream}
-            taskStatus={task.status}
             isActive={task.status === TaskStatus.QUEUED || task.status === TaskStatus.RUNNING}
             terminalRows={outputConfig.terminalRows}
             metadataHeight={metadataHeight}

--- a/src/cli/dashboard/views/task-detail.tsx
+++ b/src/cli/dashboard/views/task-detail.tsx
@@ -9,21 +9,20 @@
  *  - Usage section: token/cost summary from task_usage table
  *
  * #165 additions:
- *  - Ref-based metadata height measurement via Ink's measureElement()
- *  - Output stream rendering below metadata when outputVisible=true
- *  - computeDetailOutputLayout() for adaptive viewport sizing
+ *  - Ref-based metadata height measurement via useElementHeight() (shared hook)
+ *  - Output stream rendering below metadata via DetailOutputPanel (shared component)
+ *  - Output config grouped via DetailOutputConfig interface
  */
 
-import type { DOMElement } from 'ink';
-import { Box, measureElement, Text } from 'ink';
-import React, { useEffect, useRef, useState } from 'react';
+import { Box, Text } from 'ink';
+import React from 'react';
 import type { Task, TaskUsage } from '../../../core/domain.js';
 import { TaskStatus } from '../../../core/domain.js';
+import type { DetailOutputConfig } from '../components/detail-output-panel.js';
+import { DetailOutputPanel, useElementHeight } from '../components/detail-output-panel.js';
 import { Field, LongField, StatusField } from '../components/field.js';
-import { OutputStreamView } from '../components/output-stream-view.js';
 import { StatusBadge } from '../components/status-badge.js';
 import { formatElapsed, relativeTime, statusIcon, truncateCell } from '../format.js';
-import { computeDetailOutputLayout } from '../layout.js';
 import type { OutputStreamState } from '../use-task-output-stream.js';
 
 interface TaskDependencyRef {
@@ -42,29 +41,12 @@ interface TaskDetailProps {
   readonly usage?: TaskUsage;
   /** #165: live output stream for this task */
   readonly stream?: OutputStreamState;
-  /** #165: whether the output panel is visible */
-  readonly outputVisible?: boolean;
-  /** #165: whether the output auto-tails */
-  readonly outputAutoTail?: boolean;
-  /** #165: scroll offset when in paused mode */
-  readonly outputScrollOffset?: number;
-  /** #165: terminal row count for layout computation */
-  readonly terminalRows?: number;
+  /** #165: grouped output panel configuration */
+  readonly outputConfig?: DetailOutputConfig;
 }
 
 export const TaskDetail: React.FC<TaskDetailProps> = React.memo(
-  ({
-    task,
-    animFrame,
-    dependencies,
-    dependents,
-    usage,
-    stream,
-    outputVisible = true,
-    outputAutoTail = true,
-    outputScrollOffset = 0,
-    terminalRows = 24,
-  }) => {
+  ({ task, animFrame, dependencies, dependents, usage, stream, outputConfig }) => {
     // Compute elapsed for running tasks
     const elapsedDisplay =
       task.status === 'running' && task.startedAt !== undefined ? formatElapsed(task.startedAt) : undefined;
@@ -72,19 +54,8 @@ export const TaskDetail: React.FC<TaskDetailProps> = React.memo(
     const errorMsg = task.error instanceof Error ? task.error.message : undefined;
 
     // Ref-based metadata height measurement for adaptive output viewport (#165)
-    const metadataRef = useRef<DOMElement>(null);
-    const [metadataHeight, setMetadataHeight] = useState(0);
-
-    useEffect(() => {
-      if (metadataRef.current) {
-        const { height } = measureElement(metadataRef.current);
-        if (height !== metadataHeight) {
-          setMetadataHeight(height);
-        }
-      }
-    });
-
-    const outputLayout = computeDetailOutputLayout({ rows: terminalRows, metadataHeight });
+    // DECISION: useElementHeight intentionally omits a dependency array — see detail-output-panel.tsx
+    const [metadataRef, metadataHeight] = useElementHeight();
 
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
@@ -197,34 +168,16 @@ export const TaskDetail: React.FC<TaskDetailProps> = React.memo(
         </Box>
 
         {/* Output stream section (#165) */}
-        {outputVisible && stream !== undefined && metadataHeight > 0 ? (
-          outputLayout.tooSmall ? (
-            <Box marginTop={0}>
-              <Text dimColor>(terminal too small for output)</Text>
-            </Box>
-          ) : (
-            <Box flexDirection="column" marginTop={0}>
-              <Text dimColor>{'─'.repeat(20)}</Text>
-              {stream.lines.length === 0 ? (
-                <Box height={Math.min(3, outputLayout.outputViewportHeight)}>
-                  <Text dimColor>
-                    {task.status === TaskStatus.QUEUED || task.status === TaskStatus.RUNNING
-                      ? 'Waiting for output...'
-                      : stream.totalBytes === 0
-                        ? 'No output captured'
-                        : 'Loading output...'}
-                  </Text>
-                </Box>
-              ) : (
-                <OutputStreamView
-                  stream={stream}
-                  viewportHeight={outputLayout.outputViewportHeight}
-                  scrollOffset={outputScrollOffset}
-                  autoTail={outputAutoTail}
-                />
-              )}
-            </Box>
-          )
+        {outputConfig?.visible && stream !== undefined && metadataHeight > 0 ? (
+          <DetailOutputPanel
+            stream={stream}
+            taskStatus={task.status}
+            isActive={task.status === TaskStatus.QUEUED || task.status === TaskStatus.RUNNING}
+            terminalRows={outputConfig.terminalRows}
+            metadataHeight={metadataHeight}
+            scrollOffset={outputConfig.scrollOffset}
+            autoTail={outputConfig.autoTail}
+          />
         ) : null}
       </Box>
     );

--- a/src/cli/dashboard/views/task-detail.tsx
+++ b/src/cli/dashboard/views/task-detail.tsx
@@ -7,14 +7,24 @@
  *  - Orchestrator attribution: shows parent orchestratorId when present
  *  - Dependencies section: blocked-by and blocks lists with status icons
  *  - Usage section: token/cost summary from task_usage table
+ *
+ * #165 additions:
+ *  - Ref-based metadata height measurement via Ink's measureElement()
+ *  - Output stream rendering below metadata when outputVisible=true
+ *  - computeDetailOutputLayout() for adaptive viewport sizing
  */
 
-import { Box, Text } from 'ink';
-import React from 'react';
+import type { DOMElement } from 'ink';
+import { Box, measureElement, Text } from 'ink';
+import React, { useEffect, useRef, useState } from 'react';
 import type { Task, TaskUsage } from '../../../core/domain.js';
+import { TaskStatus } from '../../../core/domain.js';
 import { Field, LongField, StatusField } from '../components/field.js';
+import { OutputStreamView } from '../components/output-stream-view.js';
 import { StatusBadge } from '../components/status-badge.js';
 import { formatElapsed, relativeTime, statusIcon, truncateCell } from '../format.js';
+import { computeDetailOutputLayout } from '../layout.js';
+import type { OutputStreamState } from '../use-task-output-stream.js';
 
 interface TaskDependencyRef {
   readonly taskId: string;
@@ -30,122 +40,192 @@ interface TaskDetailProps {
   readonly dependents?: readonly TaskDependencyRef[];
   /** Phase C: token/cost usage summary from task_usage table */
   readonly usage?: TaskUsage;
+  /** #165: live output stream for this task */
+  readonly stream?: OutputStreamState;
+  /** #165: whether the output panel is visible */
+  readonly outputVisible?: boolean;
+  /** #165: whether the output auto-tails */
+  readonly outputAutoTail?: boolean;
+  /** #165: scroll offset when in paused mode */
+  readonly outputScrollOffset?: number;
+  /** #165: terminal row count for layout computation */
+  readonly terminalRows?: number;
 }
 
 export const TaskDetail: React.FC<TaskDetailProps> = React.memo(
-  ({ task, animFrame, dependencies, dependents, usage }) => {
+  ({
+    task,
+    animFrame,
+    dependencies,
+    dependents,
+    usage,
+    stream,
+    outputVisible = true,
+    outputAutoTail = true,
+    outputScrollOffset = 0,
+    terminalRows = 24,
+  }) => {
     // Compute elapsed for running tasks
     const elapsedDisplay =
       task.status === 'running' && task.startedAt !== undefined ? formatElapsed(task.startedAt) : undefined;
 
     const errorMsg = task.error instanceof Error ? task.error.message : undefined;
 
+    // Ref-based metadata height measurement for adaptive output viewport (#165)
+    const metadataRef = useRef<DOMElement>(null);
+    const [metadataHeight, setMetadataHeight] = useState(0);
+
+    useEffect(() => {
+      if (metadataRef.current) {
+        const { height } = measureElement(metadataRef.current);
+        if (height !== metadataHeight) {
+          setMetadataHeight(height);
+        }
+      }
+    });
+
+    const outputLayout = computeDetailOutputLayout({ rows: terminalRows, metadataHeight });
+
     return (
       <Box flexDirection="column" paddingLeft={1} paddingRight={1}>
-        {/* Header */}
-        <Box marginBottom={1}>
-          <Text bold>Task Detail</Text>
+        {/* Metadata section — measured for adaptive output viewport */}
+        <Box ref={metadataRef} flexDirection="column">
+          {/* Header */}
+          <Box marginBottom={1}>
+            <Text bold>Task Detail</Text>
+          </Box>
+
+          <Field label="ID">{truncateCell(task.id, 60)}</Field>
+          <StatusField>
+            <StatusBadge status={task.status} animFrame={animFrame} />
+          </StatusField>
+          <Field label="Priority">{task.priority}</Field>
+          {task.agent ? <Field label="Agent">{task.agent}</Field> : null}
+          {task.model ? <Field label="Model">{task.model}</Field> : null}
+          {task.workingDirectory ? (
+            <Field label="Working Directory">{truncateCell(task.workingDirectory, 50)}</Field>
+          ) : null}
+          {/* Orchestrator attribution — shows parent orchestration when present */}
+          {task.orchestratorId !== undefined ? <Field label="Orchestrator">{task.orchestratorId}</Field> : null}
+
+          {/* Prompt (full, wrapped) */}
+          <LongField label="Prompt" value={task.prompt} />
+
+          {/* Timing */}
+          <Field label="Created">{relativeTime(task.createdAt)}</Field>
+          {task.startedAt !== undefined ? <Field label="Started">{relativeTime(task.startedAt)}</Field> : null}
+          {task.completedAt !== undefined ? <Field label="Completed">{relativeTime(task.completedAt)}</Field> : null}
+          {elapsedDisplay !== undefined ? <Field label="Elapsed">{elapsedDisplay}</Field> : null}
+
+          {/* Execution limits */}
+          {task.timeout !== undefined ? <Field label="Timeout">{`${task.timeout}ms`}</Field> : null}
+          {task.maxOutputBuffer !== undefined ? (
+            <Field label="Max Output Buffer">{`${task.maxOutputBuffer} bytes`}</Field>
+          ) : null}
+
+          {/* Dependencies */}
+          {task.dependsOn !== undefined && task.dependsOn.length > 0 ? (
+            <Field label="Depends On">{task.dependsOn.join(', ')}</Field>
+          ) : null}
+          {task.dependents !== undefined && task.dependents.length > 0 ? (
+            <Field label="Dependents">{task.dependents.join(', ')}</Field>
+          ) : null}
+          {task.dependencyState !== undefined ? <Field label="Dependency State">{task.dependencyState}</Field> : null}
+
+          {/* Retry chain */}
+          {task.retryCount !== undefined && task.retryCount > 0 ? (
+            <Field label="Retry Count">{String(task.retryCount)}</Field>
+          ) : null}
+          {task.retryOf !== undefined ? <Field label="Retry Of">{task.retryOf}</Field> : null}
+          {task.parentTaskId !== undefined ? <Field label="Parent Task ID">{task.parentTaskId}</Field> : null}
+
+          {/* Exit */}
+          {task.exitCode !== undefined ? <Field label="Exit Code">{String(task.exitCode)}</Field> : null}
+          {errorMsg !== undefined ? (
+            <Box flexDirection="column" marginBottom={0}>
+              <Text bold color="cyan">
+                Error Message
+              </Text>
+              <Box paddingLeft={2}>
+                <Text color="red" wrap="wrap">
+                  {errorMsg}
+                </Text>
+              </Box>
+            </Box>
+          ) : null}
+
+          {/* Dependencies section — only shown when dependency data is present */}
+          {((dependencies !== undefined && dependencies.length > 0) ||
+            (dependents !== undefined && dependents.length > 0)) && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold dimColor>
+                Dependencies
+              </Text>
+              {dependencies !== undefined && dependencies.length > 0 && (
+                <Field label="Blocked by">
+                  {dependencies.map((d) => `${d.taskId.slice(0, 12)} ${statusIcon(d.status)} ${d.status}`).join(', ')}
+                </Field>
+              )}
+              {dependents !== undefined && dependents.length > 0 && (
+                <Field label="Blocks">
+                  {dependents.map((d) => `${d.taskId.slice(0, 12)} ${statusIcon(d.status)} ${d.status}`).join(', ')}
+                </Field>
+              )}
+            </Box>
+          )}
+
+          {/* Usage section — token/cost summary from task_usage table */}
+          {usage !== undefined && (usage.inputTokens > 0 || usage.totalCostUsd > 0) && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold dimColor>
+                Usage
+              </Text>
+              <Field label="Tokens">
+                {[
+                  `In: ${usage.inputTokens > 1000 ? `${Math.round(usage.inputTokens / 1000)}K` : String(usage.inputTokens)}`,
+                  `Out: ${usage.outputTokens > 1000 ? `${Math.round(usage.outputTokens / 1000)}K` : String(usage.outputTokens)}`,
+                  (usage.cacheCreationInputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) > 0
+                    ? `Cache: ${Math.round(((usage.cacheCreationInputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0)) / 1000)}K`
+                    : null,
+                  usage.totalCostUsd > 0 ? `Cost: $${usage.totalCostUsd.toFixed(2)}` : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </Field>
+            </Box>
+          )}
         </Box>
 
-        <Field label="ID">{truncateCell(task.id, 60)}</Field>
-        <StatusField>
-          <StatusBadge status={task.status} animFrame={animFrame} />
-        </StatusField>
-        <Field label="Priority">{task.priority}</Field>
-        {task.agent ? <Field label="Agent">{task.agent}</Field> : null}
-        {task.model ? <Field label="Model">{task.model}</Field> : null}
-        {task.workingDirectory ? (
-          <Field label="Working Directory">{truncateCell(task.workingDirectory, 50)}</Field>
-        ) : null}
-        {/* Orchestrator attribution — shows parent orchestration when present */}
-        {task.orchestratorId !== undefined ? <Field label="Orchestrator">{task.orchestratorId}</Field> : null}
-
-        {/* Prompt (full, wrapped) */}
-        <LongField label="Prompt" value={task.prompt} />
-
-        {/* Timing */}
-        <Field label="Created">{relativeTime(task.createdAt)}</Field>
-        {task.startedAt !== undefined ? <Field label="Started">{relativeTime(task.startedAt)}</Field> : null}
-        {task.completedAt !== undefined ? <Field label="Completed">{relativeTime(task.completedAt)}</Field> : null}
-        {elapsedDisplay !== undefined ? <Field label="Elapsed">{elapsedDisplay}</Field> : null}
-
-        {/* Execution limits */}
-        {task.timeout !== undefined ? <Field label="Timeout">{`${task.timeout}ms`}</Field> : null}
-        {task.maxOutputBuffer !== undefined ? (
-          <Field label="Max Output Buffer">{`${task.maxOutputBuffer} bytes`}</Field>
-        ) : null}
-
-        {/* Dependencies */}
-        {task.dependsOn !== undefined && task.dependsOn.length > 0 ? (
-          <Field label="Depends On">{task.dependsOn.join(', ')}</Field>
-        ) : null}
-        {task.dependents !== undefined && task.dependents.length > 0 ? (
-          <Field label="Dependents">{task.dependents.join(', ')}</Field>
-        ) : null}
-        {task.dependencyState !== undefined ? <Field label="Dependency State">{task.dependencyState}</Field> : null}
-
-        {/* Retry chain */}
-        {task.retryCount !== undefined && task.retryCount > 0 ? (
-          <Field label="Retry Count">{String(task.retryCount)}</Field>
-        ) : null}
-        {task.retryOf !== undefined ? <Field label="Retry Of">{task.retryOf}</Field> : null}
-        {task.parentTaskId !== undefined ? <Field label="Parent Task ID">{task.parentTaskId}</Field> : null}
-
-        {/* Exit */}
-        {task.exitCode !== undefined ? <Field label="Exit Code">{String(task.exitCode)}</Field> : null}
-        {errorMsg !== undefined ? (
-          <Box flexDirection="column" marginBottom={0}>
-            <Text bold color="cyan">
-              Error Message
-            </Text>
-            <Box paddingLeft={2}>
-              <Text color="red" wrap="wrap">
-                {errorMsg}
-              </Text>
+        {/* Output stream section (#165) */}
+        {outputVisible && stream !== undefined && metadataHeight > 0 ? (
+          outputLayout.tooSmall ? (
+            <Box marginTop={0}>
+              <Text dimColor>(terminal too small for output)</Text>
             </Box>
-          </Box>
+          ) : (
+            <Box flexDirection="column" marginTop={0}>
+              <Text dimColor>{'─'.repeat(20)}</Text>
+              {stream.lines.length === 0 ? (
+                <Box height={Math.min(3, outputLayout.outputViewportHeight)}>
+                  <Text dimColor>
+                    {task.status === TaskStatus.QUEUED || task.status === TaskStatus.RUNNING
+                      ? 'Waiting for output...'
+                      : stream.totalBytes === 0
+                        ? 'No output captured'
+                        : 'Loading output...'}
+                  </Text>
+                </Box>
+              ) : (
+                <OutputStreamView
+                  stream={stream}
+                  viewportHeight={outputLayout.outputViewportHeight}
+                  scrollOffset={outputScrollOffset}
+                  autoTail={outputAutoTail}
+                />
+              )}
+            </Box>
+          )
         ) : null}
-
-        {/* Dependencies section — only shown when dependency data is present */}
-        {((dependencies !== undefined && dependencies.length > 0) ||
-          (dependents !== undefined && dependents.length > 0)) && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>
-              Dependencies
-            </Text>
-            {dependencies !== undefined && dependencies.length > 0 && (
-              <Field label="Blocked by">
-                {dependencies.map((d) => `${d.taskId.slice(0, 12)} ${statusIcon(d.status)} ${d.status}`).join(', ')}
-              </Field>
-            )}
-            {dependents !== undefined && dependents.length > 0 && (
-              <Field label="Blocks">
-                {dependents.map((d) => `${d.taskId.slice(0, 12)} ${statusIcon(d.status)} ${d.status}`).join(', ')}
-              </Field>
-            )}
-          </Box>
-        )}
-
-        {/* Usage section — token/cost summary from task_usage table */}
-        {usage !== undefined && (usage.inputTokens > 0 || usage.totalCostUsd > 0) && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>
-              Usage
-            </Text>
-            <Field label="Tokens">
-              {[
-                `In: ${usage.inputTokens > 1000 ? `${Math.round(usage.inputTokens / 1000)}K` : String(usage.inputTokens)}`,
-                `Out: ${usage.outputTokens > 1000 ? `${Math.round(usage.outputTokens / 1000)}K` : String(usage.outputTokens)}`,
-                (usage.cacheCreationInputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) > 0
-                  ? `Cache: ${Math.round(((usage.cacheCreationInputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0)) / 1000)}K`
-                  : null,
-                usage.totalCostUsd > 0 ? `Cost: $${usage.totalCostUsd.toFixed(2)}` : null,
-              ]
-                .filter(Boolean)
-                .join(' · ')}
-            </Field>
-          </Box>
-        )}
       </Box>
     );
   },

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -3308,6 +3308,112 @@ describe('includeSystemPrompt flag via callTool()', () => {
 });
 
 // ============================================================================
+// includeEvalResponse flag — LoopStatus via callTool()
+// ============================================================================
+
+describe('includeEvalResponse flag via callTool()', () => {
+  let localLoopService: MockLoopService;
+  let adapter: MCPAdapter;
+
+  beforeEach(() => {
+    localLoopService = new MockLoopService();
+    adapter = new MCPAdapter({
+      taskManager: new MockTaskManager(),
+      logger: new MockLogger(),
+      scheduleService: stubScheduleService,
+      loopService: localLoopService,
+      agentRegistry: undefined,
+      config: testConfig,
+    });
+  });
+
+  afterEach(() => {
+    localLoopService.reset();
+  });
+
+  it('should include evalResponse in iteration objects when includeEvalResponse=true', async () => {
+    const loop = localLoopService.makeLoop();
+    const iterations: LoopIteration[] = [
+      {
+        id: 1,
+        loopId: loop.id,
+        iterationNumber: 1,
+        taskId: undefined,
+        status: 'pass',
+        startedAt: Date.now() - 3000,
+        completedAt: Date.now(),
+        score: 0.9,
+        evalResponse: '{"decision":"pass","score":0.9,"reasoning":"Excellent output"}',
+      },
+    ];
+    localLoopService.setGetLoopResult(ok({ loop, iterations }));
+
+    const result = await adapter.callTool('LoopStatus', {
+      loopId: loop.id,
+      includeHistory: true,
+      includeEvalResponse: true,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.success).toBe(true);
+    expect(response.iterations).toHaveLength(1);
+    expect(response.iterations[0].evalResponse).toBe(
+      '{"decision":"pass","score":0.9,"reasoning":"Excellent output"}',
+    );
+  });
+
+  it('should exclude evalResponse from iteration objects when includeEvalResponse is omitted (default)', async () => {
+    const loop = localLoopService.makeLoop();
+    const iterations: LoopIteration[] = [
+      {
+        id: 1,
+        loopId: loop.id,
+        iterationNumber: 1,
+        taskId: undefined,
+        status: 'pass',
+        startedAt: Date.now() - 3000,
+        completedAt: Date.now(),
+        score: 0.9,
+        evalResponse: '{"decision":"pass","score":0.9}',
+      },
+    ];
+    localLoopService.setGetLoopResult(ok({ loop, iterations }));
+
+    const result = await adapter.callTool('LoopStatus', {
+      loopId: loop.id,
+      includeHistory: true,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.success).toBe(true);
+    expect(response.iterations).toHaveLength(1);
+    expect('evalResponse' in response.iterations[0]).toBe(false);
+  });
+
+  it('should include evalType, judgeAgent, judgePrompt on loop object in response', async () => {
+    const loop = localLoopService.makeLoop({
+      evalType: 'judge',
+      judgeAgent: 'claude',
+      judgePrompt: 'Score on a scale of 0–1',
+    });
+    localLoopService.setGetLoopResult(ok({ loop }));
+
+    const result = await adapter.callTool('LoopStatus', {
+      loopId: loop.id,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const response = JSON.parse(result.content[0].text);
+    expect(response.success).toBe(true);
+    expect(response.loop.evalType).toBe('judge');
+    expect(response.loop.judgeAgent).toBe('claude');
+    expect(response.loop.judgePrompt).toBe('Score on a scale of 0–1');
+  });
+});
+
+// ============================================================================
 // ConfigureAgent — URL probe integration tests
 // Uses vi.mock (declared at module top) to control probeUrl return values.
 // ============================================================================

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -3358,9 +3358,7 @@ describe('includeEvalResponse flag via callTool()', () => {
     const response = JSON.parse(result.content[0].text);
     expect(response.success).toBe(true);
     expect(response.iterations).toHaveLength(1);
-    expect(response.iterations[0].evalResponse).toBe(
-      '{"decision":"pass","score":0.9,"reasoning":"Excellent output"}',
-    );
+    expect(response.iterations[0].evalResponse).toBe('{"decision":"pass","score":0.9,"reasoning":"Excellent output"}');
   });
 
   it('should exclude evalResponse from iteration objects when includeEvalResponse is omitted (default)', async () => {

--- a/tests/unit/cli/dashboard/detail-view.test.tsx
+++ b/tests/unit/cli/dashboard/detail-view.test.tsx
@@ -7,6 +7,7 @@
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DetailOutputConfig } from '../../../../src/cli/dashboard/components/detail-output-panel.js';
 import { formatElapsed } from '../../../../src/cli/dashboard/format.js';
 import type { DashboardData } from '../../../../src/cli/dashboard/types.js';
 import { DetailView } from '../../../../src/cli/dashboard/views/detail-view.js';
@@ -42,6 +43,14 @@ import type { ScheduleExecution } from '../../../../src/core/interfaces.js';
 // ============================================================================
 // Test fixtures
 // ============================================================================
+
+/** Stable no-op output config for tests that don't exercise the output panel */
+const NO_OUTPUT_CONFIG: DetailOutputConfig = {
+  visible: false,
+  autoTail: true,
+  scrollOffset: 0,
+  terminalRows: 24,
+};
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -509,7 +518,13 @@ describe('OrchestrationDetail', () => {
 describe('DetailView', () => {
   it('shows entity-not-found when data is null', () => {
     const { lastFrame } = render(
-      <DetailView entityType="loops" entityId="loop-missing" data={null} scrollOffset={0} />,
+      <DetailView
+        entityType="loops"
+        entityId="loop-missing"
+        data={null}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Entity not found');
   });
@@ -517,7 +532,13 @@ describe('DetailView', () => {
   it('shows entity-not-found when entity ID does not match', () => {
     const data = makeDashboardData({ loops: [makeLoop()] });
     const { lastFrame } = render(
-      <DetailView entityType="loops" entityId="loop-does-not-exist" data={data} scrollOffset={0} />,
+      <DetailView
+        entityType="loops"
+        entityId="loop-does-not-exist"
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Entity not found');
   });
@@ -525,7 +546,15 @@ describe('DetailView', () => {
   it('dispatches to LoopDetail for loops entityType', () => {
     const loop = makeLoop();
     const data = makeDashboardData({ loops: [loop] });
-    const { lastFrame } = render(<DetailView entityType="loops" entityId={loop.id} data={data} scrollOffset={0} />);
+    const { lastFrame } = render(
+      <DetailView
+        entityType="loops"
+        entityId={loop.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
+    );
     expect(lastFrame()).toContain('Loop Detail');
     expect(lastFrame()).toContain(loop.id);
   });
@@ -533,7 +562,15 @@ describe('DetailView', () => {
   it('dispatches to TaskDetail for tasks entityType', () => {
     const task = makeTask();
     const data = makeDashboardData({ tasks: [task] });
-    const { lastFrame } = render(<DetailView entityType="tasks" entityId={task.id} data={data} scrollOffset={0} />);
+    const { lastFrame } = render(
+      <DetailView
+        entityType="tasks"
+        entityId={task.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
+    );
     expect(lastFrame()).toContain('Task Detail');
     expect(lastFrame()).toContain(task.id);
   });
@@ -542,7 +579,13 @@ describe('DetailView', () => {
     const schedule = makeSchedule();
     const data = makeDashboardData({ schedules: [schedule] });
     const { lastFrame } = render(
-      <DetailView entityType="schedules" entityId={schedule.id} data={data} scrollOffset={0} />,
+      <DetailView
+        entityType="schedules"
+        entityId={schedule.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Schedule Detail');
     expect(lastFrame()).toContain(schedule.id);
@@ -552,7 +595,13 @@ describe('DetailView', () => {
     const orch = makeOrchestration();
     const data = makeDashboardData({ orchestrations: [orch] });
     const { lastFrame } = render(
-      <DetailView entityType="orchestrations" entityId={orch.id} data={data} scrollOffset={0} />,
+      <DetailView
+        entityType="orchestrations"
+        entityId={orch.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Orchestration Detail');
     expect(lastFrame()).toContain(orch.id);
@@ -565,7 +614,15 @@ describe('DetailView', () => {
       loops: [loop],
       iterations: [iter],
     });
-    const { lastFrame } = render(<DetailView entityType="loops" entityId={loop.id} data={data} scrollOffset={0} />);
+    const { lastFrame } = render(
+      <DetailView
+        entityType="loops"
+        entityId={loop.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
+    );
     expect(lastFrame()).toContain('(1 total)');
   });
 
@@ -577,7 +634,13 @@ describe('DetailView', () => {
       executions: [exec],
     });
     const { lastFrame } = render(
-      <DetailView entityType="schedules" entityId={schedule.id} data={data} scrollOffset={0} />,
+      <DetailView
+        entityType="schedules"
+        entityId={schedule.id}
+        data={data}
+        scrollOffset={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('(1 total)');
   });
@@ -999,7 +1062,14 @@ describe('DetailView — pipeline dispatch', () => {
   it('shows NotFound when pipeline entity is not in data', () => {
     const data = makeDashboardData({ pipelines: [] });
     const { lastFrame } = render(
-      <DetailView entityType="pipelines" entityId="pipeline-missing" data={data} scrollOffset={0} animFrame={0} />,
+      <DetailView
+        entityType="pipelines"
+        entityId="pipeline-missing"
+        data={data}
+        scrollOffset={0}
+        animFrame={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Entity not found');
   });
@@ -1008,7 +1078,14 @@ describe('DetailView — pipeline dispatch', () => {
     const pipeline = makePipeline();
     const data = makeDashboardData({ pipelines: [pipeline as unknown as Pipeline] });
     const { lastFrame } = render(
-      <DetailView entityType="pipelines" entityId={pipeline.id} data={data} scrollOffset={0} animFrame={0} />,
+      <DetailView
+        entityType="pipelines"
+        entityId={pipeline.id}
+        data={data}
+        scrollOffset={0}
+        animFrame={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     expect(lastFrame()).toContain('Pipeline Detail');
   });
@@ -1024,7 +1101,14 @@ describe('DetailView — pipeline dispatch', () => {
       tasks: [task],
     });
     const { lastFrame } = render(
-      <DetailView entityType="pipelines" entityId={pipeline.id} data={data} scrollOffset={0} animFrame={0} />,
+      <DetailView
+        entityType="pipelines"
+        entityId={pipeline.id}
+        data={data}
+        scrollOffset={0}
+        animFrame={0}
+        detailOutputConfig={NO_OUTPUT_CONFIG}
+      />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('Pipeline Detail');

--- a/tests/unit/cli/dashboard/footer.test.tsx
+++ b/tests/unit/cli/dashboard/footer.test.tsx
@@ -95,9 +95,9 @@ describe('Footer', () => {
       expect(lastFrame()).toContain('Esc back');
     });
 
-    it('contains "↑↓ scroll" hint', () => {
+    it('contains "↑↓ select" hint', () => {
       const { lastFrame } = render(<Footer viewKind="detail" />);
-      expect(lastFrame()).toContain('↑↓ scroll');
+      expect(lastFrame()).toContain('↑↓ select');
     });
 
     it('does not render main-view hints', () => {

--- a/tests/unit/cli/dashboard/layout.test.ts
+++ b/tests/unit/cli/dashboard/layout.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { computeMetricsLayout, computeWorkspaceLayout } from '../../../../src/cli/dashboard/layout.js';
+import {
+  computeDetailOutputLayout,
+  computeMetricsLayout,
+  computeWorkspaceLayout,
+} from '../../../../src/cli/dashboard/layout.js';
 
 // ============================================================================
 // computeMetricsLayout
@@ -287,5 +291,59 @@ describe('computeWorkspaceLayout', () => {
       const layout = computeWorkspaceLayout({ columns: 120, rows: 24, childCount: 1 });
       expect(layout.navWidth).toBe(24);
     });
+  });
+});
+
+// ============================================================================
+// computeDetailOutputLayout (#165)
+// ============================================================================
+
+describe('computeDetailOutputLayout', () => {
+  it('normal terminal (rows=30, meta=15) returns viewport=11, tooSmall=false', () => {
+    // available = 30 - 15 - 4 = 11; 11 >= 5 → tooSmall=false
+    const layout = computeDetailOutputLayout({ rows: 30, metadataHeight: 15 });
+    expect(layout.tooSmall).toBe(false);
+    expect(layout.outputViewportHeight).toBe(11);
+  });
+
+  it('tiny terminal (rows=15, meta=12) returns tooSmall=true', () => {
+    // available = 15 - 12 - 4 = -1; -1 < 5 → tooSmall=true
+    const layout = computeDetailOutputLayout({ rows: 15, metadataHeight: 12 });
+    expect(layout.tooSmall).toBe(true);
+    expect(layout.outputViewportHeight).toBe(0);
+  });
+
+  it('large terminal (rows=80, meta=20) returns viewport=56, tooSmall=false', () => {
+    // available = 80 - 20 - 4 = 56
+    const layout = computeDetailOutputLayout({ rows: 80, metadataHeight: 20 });
+    expect(layout.tooSmall).toBe(false);
+    expect(layout.outputViewportHeight).toBe(56);
+  });
+
+  it('zero metadata (rows=30, meta=0) returns viewport=26, tooSmall=false', () => {
+    // available = 30 - 0 - 4 = 26
+    const layout = computeDetailOutputLayout({ rows: 30, metadataHeight: 0 });
+    expect(layout.tooSmall).toBe(false);
+    expect(layout.outputViewportHeight).toBe(26);
+  });
+
+  it('metadata fills screen (rows=20, meta=18) returns tooSmall=true', () => {
+    // available = 20 - 18 - 4 = -2; -2 < 5 → tooSmall=true
+    const layout = computeDetailOutputLayout({ rows: 20, metadataHeight: 18 });
+    expect(layout.tooSmall).toBe(true);
+    expect(layout.outputViewportHeight).toBe(0);
+  });
+
+  it('boundary: exactly 5 available rows returns tooSmall=false', () => {
+    // available = 9 - 0 - 4 = 5; 5 >= 5 → tooSmall=false
+    const layout = computeDetailOutputLayout({ rows: 9, metadataHeight: 0 });
+    expect(layout.tooSmall).toBe(false);
+    expect(layout.outputViewportHeight).toBe(5);
+  });
+
+  it('boundary: exactly 4 available rows returns tooSmall=true', () => {
+    // available = 8 - 0 - 4 = 4; 4 < 5 → tooSmall=true
+    const layout = computeDetailOutputLayout({ rows: 8, metadataHeight: 0 });
+    expect(layout.tooSmall).toBe(true);
   });
 });

--- a/tests/unit/cli/dashboard/loop-detail-helpers.test.ts
+++ b/tests/unit/cli/dashboard/loop-detail-helpers.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for loop-detail pure helper functions
+ * ARCHITECTURE: Pure function tests — no React mounting, no Ink dependency
+ * Covers: resolveIterationIndex, renderConvergenceLine
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveIterationIndex } from '../../../../src/cli/dashboard/keyboard/helpers.js';
+import { renderConvergenceLine } from '../../../../src/cli/dashboard/views/loop-detail.js';
+import type { LoopIteration } from '../../../../src/core/domain.js';
+import type { LoopId, TaskId } from '../../../../src/core/types.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeIter(
+  n: number,
+  opts: {
+    score?: number;
+    status?: LoopIteration['status'];
+    taskId?: string;
+  } = {},
+): LoopIteration {
+  return {
+    id: n,
+    loopId: 'loop-test' as LoopId,
+    iterationNumber: n,
+    taskId: opts.taskId ? (opts.taskId as TaskId) : undefined,
+    status: opts.status ?? 'pass',
+    score: opts.score,
+    startedAt: Date.now(),
+  } as LoopIteration;
+}
+
+// ============================================================================
+// resolveIterationIndex
+// ============================================================================
+
+describe('resolveIterationIndex', () => {
+  const iterations = [makeIter(1), makeIter(2), makeIter(3)];
+
+  it('returns 0 when selectedNumber is null', () => {
+    expect(resolveIterationIndex(null, iterations)).toBe(0);
+  });
+
+  it('returns correct index for found iterationNumber', () => {
+    expect(resolveIterationIndex(2, iterations)).toBe(1);
+    expect(resolveIterationIndex(3, iterations)).toBe(2);
+  });
+
+  it('returns 0 when iterationNumber not found', () => {
+    expect(resolveIterationIndex(99, iterations)).toBe(0);
+  });
+
+  it('returns 0 for empty array', () => {
+    expect(resolveIterationIndex(1, [])).toBe(0);
+    expect(resolveIterationIndex(null, [])).toBe(0);
+  });
+
+  it('finds the first iteration by number', () => {
+    expect(resolveIterationIndex(1, iterations)).toBe(0);
+  });
+});
+
+// ============================================================================
+// renderConvergenceLine
+// ============================================================================
+
+describe('renderConvergenceLine', () => {
+  it('returns empty string when no scored iterations', () => {
+    const iters = [makeIter(1, { score: undefined })];
+    expect(renderConvergenceLine(iters, 'maximize')).toBe('');
+  });
+
+  it('returns empty string for single scored iteration', () => {
+    // 1 scored iteration: no trend to show (need 0 comparison baseline)
+    // NOTE: First iter always gets → since runningBest=scored[0].score
+    const iters = [makeIter(1, { score: 3.5 })];
+    const result = renderConvergenceLine(iters, 'maximize');
+    // Single item: gets the → arrow because it equals itself (runningBest)
+    expect(result).toBe('3.5→');
+  });
+
+  it('maximize: shows ↑ when score improves', () => {
+    // DESC order (newest first) → reverses to [1, 2] chronologically
+    const iters = [makeIter(2, { score: 5.0 }), makeIter(1, { score: 3.0 })];
+    const result = renderConvergenceLine(iters, 'maximize');
+    // chronological: iter1=3.0→, iter2=5.0↑
+    expect(result).toBe('3.0→ 5.0↑');
+  });
+
+  it('maximize: shows ↓ when score regresses', () => {
+    const iters = [makeIter(2, { score: 2.0 }), makeIter(1, { score: 5.0 })];
+    const result = renderConvergenceLine(iters, 'maximize');
+    // chronological: iter1=5.0→, iter2=2.0↓
+    expect(result).toBe('5.0→ 2.0↓');
+  });
+
+  it('maximize: shows → when score stays same', () => {
+    const iters = [makeIter(2, { score: 3.0 }), makeIter(1, { score: 3.0 })];
+    const result = renderConvergenceLine(iters, 'maximize');
+    expect(result).toBe('3.0→ 3.0→');
+  });
+
+  it('minimize: shows ↑ when score decreases (improvement)', () => {
+    const iters = [makeIter(2, { score: 2.0 }), makeIter(1, { score: 5.0 })];
+    const result = renderConvergenceLine(iters, 'minimize');
+    // chronological: iter1=5.0→, iter2=2.0↑ (lower is better)
+    expect(result).toBe('5.0→ 2.0↑');
+  });
+
+  it('minimize: shows ↓ when score increases (regression)', () => {
+    const iters = [makeIter(2, { score: 8.0 }), makeIter(1, { score: 3.0 })];
+    const result = renderConvergenceLine(iters, 'minimize');
+    // chronological: iter1=3.0→, iter2=8.0↓ (higher is worse)
+    expect(result).toBe('3.0→ 8.0↓');
+  });
+
+  it('defaults to maximize when evalDirection is undefined', () => {
+    const iters = [makeIter(2, { score: 5.0 }), makeIter(1, { score: 3.0 })];
+    const maximize = renderConvergenceLine(iters, 'maximize');
+    const defaultDir = renderConvergenceLine(iters, undefined);
+    expect(defaultDir).toBe(maximize);
+  });
+
+  it('excludes progress-status iterations from trend', () => {
+    const iters = [
+      makeIter(3, { score: 4.0, status: 'pass' }),
+      makeIter(2, { score: 3.5, status: 'progress' }), // excluded
+      makeIter(1, { score: 3.0, status: 'pass' }),
+    ];
+    const result = renderConvergenceLine(iters, 'maximize');
+    // chronological: iter1=3.0→, iter3=4.0↑ (iter2 skipped)
+    expect(result).toBe('3.0→ 4.0↑');
+  });
+
+  it('caps at last 20 scored iterations', () => {
+    // Create 25 iterations in DESC order (newest first)
+    const iters: LoopIteration[] = [];
+    for (let i = 25; i >= 1; i--) {
+      iters.push(makeIter(i, { score: i * 1.0 }));
+    }
+    const result = renderConvergenceLine(iters, 'maximize');
+    const parts = result.split(' ');
+    // Should only have 20 parts (last 20 of 25)
+    expect(parts).toHaveLength(20);
+    // First part should be iter 6 (scores 6.0 through 25.0)
+    expect(parts[0]).toMatch(/^6\.0/);
+  });
+
+  it('returns empty string when all iterations have undefined scores', () => {
+    const iters = [makeIter(1, { score: undefined }), makeIter(2, { score: undefined })];
+    expect(renderConvergenceLine(iters, 'maximize')).toBe('');
+  });
+
+  it('running best tracks improvements correctly over multiple iters', () => {
+    // Ascending scores: 1→3→2→5→4 — best should track: 1, 3, 3, 5, 5
+    const iters = [
+      makeIter(5, { score: 4.0 }), // DESC order
+      makeIter(4, { score: 5.0 }),
+      makeIter(3, { score: 2.0 }),
+      makeIter(2, { score: 3.0 }),
+      makeIter(1, { score: 1.0 }),
+    ];
+    const result = renderConvergenceLine(iters, 'maximize');
+    // chronological: 1→, 3↑, 2↓, 5↑, 4↓
+    expect(result).toBe('1.0→ 3.0↑ 2.0↓ 5.0↑ 4.0↓');
+  });
+});

--- a/tests/unit/cli/dashboard/loop-detail-helpers.test.ts
+++ b/tests/unit/cli/dashboard/loop-detail-helpers.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { resolveIterationIndex } from '../../../../src/cli/dashboard/keyboard/helpers.js';
-import { renderConvergenceLine } from '../../../../src/cli/dashboard/views/loop-detail.js';
+import { parseEvalResponseJson, renderConvergenceLine } from '../../../../src/cli/dashboard/views/loop-detail.js';
 import type { LoopIteration } from '../../../../src/core/domain.js';
 import type { LoopId, TaskId } from '../../../../src/core/types.js';
 
@@ -166,5 +166,60 @@ describe('renderConvergenceLine', () => {
     const result = renderConvergenceLine(iters, 'maximize');
     // chronological: 1→, 3↑, 2↓, 5↑, 4↓
     expect(result).toBe('1.0→ 3.0↑ 2.0↓ 5.0↑ 4.0↓');
+  });
+});
+
+// ============================================================================
+// parseEvalResponseJson
+// ============================================================================
+
+describe('parseEvalResponseJson', () => {
+  it('returns structured object with all fields for valid JSON', () => {
+    const raw = JSON.stringify({ decision: 'pass', score: 0.95, reasoning: 'Looks good' });
+    const result = parseEvalResponseJson(raw);
+    expect(result).toEqual({ decision: 'pass', score: 0.95, reasoning: 'Looks good' });
+  });
+
+  it('returns object with only score field when only score is present', () => {
+    const raw = JSON.stringify({ score: 0.7 });
+    const result = parseEvalResponseJson(raw);
+    expect(result).toEqual({ score: 0.7, decision: undefined, reasoning: undefined });
+  });
+
+  it('coerces score from string to number', () => {
+    const raw = JSON.stringify({ decision: 'fail', score: '0.87', reasoning: 'Too slow' });
+    const result = parseEvalResponseJson(raw);
+    expect(result).not.toBeNull();
+    expect(result?.score).toBe(0.87);
+  });
+
+  it('returns null for invalid JSON string', () => {
+    expect(parseEvalResponseJson('not valid json {')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseEvalResponseJson('')).toBeNull();
+  });
+
+  it('returns null for JSON array (non-object)', () => {
+    expect(parseEvalResponseJson(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+
+  it('returns null for JSON number (non-object)', () => {
+    expect(parseEvalResponseJson(JSON.stringify(42))).toBeNull();
+  });
+
+  it('returns null for JSON null', () => {
+    expect(parseEvalResponseJson(JSON.stringify(null))).toBeNull();
+  });
+
+  it('omits fields with wrong types rather than coercing them', () => {
+    const raw = JSON.stringify({ decision: 123, score: true, reasoning: null });
+    const result = parseEvalResponseJson(raw);
+    // decision is not a string, score is not number/parseable string, reasoning is not string
+    expect(result).not.toBeNull();
+    expect(result?.decision).toBeUndefined();
+    expect(result?.score).toBeUndefined();
+    expect(result?.reasoning).toBeUndefined();
   });
 });

--- a/tests/unit/cli/dashboard/nav-reducer.test.ts
+++ b/tests/unit/cli/dashboard/nav-reducer.test.ts
@@ -24,6 +24,10 @@ const INITIAL_NAV: NavState = {
   scrollOffsets: { loops: 0, tasks: 0, schedules: 0, orchestrations: 0, pipelines: 0 },
   orchestrationChildSelectedTaskId: null,
   orchestrationChildPage: 0,
+  detailOutputVisible: true,
+  detailOutputAutoTail: true,
+  detailOutputScrollOffset: 0,
+  loopIterationSelectedNumber: null,
 };
 
 function makeState(overrides: Partial<DashboardState> = {}): DashboardState {
@@ -181,5 +185,76 @@ describe('immutability', () => {
     // Only animFrame changed — nav and workspaceNav should be same reference
     expect(next.nav).toBe(state.nav);
     expect(next.workspaceNav).toBe(state.workspaceNav);
+  });
+});
+
+// ============================================================================
+// NavState new fields — output state + loop iteration (#165 + #168)
+// ============================================================================
+
+describe('NavState — new output + iteration fields', () => {
+  it('SET_VIEW to detail does NOT reset detailOutputVisible', () => {
+    // DECISION: Reducers must NOT reset nav state on SET_VIEW so that Esc-return
+    // from a drilled-through detail preserves the user's previous output state.
+    const state = makeState({
+      nav: { ...INITIAL_NAV, detailOutputVisible: false, detailOutputAutoTail: false },
+    });
+    const next = dashboardReducer(state, {
+      type: 'SET_VIEW',
+      view: { kind: 'detail', entityType: 'tasks', entityId: 'task-1' as never, returnTo: 'main' },
+    });
+    expect(next.nav.detailOutputVisible).toBe(false);
+    expect(next.nav.detailOutputAutoTail).toBe(false);
+  });
+
+  it('SET_VIEW to detail does NOT reset loopIterationSelectedNumber', () => {
+    const state = makeState({
+      nav: { ...INITIAL_NAV, loopIterationSelectedNumber: 5 },
+    });
+    const next = dashboardReducer(state, {
+      type: 'SET_VIEW',
+      view: { kind: 'detail', entityType: 'loops', entityId: 'loop-1' as never, returnTo: 'main' },
+    });
+    expect(next.nav.loopIterationSelectedNumber).toBe(5);
+  });
+
+  it('SET_VIEW preserves all nav state fields', () => {
+    const customNav: NavState = {
+      ...INITIAL_NAV,
+      detailOutputVisible: false,
+      detailOutputAutoTail: false,
+      detailOutputScrollOffset: 7,
+      loopIterationSelectedNumber: 3,
+    };
+    const state = makeState({ nav: customNav });
+    const next = dashboardReducer(state, { type: 'SET_VIEW', view: { kind: 'main' } });
+    expect(next.nav).toBe(customNav); // referential equality — same object
+  });
+
+  it('UPDATE_NAV can update detailOutputVisible', () => {
+    const state = makeState({ nav: { ...INITIAL_NAV, detailOutputVisible: true } });
+    const next = dashboardReducer(state, {
+      type: 'UPDATE_NAV',
+      updater: (prev) => ({ ...prev, detailOutputVisible: false }),
+    });
+    expect(next.nav.detailOutputVisible).toBe(false);
+  });
+
+  it('UPDATE_NAV can update loopIterationSelectedNumber', () => {
+    const state = makeState({ nav: { ...INITIAL_NAV, loopIterationSelectedNumber: null } });
+    const next = dashboardReducer(state, {
+      type: 'UPDATE_NAV',
+      updater: (prev) => ({ ...prev, loopIterationSelectedNumber: 7 }),
+    });
+    expect(next.nav.loopIterationSelectedNumber).toBe(7);
+  });
+
+  it('UPDATE_NAV can update detailOutputScrollOffset', () => {
+    const state = makeState({ nav: { ...INITIAL_NAV, detailOutputScrollOffset: 0 } });
+    const next = dashboardReducer(state, {
+      type: 'UPDATE_NAV',
+      updater: (prev) => ({ ...prev, detailOutputScrollOffset: 5 }),
+    });
+    expect(next.nav.detailOutputScrollOffset).toBe(5);
   });
 });

--- a/tests/unit/cli/dashboard/use-keyboard.test.tsx
+++ b/tests/unit/cli/dashboard/use-keyboard.test.tsx
@@ -33,6 +33,7 @@ import { createInitialWorkspaceNavState } from '../../../../src/cli/dashboard/wo
 import type {
   Loop,
   LoopId,
+  LoopIteration,
   Orchestration,
   OrchestratorChild,
   OrchestratorId,
@@ -153,6 +154,10 @@ const INITIAL_NAV: NavState = {
   scrollOffsets: { loops: 0, tasks: 0, schedules: 0, orchestrations: 0, pipelines: 0 },
   orchestrationChildSelectedTaskId: null,
   orchestrationChildPage: 0,
+  detailOutputVisible: true,
+  detailOutputAutoTail: true,
+  detailOutputScrollOffset: 0,
+  loopIterationSelectedNumber: null,
 };
 
 // ============================================================================
@@ -206,6 +211,10 @@ function KeyboardWrapper({
       <Text>scroll-loops:{nav.scrollOffsets.loops}</Text>
       <Text>orch-child-sel:{nav.orchestrationChildSelectedTaskId ?? 'null'}</Text>
       <Text>orch-child-page:{nav.orchestrationChildPage}</Text>
+      <Text>out-visible:{nav.detailOutputVisible ? 'true' : 'false'}</Text>
+      <Text>out-tail:{nav.detailOutputAutoTail ? 'true' : 'false'}</Text>
+      <Text>out-scroll:{nav.detailOutputScrollOffset}</Text>
+      <Text>loop-iter-sel:{nav.loopIterationSelectedNumber ?? 'null'}</Text>
     </Box>
   );
 }
@@ -1134,5 +1143,271 @@ describe('useKeyboard — D3 orchestration detail child navigation', () => {
     expect(lastFrame()).toContain('orch-child-sel:task-jk-002');
     await press(stdin, 'k'); // like up
     expect(lastFrame()).toContain('orch-child-sel:task-jk-001');
+  });
+});
+
+// ============================================================================
+// Output controls — task/orchestration detail (#165)
+// ============================================================================
+
+describe('useKeyboard — output controls in detail view (#165)', () => {
+  function taskDetailView(taskId: string) {
+    return {
+      kind: 'detail' as const,
+      entityType: 'tasks' as const,
+      entityId: taskId as TaskId,
+      returnTo: 'main' as const,
+    };
+  }
+
+  function loopDetailView(loopId: string) {
+    return {
+      kind: 'detail' as const,
+      entityType: 'loops' as const,
+      entityId: loopId as LoopId,
+      returnTo: 'main' as const,
+    };
+  }
+
+  it('"o" toggles detailOutputVisible in task detail', async () => {
+    const task = makeTask('task-out-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputVisible: true };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-out-001')} />,
+    );
+    expect(lastFrame()).toContain('out-visible:true');
+    await press(stdin, 'o');
+    expect(lastFrame()).toContain('out-visible:false');
+    await press(stdin, 'o');
+    expect(lastFrame()).toContain('out-visible:true');
+  });
+
+  it('"o" is a no-op in loop detail (output controls guarded to task/orch only)', async () => {
+    const loop = makeLoop('loop-out-001');
+    const data = makeDashboardData({ loops: [loop] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputVisible: true };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={loopDetailView('loop-out-001')} />,
+    );
+    expect(lastFrame()).toContain('out-visible:true');
+    await press(stdin, 'o');
+    // loops swallow all keys — visible unchanged but loop detail is active
+    expect(lastFrame()).toContain('detail-type:loops');
+    // visible stays true since 'o' is swallowed without toggling
+    expect(lastFrame()).toContain('out-visible:true');
+  });
+
+  it('"[" scrolls output up and sets auto-tail false', async () => {
+    const task = makeTask('task-scroll-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputScrollOffset: 3, detailOutputAutoTail: true };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-scroll-001')} />,
+    );
+    await press(stdin, '[');
+    expect(lastFrame()).toContain('out-scroll:2');
+    expect(lastFrame()).toContain('out-tail:false');
+  });
+
+  it('"[" clamps at 0', async () => {
+    const task = makeTask('task-clamp-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputScrollOffset: 0 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-clamp-001')} />,
+    );
+    await press(stdin, '[');
+    expect(lastFrame()).toContain('out-scroll:0');
+  });
+
+  it('"]" scrolls output down', async () => {
+    const task = makeTask('task-down-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputScrollOffset: 5 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-down-001')} />,
+    );
+    await press(stdin, ']');
+    expect(lastFrame()).toContain('out-scroll:6');
+  });
+
+  it('"G" re-engages auto-tail', async () => {
+    const task = makeTask('task-tail-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputAutoTail: false, detailOutputScrollOffset: 10 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-tail-001')} />,
+    );
+    await press(stdin, 'G');
+    expect(lastFrame()).toContain('out-tail:true');
+    expect(lastFrame()).toContain('out-scroll:0');
+  });
+
+  it('"g" jumps to top without auto-tail', async () => {
+    const task = makeTask('task-top-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = { ...INITIAL_NAV, detailOutputAutoTail: true, detailOutputScrollOffset: 8 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={taskDetailView('task-top-001')} />,
+    );
+    await press(stdin, 'g');
+    expect(lastFrame()).toContain('out-tail:false');
+    expect(lastFrame()).toContain('out-scroll:0');
+  });
+});
+
+// ============================================================================
+// Loop iteration navigation (#168)
+// ============================================================================
+
+describe('useKeyboard — loop iteration navigation (#168)', () => {
+  function loopDetailView(loopId: string) {
+    return {
+      kind: 'detail' as const,
+      entityType: 'loops' as const,
+      entityId: loopId as LoopId,
+      returnTo: 'main' as const,
+    };
+  }
+
+  function makeIteration(n: number, taskId?: string): LoopIteration {
+    return {
+      id: n,
+      loopId: 'loop-iter-test' as LoopId,
+      iterationNumber: n,
+      taskId: taskId ? (taskId as TaskId) : undefined,
+      status: 'pass',
+      startedAt: Date.now(),
+    } as LoopIteration;
+  }
+
+  it('↓ moves loopIterationSelectedNumber to next iteration', async () => {
+    const loop = makeLoop('loop-nav-001');
+    const iterations: readonly LoopIteration[] = [makeIteration(1, 'task-001'), makeIteration(2, 'task-002')];
+    const data = makeDashboardData({ loops: [loop], iterations });
+    const nav: NavState = { ...INITIAL_NAV, loopIterationSelectedNumber: 1 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={loopDetailView('loop-nav-001')} />,
+    );
+    expect(lastFrame()).toContain('loop-iter-sel:1');
+    await press(stdin, '\x1B[B'); // down arrow
+    expect(lastFrame()).toContain('loop-iter-sel:2');
+  });
+
+  it('↑ moves loopIterationSelectedNumber to previous iteration', async () => {
+    const loop = makeLoop('loop-nav-002');
+    const iterations: readonly LoopIteration[] = [makeIteration(1, 'task-001'), makeIteration(2, 'task-002')];
+    const data = makeDashboardData({ loops: [loop], iterations });
+    const nav: NavState = { ...INITIAL_NAV, loopIterationSelectedNumber: 2 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={loopDetailView('loop-nav-002')} />,
+    );
+    await press(stdin, '\x1B[A'); // up arrow
+    expect(lastFrame()).toContain('loop-iter-sel:1');
+  });
+
+  it('Enter on iteration drills into task detail', async () => {
+    const loop = makeLoop('loop-drill-001');
+    const iterations: readonly LoopIteration[] = [makeIteration(1, 'task-drill-001')];
+    const data = makeDashboardData({ loops: [loop], iterations });
+    const nav: NavState = { ...INITIAL_NAV, loopIterationSelectedNumber: 1 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={loopDetailView('loop-drill-001')} />,
+    );
+    await press(stdin, '\r');
+    expect(lastFrame()).toContain('view:detail');
+    expect(lastFrame()).toContain('detail-type:tasks');
+    expect(lastFrame()).toContain('detail-id:task-drill-001');
+  });
+
+  it('Enter is a no-op when selected iteration has no taskId', async () => {
+    const loop = makeLoop('loop-notask-001');
+    const iterations: readonly LoopIteration[] = [makeIteration(1, undefined)];
+    const data = makeDashboardData({ loops: [loop], iterations });
+    const nav: NavState = { ...INITIAL_NAV, loopIterationSelectedNumber: 1 };
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper initialData={data} initialNav={nav} initialView={loopDetailView('loop-notask-001')} />,
+    );
+    await press(stdin, '\r');
+    // Still in loop detail — no navigation to task detail
+    expect(lastFrame()).toContain('detail-type:loops');
+  });
+
+  it('Esc from task detail returns to loop detail when returnTo is loops variant', async () => {
+    const loop = makeLoop('loop-esc-001');
+    const task = makeTask('task-esc-001');
+    const data = makeDashboardData({ loops: [loop], tasks: [task] });
+    const { lastFrame, stdin } = render(
+      <KeyboardWrapper
+        initialData={data}
+        initialView={{
+          kind: 'detail',
+          entityType: 'tasks',
+          entityId: 'task-esc-001' as TaskId,
+          returnTo: { kind: 'loops', entityId: 'loop-esc-001' as LoopId, originalReturnTo: 'main' },
+        }}
+      />,
+    );
+    expect(lastFrame()).toContain('detail-type:tasks');
+    await press(stdin, '\x1B'); // Escape
+    expect(lastFrame()).toContain('detail-type:loops');
+    expect(lastFrame()).toContain('detail-id:loop-esc-001');
+  });
+});
+
+// ============================================================================
+// main→detail Enter: nav state resets (#165 + #168)
+// ============================================================================
+
+describe('useKeyboard — main→detail Enter resets nav state', () => {
+  it('Enter from main→task resets output state (visible=true)', async () => {
+    const task = makeTask('task-reset-001');
+    const data = makeDashboardData({ tasks: [task] });
+    const nav: NavState = {
+      ...INITIAL_NAV,
+      focusedPanel: 'tasks',
+      detailOutputVisible: false,
+      detailOutputAutoTail: false,
+      detailOutputScrollOffset: 7,
+      loopIterationSelectedNumber: 3,
+    };
+    const { lastFrame, stdin } = render(<KeyboardWrapper initialData={data} initialNav={nav} />);
+    await press(stdin, '\r');
+    expect(lastFrame()).toContain('view:detail');
+    expect(lastFrame()).toContain('out-visible:true');
+    expect(lastFrame()).toContain('out-tail:true');
+    expect(lastFrame()).toContain('out-scroll:0');
+    expect(lastFrame()).toContain('loop-iter-sel:null');
+  });
+
+  it('Enter from main→orchestration resets output hidden (visible=false)', async () => {
+    const orch = makeOrchestration('orch-reset-001');
+    const data = makeDashboardData({ orchestrations: [orch] });
+    const nav: NavState = {
+      ...INITIAL_NAV,
+      focusedPanel: 'orchestrations',
+      detailOutputVisible: true,
+    };
+    const { lastFrame, stdin } = render(<KeyboardWrapper initialData={data} initialNav={nav} />);
+    await press(stdin, '\r');
+    expect(lastFrame()).toContain('view:detail');
+    // Orchestrations: visible=false (no direct task output concept at orchestration level)
+    expect(lastFrame()).toContain('out-visible:false');
+  });
+
+  it('Enter from main→loop resets loopIterationSelectedNumber to null', async () => {
+    const loop = makeLoop('loop-reset-001');
+    const data = makeDashboardData({ loops: [loop] });
+    const nav: NavState = {
+      ...INITIAL_NAV,
+      focusedPanel: 'loops',
+      loopIterationSelectedNumber: 5,
+    };
+    const { lastFrame, stdin } = render(<KeyboardWrapper initialData={data} initialNav={nav} />);
+    await press(stdin, '\r');
+    expect(lastFrame()).toContain('view:detail');
+    expect(lastFrame()).toContain('detail-type:loops');
+    expect(lastFrame()).toContain('loop-iter-sel:null');
   });
 });


### PR DESCRIPTION
## Summary

- **#165 — Stream Task Output in Detail Views**: Expands the existing output streaming infrastructure (previously workspace-only) to task detail and orchestration detail views. Adds `o` toggle, `[/]` scroll, `g/G` jump controls. Ref-based layout measurement via Ink's `measureElement` for adaptive viewport sizing.
- **#168 — Surface Evaluation Data in Loop Detail**: Adds iteration row selection (↑/↓), expanded eval section below iteration table (full evalFeedback, structured/raw evalResponse, exitCode, errorMessage), convergence trend line for optimize loops. Loop iteration drill-through to task detail with Esc return. MCP `LoopStatus` gets `includeEvalResponse` opt-in flag and eval config fields.

Both issues share overlapping files (types.ts, handle-detail-keys.ts, detail-view.tsx, app.tsx, hints.ts) so they are implemented on a single branch.

### Key Design Decisions

- **Nav state reset in Enter handler, not SET_VIEW reducer** — preserves state across drill-through returns
- **Output controls guarded to task/orchestration only** — `o/[/]/g/G` are no-ops in loop/schedule/pipeline detail
- **Iteration selection by iterationNumber** — stable across poll refreshes (not array index)
- **evalResponse opt-in via `includeEvalResponse`** — prevents MCP response bloat (can be 16KB+)
- **Ref-based layout measurement** — `measureElement` reads Yoga node height, eliminates fragile static line-counting

### Files Changed (17)

| Area | Files |
|------|-------|
| NavState + helpers | `types.ts`, `app.tsx`, `keyboard/helpers.ts` |
| #168 Loop eval | `views/loop-detail.tsx`, `views/detail-view.tsx`, `keyboard/handle-detail-keys.ts`, `keyboard/handle-main-keys.ts`, `adapters/mcp-adapter.ts` |
| #165 Output streaming | `layout.ts`, `views/task-detail.tsx`, `views/orchestration-detail.tsx`, `views/detail-view.tsx`, `keyboard/handle-detail-keys.ts`, `keyboard/handle-main-keys.ts`, `keyboard/hints.ts`, `app.tsx` |
| Tests | `layout.test.ts`, `nav-reducer.test.ts`, `use-keyboard.test.tsx`, `loop-detail-helpers.test.ts` (new), `footer.test.tsx` |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` — clean (321 files)
- [x] `npm run build` — clean
- [x] `npm run test:dashboard` — 701 tests passing
- [x] `npm run test:cli` — 299 tests passing
- [x] `npm run test:core` — 375 tests passing
- [x] `npm run test:handlers` — 189 tests passing
- [x] `npm run test:adapters` — 163 tests passing
- [x] Quality gates: Validator ✅ → Simplifier ✅ → Scrutinizer ✅ → re-Validator ✅ → Evaluator ✅ → Tester ✅

Closes #165, closes #168