### PR TITLE
feat(channels): Phase 8 — Channel CLI & MCP (#183)

### DIFF
--- a/.devflow/decisions/decisions.md
+++ b/.devflow/decisions/decisions.md
@@ -1,4 +1,4 @@
-<!-- TL;DR: 2 decisions. Key: ADR-001, ADR-002 -->
+<!-- TL;DR: 3 decisions. Key: ADR-001, ADR-002, ADR-003 -->
 # Architecture Decision Records
 
 Explicit design choices and trade-offs made during development.
@@ -18,3 +18,11 @@ Explicit design choices and trade-offs made during development.
 - **Rationale**: Keeps the review thread auditable, documents reasoning for anyone reading the PR later, and prevents the same issues being re-raised in future review cycles. The 300ms hardcoded wait in the tmux worker path was specifically documented as intentional (no feedback signal available).
 - **Status**: Active
 - **Source**: sidecar:obs_c3d9e5
+
+## ADR-003: Pre-existing design gaps found during PR review are tracked as GitHub issues rather than fixed in-scope
+
+- **Context**: PR #193 (channel service layer) — Greptile surfaced a P1 about recovered tmux sessions having no output callbacks, a limitation in `TmuxConnectorPort` that predates the PR
+- **Decision**: Pre-existing gaps not introduced by the current PR are replied to with an explanation and tracked as a GitHub issue (e.g. #194) rather than fixed in-scope
+- **Rationale**: Keeps PR scope bounded and avoids scope creep on already-large feature PRs. A GitHub issue provides a durable record that a reply comment alone would not — it cannot be forgotten and can be prioritized, assigned, and referenced in future work.
+- **Status**: Active
+- **Source**: sidecar:obs_e2c7b3

--- a/.devflow/decisions/pitfalls.md
+++ b/.devflow/decisions/pitfalls.md
@@ -1,4 +1,4 @@
-<!-- TL;DR: 3 pitfalls. Key: PF-001, PF-002, PF-003 -->
+<!-- TL;DR: 5 pitfalls. Key: PF-001, PF-002, PF-003, PF-004, PF-005 -->
 # Known Pitfalls
 
 Area-specific gotchas, fragile areas, and past bugs.
@@ -29,3 +29,21 @@ Area-specific gotchas, fragile areas, and past bugs.
 - **Resolution**: Before writing any feature code, run `git branch --show-current` and verify the branch. If not on the expected feature branch, create and checkout it explicitly. When the plan or issue specifies a branch name (e.g. `feat/181-channel-domain-persistence`), use it verbatim from the start.
 - **Status**: Active
 - **Source**: sidecar:obs_a4f7c2
+
+## PF-004: Multi-step create rollback must clean all three layers — DB record, external resource, and in-memory state
+
+- **Area**: error handling / rollback completeness in service layer
+- **Issue**: `ChannelManager` rollback on `ChannelCreated` emit failure cleaned tmux sessions and in-memory state but omitted `channelRepository.delete()`, leaving an orphaned channel DB record with the channel name permanently occupied
+- **Impact**: Channel name could not be reused until process restart; `ChannelCreated` re-emits or retries would fail with a name-collision error
+- **Resolution**: When rolling back a multi-step create operation (DB write → external resource allocation → event emit), reverse all three layers in LIFO order. A rollback that only handles external resources and memory but skips the DB record leaves state permanently inconsistent until process restart.
+- **Status**: Active
+- **Source**: sidecar:obs_d1f4a8
+
+## PF-005: Greptile re-reviews on every commit push — Greptile resolution is a multi-round cycle, not a one-shot pass
+
+- **Area**: PR review workflow with Greptile automated reviewer
+- **Issue**: Each time a fix is pushed to the branch, Greptile runs a fresh review of the entire diff and can surface new findings. Initial batch resolution is not final.
+- **Impact**: Declaring "all comments resolved" after the first round led to the user having to explicitly ask for a re-check, which surfaced a new P1 (`rrFirstMemberSeen` never reset). Missing this would have merged a stateful reset bug.
+- **Resolution**: After each push+fix cycle, explicitly poll the PR for new Greptile comments before declaring resolution complete. Expect 2–3 rounds on active PRs. Only close out when a full push-and-check cycle yields no new findings.
+- **Status**: Active
+- **Source**: sidecar:obs_f3a9d6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ When adding task dependencies:
 
 ### MCP Tools
 
-All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `RetryTask`, `ResumeTask`, `CreatePipeline`, `PipelineStatus`, `ListPipelines`, `CancelPipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`, `ListSchedules`, `ScheduleStatus`, `PauseSchedule`, `ResumeSchedule`, `CancelSchedule`, `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`, `InitCustomOrchestrator`, `ListAgents`, `ConfigureAgent`
+All tools use PascalCase: `DelegateTask`, `TaskStatus`, `TaskLogs`, `CancelTask`, `RetryTask`, `ResumeTask`, `CreatePipeline`, `PipelineStatus`, `ListPipelines`, `CancelPipeline`, `CreateLoop`, `LoopStatus`, `ListLoops`, `CancelLoop`, `PauseLoop`, `ResumeLoop`, `ScheduleTask`, `SchedulePipeline`, `ScheduleLoop`, `ListSchedules`, `ScheduleStatus`, `PauseSchedule`, `ResumeSchedule`, `CancelSchedule`, `CreateOrchestrator`, `OrchestratorStatus`, `ListOrchestrators`, `CancelOrchestrator`, `InitCustomOrchestrator`, `ListAgents`, `ConfigureAgent`, `CreateChannel`, `DestroyChannel`, `ChannelStatus`, `ListChannels`, `SendChannelMessage`, `PauseChannel`, `ResumeChannel`
 
 `DelegateTask` accepts an optional `metadata.orchestratorId` field for orchestrator attribution. Long-running MCP servers should pass this so sub-tasks are attributed to the calling orchestration even when the process ID changes across restarts.
 
@@ -322,6 +322,9 @@ Quick reference for common operations:
 | Translation middleware | `src/translation/middleware/` |
 | Pipeline repository | `src/implementations/pipeline-repository.ts` |
 | Channel repository | `src/implementations/channel-repository.ts` |
+| Channel service | `src/services/channel-manager.ts` |
+| Channel CLI command | `src/cli/commands/channel.ts` |
+| Msg CLI command | `src/cli/commands/msg.ts` |
 | Pipeline handler | `src/services/handlers/pipeline-handler.ts` |
 | Interactive orchestrator | `src/cli/commands/orchestrate-interactive.ts` |
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:tmux:integration": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/integration/tmux --no-file-parallelism",
     "test:scheduling": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/services/schedule-manager.test.ts tests/unit/services/schedule-executor.test.ts tests/unit/services/handlers/schedule-handler.test.ts --no-file-parallelism",
     "test:checkpoints": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/implementations/checkpoint-repository.test.ts tests/unit/services/handlers/checkpoint-handler.test.ts --no-file-parallelism",
-    "test:cli": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/cli.test.ts tests/unit/cli-init.test.ts tests/unit/cli-services.test.ts tests/unit/retry-functionality.test.ts tests/unit/read-only-context.test.ts --no-file-parallelism",
+    "test:cli": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/cli.test.ts tests/unit/cli-init.test.ts tests/unit/cli-services.test.ts tests/unit/retry-functionality.test.ts tests/unit/read-only-context.test.ts tests/unit/cli/channel.test.ts tests/unit/cli/msg.test.ts --no-file-parallelism",
     "test:error-scenarios": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/error-scenarios --no-file-parallelism",
     "test:integration": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/integration --exclude='**/tmux/**' --no-file-parallelism",
     "test:dashboard": "NODE_OPTIONS='--max-old-space-size=2048' vitest run tests/unit/cli/dashboard --no-file-parallelism",

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -4270,7 +4270,12 @@ export class MCPAdapter {
           },
         };
       }
-      const pathValidation = validatePath(data.workingDirectory);
+      // SECURITY: Pass '/' as baseDir so any absolute path is permitted — the isAbsolute()
+      // guard above already blocks relative paths. Using process.cwd() (the default) would
+      // reject any path outside the server's install directory, which incorrectly breaks
+      // all valid workingDirectory values. validatePath still resolves symlinks to catch
+      // symlink-based traversal attacks.
+      const pathValidation = validatePath(data.workingDirectory, '/');
       if (!pathValidation.ok) {
         return {
           ok: false,

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -561,24 +561,17 @@ const CancelLoopSchema = z.object({
 
 // Channel-related Zod schemas (Phase 8, epic #183)
 
-/**
- * ADR-001: Channel name regex imported from domain.ts (single source of truth).
- * Constraint: lowercase alphanumeric with interior hyphens, max 64 chars.
- * Must be a subset of tmux SESSION_NAME_REGEX — no transformation needed.
- */
-const channelNamePattern = CHANNEL_NAME_REGEX;
-
 export const CreateChannelSchema = z.object({
   name: z
     .string()
-    .regex(channelNamePattern, 'Channel name must be lowercase alphanumeric with interior hyphens, max 64 chars')
+    .regex(CHANNEL_NAME_REGEX, 'Channel name must be lowercase alphanumeric with interior hyphens, max 64 chars')
     .describe('Channel name (unique identifier, used as tmux session name suffix)'),
   members: z
     .array(
       z.object({
         name: z
           .string()
-          .regex(channelNamePattern, 'Member name must be lowercase alphanumeric with interior hyphens, max 64 chars')
+          .regex(CHANNEL_NAME_REGEX, 'Member name must be lowercase alphanumeric with interior hyphens, max 64 chars')
           .describe('Member name'),
         agent: z.string().min(1).describe('Agent provider for this member'),
         systemPrompt: z.string().max(100_000).optional().describe('Per-member system prompt'),

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -574,7 +574,7 @@ export const CreateChannelSchema = z.object({
           .string()
           .regex(CHANNEL_NAME_REGEX, 'Member name must be lowercase alphanumeric with interior hyphens, max 64 chars')
           .describe('Member name'),
-        agent: z.string().min(1).describe('Agent provider for this member'),
+        agent: z.enum(AGENT_PROVIDERS_TUPLE).describe('Agent provider for this member'),
         systemPrompt: z.string().max(100_000).optional().describe('Per-member system prompt'),
       }),
     )
@@ -4296,8 +4296,8 @@ export class MCPAdapter {
           agent: m.agent,
           // Per-member systemPrompt wins (??). Fall back to top-level only for the sole member.
           systemPrompt: m.systemPrompt ?? (data.members.length === 1 && idx === 0 ? data.systemPrompt : undefined),
-        })) as ChannelMemberRequest[],
-        communicationMode: data.communicationMode as CommunicationMode | undefined,
+        })),
+        communicationMode: data.communicationMode,
         maxRounds: data.maxRounds,
         topic: data.topic,
         workingDirectory: data.workingDirectory,

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -4293,7 +4293,7 @@ export class MCPAdapter {
                 channelId: channel.id,
                 name: channel.name,
                 status: channel.status,
-                memberCount: channel.members.length,
+                members: channel.members.map((m) => ({ name: m.name, agent: m.agent, status: m.status })),
                 communicationMode: channel.communicationMode ?? null,
                 maxRounds: channel.maxRounds ?? null,
                 message: 'Channel created successfully',

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -3,6 +3,7 @@
  * Bridges the MCP protocol with our new architecture
  */
 
+import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import {
@@ -25,6 +26,11 @@ import {
   saveAgentConfig,
 } from '../core/configuration.js';
 import {
+  type Channel,
+  type ChannelCreateRequest,
+  ChannelId,
+  ChannelStatus,
+  type CommunicationMode,
   EvalMode,
   LoopCreateRequest,
   LoopId,
@@ -48,6 +54,7 @@ import {
   TaskRequest,
 } from '../core/domain.js';
 import {
+  ChannelService,
   Logger,
   LoopService,
   OrchestrationService,
@@ -551,6 +558,83 @@ const CancelLoopSchema = z.object({
   cancelTasks: z.boolean().optional().default(true).describe('Also cancel in-flight tasks'),
 });
 
+// Channel-related Zod schemas (Phase 8, epic #183)
+
+/**
+ * DECISION: Channel name regex mirrors CHANNEL_NAME_REGEX from domain.ts.
+ * Inline here so the MCP layer validates without importing domain constants.
+ * Constraint: lowercase alphanumeric with interior hyphens, max 64 chars.
+ * ADR-001: Must be a subset of tmux SESSION_NAME_REGEX — no transformation needed.
+ */
+const channelNamePattern = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+
+export const CreateChannelSchema = z.object({
+  name: z
+    .string()
+    .regex(channelNamePattern, 'Channel name must be lowercase alphanumeric with interior hyphens, max 64 chars')
+    .describe('Channel name (unique identifier, used as tmux session name suffix)'),
+  members: z
+    .array(
+      z.object({
+        name: z
+          .string()
+          .regex(channelNamePattern, 'Member name must be lowercase alphanumeric with interior hyphens, max 64 chars')
+          .describe('Member name'),
+        agent: z.string().min(1).describe('Agent provider for this member'),
+        systemPrompt: z.string().max(100_000).optional().describe('Per-member system prompt'),
+      }),
+    )
+    .min(1, 'At least one member is required')
+    .max(10, 'At most 10 members allowed')
+    .describe('Channel members'),
+  communicationMode: z
+    .enum(['broadcast', 'directed', 'round-robin'])
+    .optional()
+    .describe('Message routing strategy (default: broadcast for ≥2 members)'),
+  maxRounds: z
+    .number()
+    .int()
+    .min(1)
+    .max(10_000)
+    .optional()
+    .describe('Maximum conversation rounds before channel transitions to COMPLETED (required for ≥2 members)'),
+  topic: z.string().optional().describe('Initial topic delivered to members on creation'),
+  workingDirectory: z.string().optional().describe('Working directory for member agent sessions (absolute path)'),
+  systemPrompt: z
+    .string()
+    .max(100_000)
+    .optional()
+    .describe('System prompt for single-member channels (overrides per-member systemPrompt)'),
+});
+
+export const DestroyChannelSchema = z.object({
+  channelId: z.string().min(1).describe('Channel ID to destroy'),
+  reason: z.string().optional().describe('Reason for destruction (informational)'),
+});
+
+export const ChannelStatusSchema = z.object({
+  channelId: z.string().min(1).describe('Channel ID'),
+});
+
+export const ListChannelsSchema = z.object({
+  status: z.enum(['active', 'paused', 'completed', 'destroyed']).optional().describe('Filter by status'),
+  limit: z.number().int().min(1).max(100).optional().describe('Maximum results to return'),
+});
+
+export const SendChannelMessageSchema = z.object({
+  channelId: z.string().min(1).describe('Channel ID'),
+  message: z.string().min(1).max(262_144).describe('Message text to deliver (max 256KB)'),
+  targetMember: z.string().optional().describe('Deliver to this specific member only (omit for mode-default routing)'),
+});
+
+export const PauseChannelSchema = z.object({
+  channelId: z.string().min(1).describe('Channel ID to pause'),
+});
+
+export const ResumeChannelSchema = z.object({
+  channelId: z.string().min(1).describe('Channel ID to resume'),
+});
+
 /** Standard MCP tool response shape */
 interface MCPToolResponse {
   [key: string]: unknown;
@@ -567,6 +651,13 @@ export interface MCPAdapterDeps {
   readonly config: Configuration;
   readonly orchestrationService?: OrchestrationService;
   readonly pipelineRepository?: PipelineRepository;
+  /**
+   * Channel service for multi-agent channel management (Phase 8, epic #183).
+   * ARCHITECTURE: Optional — unavailable in environments without tmux or when
+   * ChannelManager.create() fails at bootstrap. All channel tool handlers guard
+   * against undefined with an actionable error message.
+   */
+  readonly channelService?: ChannelService;
 }
 
 export class MCPAdapter {
@@ -580,6 +671,7 @@ export class MCPAdapter {
   private readonly config: Configuration;
   private readonly orchestrationService?: OrchestrationService;
   private readonly pipelineRepository?: PipelineRepository;
+  private readonly channelService?: ChannelService;
 
   constructor(deps: MCPAdapterDeps) {
     this.taskManager = deps.taskManager;
@@ -590,6 +682,7 @@ export class MCPAdapter {
     this.config = deps.config;
     this.orchestrationService = deps.orchestrationService;
     this.pipelineRepository = deps.pipelineRepository;
+    this.channelService = deps.channelService;
     this.server = new Server(
       {
         name: 'autobeat',
@@ -684,6 +777,21 @@ export class MCPAdapter {
         return await this.handleCancelPipeline(args);
       case 'ConfigureAgent':
         return await this.handleConfigureAgent(args);
+      // Channel tools (Phase 8, epic #183)
+      case 'CreateChannel':
+        return await this.handleCreateChannel(args);
+      case 'DestroyChannel':
+        return await this.handleDestroyChannel(args);
+      case 'ChannelStatus':
+        return await this.handleChannelStatus(args);
+      case 'ListChannels':
+        return await this.handleListChannels(args);
+      case 'SendChannelMessage':
+        return await this.handleSendChannelMessage(args);
+      case 'PauseChannel':
+        return await this.handlePauseChannel(args);
+      case 'ResumeChannel':
+        return await this.handleResumeChannel(args);
       default:
         return {
           content: [
@@ -1776,6 +1884,145 @@ export class MCPAdapter {
                   },
                 },
                 required: ['agent'],
+              },
+            },
+            // Channel tools (Phase 8, epic #183)
+            {
+              name: 'CreateChannel',
+              description:
+                'Create a multi-agent communication channel and spawn member tmux sessions. Members communicate via the configured routing strategy.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description:
+                      'Channel name (unique identifier, lowercase alphanumeric with interior hyphens, max 64 chars)',
+                    pattern: '^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$',
+                  },
+                  members: {
+                    type: 'array',
+                    description: 'Channel members (1–10)',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string', description: 'Member name' },
+                        agent: { type: 'string', description: 'Agent provider' },
+                        systemPrompt: { type: 'string', description: 'Per-member system prompt (max 100KB)' },
+                      },
+                      required: ['name', 'agent'],
+                    },
+                    minItems: 1,
+                    maxItems: 10,
+                  },
+                  communicationMode: {
+                    type: 'string',
+                    enum: ['broadcast', 'directed', 'round-robin'],
+                    description: 'Message routing strategy (default: broadcast for ≥2 members)',
+                  },
+                  maxRounds: {
+                    type: 'number',
+                    description: 'Maximum conversation rounds before COMPLETED (required for ≥2 members)',
+                    minimum: 1,
+                    maximum: 10000,
+                  },
+                  topic: {
+                    type: 'string',
+                    description: 'Initial topic delivered to members on creation',
+                  },
+                  workingDirectory: {
+                    type: 'string',
+                    description: 'Working directory for member agent sessions (absolute path)',
+                  },
+                },
+                required: ['name', 'members'],
+              },
+            },
+            {
+              name: 'DestroyChannel',
+              description: 'Destroy a channel and kill all member tmux sessions.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  channelId: { type: 'string', description: 'Channel ID to destroy' },
+                  reason: { type: 'string', description: 'Reason for destruction (informational)' },
+                },
+                required: ['channelId'],
+              },
+            },
+            {
+              name: 'ChannelStatus',
+              description: 'Get status and member details for a channel.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  channelId: { type: 'string', description: 'Channel ID' },
+                },
+                required: ['channelId'],
+              },
+            },
+            {
+              name: 'ListChannels',
+              description: 'List channels, optionally filtered by status.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string',
+                    enum: ['active', 'paused', 'completed', 'destroyed'],
+                    description: 'Filter by channel status',
+                  },
+                  limit: {
+                    type: 'number',
+                    description: 'Maximum results (1–100)',
+                    minimum: 1,
+                    maximum: 100,
+                  },
+                },
+              },
+            },
+            {
+              name: 'SendChannelMessage',
+              description:
+                'Send a message to a channel. Routes to target member or uses mode-default routing (broadcast/round-robin).',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  channelId: { type: 'string', description: 'Channel ID' },
+                  message: {
+                    type: 'string',
+                    description: 'Message text (max 256KB)',
+                    minLength: 1,
+                    maxLength: 262144,
+                  },
+                  targetMember: {
+                    type: 'string',
+                    description: 'Deliver to this specific member only (omit for mode-default routing)',
+                  },
+                },
+                required: ['channelId', 'message'],
+              },
+            },
+            {
+              name: 'PauseChannel',
+              description: 'Pause an active channel (suppress message routing while members continue running).',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  channelId: { type: 'string', description: 'Channel ID to pause' },
+                },
+                required: ['channelId'],
+              },
+            },
+            {
+              name: 'ResumeChannel',
+              description: 'Resume a paused channel.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  channelId: { type: 'string', description: 'Channel ID to resume' },
+                },
+                required: ['channelId'],
               },
             },
           ],
@@ -3975,5 +4222,406 @@ export class MCPAdapter {
         },
       ],
     };
+  }
+
+  // ─── Channel handlers (Phase 8, epic #183) ─────────────────────────────────
+
+  /**
+   * Handle CreateChannel tool call.
+   * Creates a channel and spawns member tmux sessions.
+   */
+  private async handleCreateChannel(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = CreateChannelSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const data = parseResult.data;
+
+    // SECURITY: workingDirectory must be an absolute path (prevents path traversal via relative refs)
+    if (data.workingDirectory) {
+      if (!path.isAbsolute(data.workingDirectory)) {
+        return {
+          content: [{ type: 'text', text: `Invalid working directory: must be an absolute path` }],
+          isError: true,
+        };
+      }
+      const pathValidation = validatePath(data.workingDirectory);
+      if (!pathValidation.ok) {
+        return {
+          content: [{ type: 'text', text: `Invalid working directory: ${pathValidation.error.message}` }],
+          isError: true,
+        };
+      }
+    }
+
+    const request: ChannelCreateRequest = {
+      name: data.name,
+      members: data.members.map((m) => ({
+        name: m.name,
+        agent: m.agent as import('../core/agents.js').AgentProvider,
+        systemPrompt: m.systemPrompt,
+      })),
+      communicationMode: data.communicationMode as CommunicationMode | undefined,
+      maxRounds: data.maxRounds,
+      topic: data.topic,
+      workingDirectory: data.workingDirectory,
+    };
+
+    const result = await this.channelService.createChannel(request);
+
+    return match(result, {
+      ok: (channel: Channel) => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                success: true,
+                channelId: channel.id,
+                name: channel.name,
+                status: channel.status,
+                memberCount: channel.members.length,
+                communicationMode: channel.communicationMode ?? null,
+                maxRounds: channel.maxRounds ?? null,
+                message: 'Channel created successfully',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle DestroyChannel tool call.
+   */
+  private async handleDestroyChannel(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = DestroyChannelSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { channelId } = parseResult.data;
+    const result = await this.channelService.destroyChannel(ChannelId(channelId), 'user-requested');
+
+    return match(result, {
+      ok: () => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true, channelId, message: 'Channel destroyed' }, null, 2),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle ChannelStatus tool call.
+   */
+  private async handleChannelStatus(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = ChannelStatusSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { channelId } = parseResult.data;
+    const result = await this.channelService.getChannel(ChannelId(channelId));
+
+    return match(result, {
+      ok: (channel: Channel | null) => {
+        if (!channel) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ success: false, error: `Channel not found: ${channelId}` }, null, 2),
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  channel: {
+                    id: channel.id,
+                    name: channel.name,
+                    status: channel.status,
+                    communicationMode: channel.communicationMode ?? null,
+                    maxRounds: channel.maxRounds ?? null,
+                    currentRound: channel.currentRound,
+                    topic: channel.topic ?? null,
+                    members: channel.members.map((m) => ({
+                      name: m.name,
+                      agent: m.agent,
+                      status: m.status,
+                    })),
+                    createdAt: new Date(channel.createdAt).toISOString(),
+                    updatedAt: new Date(channel.updatedAt).toISOString(),
+                  },
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      },
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle ListChannels tool call.
+   */
+  private async handleListChannels(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = ListChannelsSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { status, limit } = parseResult.data;
+
+    // Map string status to enum
+    let statusEnum: ChannelStatus | undefined;
+    if (status) {
+      const statusMap: Record<string, ChannelStatus> = {
+        active: ChannelStatus.ACTIVE,
+        paused: ChannelStatus.PAUSED,
+        completed: ChannelStatus.COMPLETED,
+        destroyed: ChannelStatus.DESTROYED,
+      };
+      statusEnum = statusMap[status];
+    }
+
+    const result = await this.channelService.listChannels(statusEnum, limit);
+
+    return match(result, {
+      ok: (channels: readonly Channel[]) => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                success: true,
+                count: channels.length,
+                channels: channels.map((ch) => ({
+                  id: ch.id,
+                  name: ch.name,
+                  status: ch.status,
+                  memberCount: ch.members.length,
+                  communicationMode: ch.communicationMode ?? null,
+                  currentRound: ch.currentRound,
+                  maxRounds: ch.maxRounds ?? null,
+                  createdAt: new Date(ch.createdAt).toISOString(),
+                })),
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle SendChannelMessage tool call.
+   */
+  private async handleSendChannelMessage(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = SendChannelMessageSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { channelId, message, targetMember } = parseResult.data;
+    const result = await this.channelService.sendMessage(ChannelId(channelId), message, targetMember);
+
+    return match(result, {
+      ok: () => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                success: true,
+                channelId,
+                target: targetMember ?? 'all',
+                message: 'Message delivered',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle PauseChannel tool call.
+   */
+  private async handlePauseChannel(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = PauseChannelSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { channelId } = parseResult.data;
+    const result = await this.channelService.pauseChannel(ChannelId(channelId));
+
+    return match(result, {
+      ok: () => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true, channelId, status: 'paused', message: 'Channel paused' }, null, 2),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
+  }
+
+  /**
+   * Handle ResumeChannel tool call.
+   */
+  private async handleResumeChannel(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = ResumeChannelSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    if (!this.channelService) {
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+        ],
+        isError: true,
+      };
+    }
+
+    const { channelId } = parseResult.data;
+    const result = await this.channelService.resumeChannel(ChannelId(channelId));
+
+    return match(result, {
+      ok: () => ({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true, channelId, status: 'active', message: 'Channel resumed' }, null, 2),
+          },
+        ],
+      }),
+      err: (error: Error) => ({
+        content: [{ type: 'text', text: JSON.stringify({ success: false, error: error.message }, null, 2) }],
+        isError: true,
+      }),
+    });
   }
 }

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -30,6 +30,7 @@ import {
   type Channel,
   type ChannelCreateRequest,
   ChannelId,
+  type ChannelMemberRequest,
   ChannelStatus,
   type CommunicationMode,
   EvalMode,
@@ -4235,9 +4236,7 @@ export class MCPAdapter {
    * Return the channel service if available, or a ready-to-return error response if not.
    * All channel handlers call this once and early-return on the error branch.
    */
-  private requireChannelService():
-    | { ok: true; service: ChannelService }
-    | { ok: false; response: MCPToolResponse } {
+  private requireChannelService(): { ok: true; service: ChannelService } | { ok: false; response: MCPToolResponse } {
     if (!this.channelService) {
       return {
         ok: false,
@@ -4259,36 +4258,45 @@ export class MCPAdapter {
    */
   private buildChannelCreateRequest(
     data: z.infer<typeof CreateChannelSchema>,
-  ): ChannelCreateRequest | MCPToolResponse {
+  ): { ok: true; request: ChannelCreateRequest } | { ok: false; response: MCPToolResponse } {
     // SECURITY: workingDirectory must be an absolute path (prevents path traversal via relative refs)
     if (data.workingDirectory) {
       if (!path.isAbsolute(data.workingDirectory)) {
         return {
-          content: [{ type: 'text', text: `Invalid working directory: must be an absolute path` }],
-          isError: true,
+          ok: false,
+          response: {
+            content: [{ type: 'text', text: `Invalid working directory: must be an absolute path` }],
+            isError: true,
+          },
         };
       }
       const pathValidation = validatePath(data.workingDirectory);
       if (!pathValidation.ok) {
         return {
-          content: [{ type: 'text', text: `Invalid working directory: ${pathValidation.error.message}` }],
-          isError: true,
+          ok: false,
+          response: {
+            content: [{ type: 'text', text: `Invalid working directory: ${pathValidation.error.message}` }],
+            isError: true,
+          },
         };
       }
     }
 
     return {
-      name: data.name,
-      members: data.members.map((m, idx) => ({
-        name: m.name,
-        agent: m.agent,
-        // Per-member systemPrompt wins (??). Fall back to top-level only for the sole member.
-        systemPrompt: m.systemPrompt ?? (data.members.length === 1 && idx === 0 ? data.systemPrompt : undefined),
-      })),
-      communicationMode: data.communicationMode as CommunicationMode | undefined,
-      maxRounds: data.maxRounds,
-      topic: data.topic,
-      workingDirectory: data.workingDirectory,
+      ok: true,
+      request: {
+        name: data.name,
+        members: data.members.map((m, idx) => ({
+          name: m.name,
+          agent: m.agent,
+          // Per-member systemPrompt wins (??). Fall back to top-level only for the sole member.
+          systemPrompt: m.systemPrompt ?? (data.members.length === 1 && idx === 0 ? data.systemPrompt : undefined),
+        })) as ChannelMemberRequest[],
+        communicationMode: data.communicationMode as CommunicationMode | undefined,
+        maxRounds: data.maxRounds,
+        topic: data.topic,
+        workingDirectory: data.workingDirectory,
+      },
     };
   }
 
@@ -4308,10 +4316,10 @@ export class MCPAdapter {
     const svcResult = this.requireChannelService();
     if (!svcResult.ok) return svcResult.response;
 
-    const requestOrError = this.buildChannelCreateRequest(parseResult.data);
-    if ('isError' in requestOrError) return requestOrError;
+    const buildResult = this.buildChannelCreateRequest(parseResult.data);
+    if (!buildResult.ok) return buildResult.response;
 
-    const result = await svcResult.service.createChannel(requestOrError);
+    const result = await svcResult.service.createChannel(buildResult.request);
 
     return match(result, {
       ok: (channel: Channel) => ({

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -26,6 +26,7 @@ import {
   saveAgentConfig,
 } from '../core/configuration.js';
 import {
+  CHANNEL_NAME_REGEX,
   type Channel,
   type ChannelCreateRequest,
   ChannelId,
@@ -561,12 +562,11 @@ const CancelLoopSchema = z.object({
 // Channel-related Zod schemas (Phase 8, epic #183)
 
 /**
- * DECISION: Channel name regex mirrors CHANNEL_NAME_REGEX from domain.ts.
- * Inline here so the MCP layer validates without importing domain constants.
+ * ADR-001: Channel name regex imported from domain.ts (single source of truth).
  * Constraint: lowercase alphanumeric with interior hyphens, max 64 chars.
- * ADR-001: Must be a subset of tmux SESSION_NAME_REGEX — no transformation needed.
+ * Must be a subset of tmux SESSION_NAME_REGEX — no transformation needed.
  */
-const channelNamePattern = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+const channelNamePattern = CHANNEL_NAME_REGEX;
 
 export const CreateChannelSchema = z.object({
   name: z
@@ -609,7 +609,10 @@ export const CreateChannelSchema = z.object({
 
 export const DestroyChannelSchema = z.object({
   channelId: z.string().min(1).describe('Channel ID to destroy'),
-  reason: z.string().optional().describe('Reason for destruction (informational)'),
+  reason: z
+    .enum(['user-requested', 'max-rounds-reached', 'all-members-crashed'])
+    .optional()
+    .describe('Reason for destruction (default: user-requested)'),
 });
 
 export const ChannelStatusSchema = z.object({
@@ -1934,6 +1937,10 @@ export class MCPAdapter {
                     type: 'string',
                     description: 'Working directory for member agent sessions (absolute path)',
                   },
+                  systemPrompt: {
+                    type: 'string',
+                    description: 'System prompt for single-member channels (overrides per-member systemPrompt, max 100KB)',
+                  },
                 },
                 required: ['name', 'members'],
               },
@@ -1945,7 +1952,11 @@ export class MCPAdapter {
                 type: 'object',
                 properties: {
                   channelId: { type: 'string', description: 'Channel ID to destroy' },
-                  reason: { type: 'string', description: 'Reason for destruction (informational)' },
+                  reason: {
+                    type: 'string',
+                    enum: ['user-requested', 'max-rounds-reached', 'all-members-crashed'],
+                    description: 'Reason for destruction (default: user-requested)',
+                  },
                 },
                 required: ['channelId'],
               },
@@ -4269,10 +4280,12 @@ export class MCPAdapter {
 
     const request: ChannelCreateRequest = {
       name: data.name,
-      members: data.members.map((m) => ({
+      members: data.members.map((m, idx) => ({
         name: m.name,
         agent: m.agent as import('../core/agents.js').AgentProvider,
-        systemPrompt: m.systemPrompt,
+        // Apply top-level systemPrompt to the sole member when members.length === 1,
+        // falling back to the per-member value if both are provided (per-member wins).
+        systemPrompt: m.systemPrompt ?? (data.members.length === 1 && idx === 0 ? data.systemPrompt : undefined),
       })),
       communicationMode: data.communicationMode as CommunicationMode | undefined,
       maxRounds: data.maxRounds,
@@ -4332,8 +4345,8 @@ export class MCPAdapter {
       };
     }
 
-    const { channelId } = parseResult.data;
-    const result = await this.channelService.destroyChannel(ChannelId(channelId), 'user-requested');
+    const { channelId, reason } = parseResult.data;
+    const result = await this.channelService.destroyChannel(ChannelId(channelId), reason ?? 'user-requested');
 
     return match(result, {
       ok: () => ({

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -4232,29 +4232,34 @@ export class MCPAdapter {
   // ─── Channel handlers (Phase 8, epic #183) ─────────────────────────────────
 
   /**
-   * Handle CreateChannel tool call.
-   * Creates a channel and spawns member tmux sessions.
+   * Return the channel service if available, or a ready-to-return error response if not.
+   * All channel handlers call this once and early-return on the error branch.
    */
-  private async handleCreateChannel(args: unknown): Promise<MCPToolResponse> {
-    const parseResult = CreateChannelSchema.safeParse(args);
-    if (!parseResult.success) {
-      return {
-        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
-        isError: true,
-      };
-    }
-
+  private requireChannelService():
+    | { ok: true; service: ChannelService }
+    | { ok: false; response: MCPToolResponse } {
     if (!this.channelService) {
       return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
+        ok: false,
+        response: {
+          content: [
+            { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
+          ],
+          isError: true,
+        },
       };
     }
+    return { ok: true, service: this.channelService };
+  }
 
-    const data = parseResult.data;
-
+  /**
+   * Build the ChannelCreateRequest from validated input.
+   * Returns a validation error MCPToolResponse on path-validation failure, or the request on success.
+   * DECISION: per-member systemPrompt wins over the top-level field (??-coalesce, left operand wins).
+   */
+  private buildChannelCreateRequest(
+    data: z.infer<typeof CreateChannelSchema>,
+  ): ChannelCreateRequest | MCPToolResponse {
     // SECURITY: workingDirectory must be an absolute path (prevents path traversal via relative refs)
     if (data.workingDirectory) {
       if (!path.isAbsolute(data.workingDirectory)) {
@@ -4272,13 +4277,12 @@ export class MCPAdapter {
       }
     }
 
-    const request: ChannelCreateRequest = {
+    return {
       name: data.name,
       members: data.members.map((m, idx) => ({
         name: m.name,
-        agent: m.agent as import('../core/agents.js').AgentProvider,
-        // Apply top-level systemPrompt to the sole member when members.length === 1,
-        // falling back to the per-member value if both are provided (per-member wins).
+        agent: m.agent,
+        // Per-member systemPrompt wins (??). Fall back to top-level only for the sole member.
         systemPrompt: m.systemPrompt ?? (data.members.length === 1 && idx === 0 ? data.systemPrompt : undefined),
       })),
       communicationMode: data.communicationMode as CommunicationMode | undefined,
@@ -4286,8 +4290,28 @@ export class MCPAdapter {
       topic: data.topic,
       workingDirectory: data.workingDirectory,
     };
+  }
 
-    const result = await this.channelService.createChannel(request);
+  /**
+   * Handle CreateChannel tool call.
+   * Creates a channel and spawns member tmux sessions.
+   */
+  private async handleCreateChannel(args: unknown): Promise<MCPToolResponse> {
+    const parseResult = CreateChannelSchema.safeParse(args);
+    if (!parseResult.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parseResult.error.message}` }],
+        isError: true,
+      };
+    }
+
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
+
+    const requestOrError = this.buildChannelCreateRequest(parseResult.data);
+    if ('isError' in requestOrError) return requestOrError;
+
+    const result = await svcResult.service.createChannel(requestOrError);
 
     return match(result, {
       ok: (channel: Channel) => ({
@@ -4330,17 +4354,11 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { channelId, reason } = parseResult.data;
-    const result = await this.channelService.destroyChannel(ChannelId(channelId), reason ?? 'user-requested');
+    const result = await svcResult.service.destroyChannel(ChannelId(channelId), reason ?? 'user-requested');
 
     return match(result, {
       ok: () => ({
@@ -4370,17 +4388,11 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { channelId } = parseResult.data;
-    const result = await this.channelService.getChannel(ChannelId(channelId));
+    const result = await svcResult.service.getChannel(ChannelId(channelId));
 
     return match(result, {
       ok: (channel: Channel | null) => {
@@ -4445,18 +4457,12 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { status, limit } = parseResult.data;
     const statusEnum = status as ChannelStatus | undefined;
-    const result = await this.channelService.listChannels(statusEnum, limit);
+    const result = await svcResult.service.listChannels(statusEnum, limit);
 
     return match(result, {
       ok: (channels: readonly Channel[]) => ({
@@ -4503,17 +4509,11 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { channelId, message, targetMember } = parseResult.data;
-    const result = await this.channelService.sendMessage(ChannelId(channelId), message, targetMember);
+    const result = await svcResult.service.sendMessage(ChannelId(channelId), message, targetMember);
 
     return match(result, {
       ok: () => ({
@@ -4552,17 +4552,11 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { channelId } = parseResult.data;
-    const result = await this.channelService.pauseChannel(ChannelId(channelId));
+    const result = await svcResult.service.pauseChannel(ChannelId(channelId));
 
     return match(result, {
       ok: () => ({
@@ -4592,17 +4586,11 @@ export class MCPAdapter {
       };
     }
 
-    if (!this.channelService) {
-      return {
-        content: [
-          { type: 'text', text: JSON.stringify({ success: false, error: 'Channel service unavailable' }, null, 2) },
-        ],
-        isError: true,
-      };
-    }
+    const svcResult = this.requireChannelService();
+    if (!svcResult.ok) return svcResult.response;
 
     const { channelId } = parseResult.data;
-    const result = await this.channelService.resumeChannel(ChannelId(channelId));
+    const result = await svcResult.service.resumeChannel(ChannelId(channelId));
 
     return match(result, {
       ok: () => ({

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -4448,19 +4448,7 @@ export class MCPAdapter {
     }
 
     const { status, limit } = parseResult.data;
-
-    // Map string status to enum
-    let statusEnum: ChannelStatus | undefined;
-    if (status) {
-      const statusMap: Record<string, ChannelStatus> = {
-        active: ChannelStatus.ACTIVE,
-        paused: ChannelStatus.PAUSED,
-        completed: ChannelStatus.COMPLETED,
-        destroyed: ChannelStatus.DESTROYED,
-      };
-      statusEnum = statusMap[status];
-    }
-
+    const statusEnum = status as ChannelStatus | undefined;
     const result = await this.channelService.listChannels(statusEnum, limit);
 
     return match(result, {

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -598,7 +598,7 @@ export const CreateChannelSchema = z.object({
     .string()
     .max(100_000)
     .optional()
-    .describe('System prompt for single-member channels (overrides per-member systemPrompt)'),
+    .describe('System prompt for single-member channels (used when per-member systemPrompt is not set)'),
 });
 
 export const DestroyChannelSchema = z.object({
@@ -1934,7 +1934,7 @@ export class MCPAdapter {
                   systemPrompt: {
                     type: 'string',
                     description:
-                      'System prompt for single-member channels (overrides per-member systemPrompt, max 100KB)',
+                      'System prompt for single-member channels (used when per-member systemPrompt is not set, max 100KB)',
                   },
                 },
                 required: ['name', 'members'],

--- a/src/adapters/mcp-adapter.ts
+++ b/src/adapters/mcp-adapter.ts
@@ -1939,7 +1939,8 @@ export class MCPAdapter {
                   },
                   systemPrompt: {
                     type: 'string',
-                    description: 'System prompt for single-member channels (overrides per-member systemPrompt, max 100KB)',
+                    description:
+                      'System prompt for single-member channels (overrides per-member systemPrompt, max 100KB)',
                   },
                 },
                 required: ['name', 'members'],

--- a/src/adapters/mcp-instructions.ts
+++ b/src/adapters/mcp-instructions.ts
@@ -70,6 +70,39 @@ Two-step pattern:
 The built-in CreateOrchestrator is this pattern with a pre-built system prompt.
 InitCustomOrchestrator gives you the building blocks to create your own.
 
+### Channels (CreateChannel, SendChannelMessage, etc.)
+Use for persistent multi-agent communication sessions where agents talk to each other.
+Channels own their member sessions — each member is a long-running agent process that receives messages and can respond.
+
+**Create a single-agent channel** (one member, no maxRounds required):
+\`\`\`
+CreateChannel { name: "research", members: [{ name: "research", agent: "claude" }], topic: "Summarize the codebase" }
+\`\`\`
+
+**Create a multi-agent channel** (two or more members, maxRounds required):
+\`\`\`
+CreateChannel {
+  name: "code-review",
+  members: [
+    { name: "author", agent: "claude", systemPrompt: "You are the code author." },
+    { name: "reviewer", agent: "claude", systemPrompt: "You are the code reviewer." }
+  ],
+  communicationMode: "round-robin",
+  maxRounds: 10,
+  topic: "Review the authentication module"
+}
+\`\`\`
+
+**Communication modes**:
+- \`broadcast\` (default) — messages go to all active members
+- \`directed\` — members address each other by name (\`@member-name: message\`)
+- \`round-robin\` — members take turns in fixed order
+
+**Send a message** to the channel (routes per mode) or a specific member:
+- SendChannelMessage { channelId: "ch-...", message: "...", targetMember: "reviewer" }
+
+**Lifecycle**: ChannelStatus → ListChannels → PauseChannel / ResumeChannel → DestroyChannel
+
 ## Monitoring Patterns
 
 ### Check on work
@@ -80,6 +113,8 @@ InitCustomOrchestrator gives you the building blocks to create your own.
 - OrchestratorStatus with orchestratorId → see plan steps and progress
 - PipelineStatus with pipelineId → check overall pipeline status and per-step task IDs
 - ListPipelines → list pipelines with optional status filter (pending/running/completed/failed/cancelled)
+- ChannelStatus with channelId → see channel details and member statuses
+- ListChannels → list channels with optional status filter
 
 ### React to results
 - TaskLogs to read output, then decide next steps

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -707,26 +707,28 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   });
 
   // Register MCP adapter
-  // ARCHITECTURE: channelService is async (ChannelManager.create()), so the mcpAdapter
-  // factory must be async too. container.registerSingleton() supports async factories
-  // via container.resolve() (not container.get()). channelService is optional — if
-  // resolution fails, MCPAdapter is still created with channelService: undefined.
-  container.registerSingleton('mcpAdapter', async () => {
+  // ARCHITECTURE: channelService is pre-resolved in server/run modes (where the MCP adapter
+  // is actually used) so the factory can be synchronous and use container.get() directly.
+  // In cli mode (withServices()) the mcpAdapter factory is registered but never resolved,
+  // so the pre-resolve is intentionally skipped to avoid ChannelManager.create() latency.
+  // channelService is optional — if resolution fails, MCPAdapter is created without it.
+  let preResolvedChannelService: ChannelService | undefined;
+  if (!skipProxy) {
+    // 'server' or 'run' modes — pre-resolve so the factory below is synchronous
+    const channelServiceResult = await container.resolve<ChannelService>('channelService');
+    if (channelServiceResult.ok) {
+      preResolvedChannelService = channelServiceResult.value;
+    } else {
+      logger.warn('MCPAdapter: channelService unavailable, channel tools disabled', {
+        error: channelServiceResult.error.message,
+      });
+    }
+  }
+
+  container.registerSingleton('mcpAdapter', () => {
     const taskManagerResult = container.get<TaskManager>('taskManager');
     if (!taskManagerResult.ok) {
       throw new Error(`Failed to get taskManager for MCPAdapter: ${taskManagerResult.error.message}`);
-    }
-
-    // Resolve channelService (async factory). Absent in test environments or if bootstrap failed.
-    let channelService: ChannelService | undefined;
-    const channelServiceResult = await container.resolve<ChannelService>('channelService');
-    if (channelServiceResult.ok) {
-      channelService = channelServiceResult.value;
-    } else {
-      getFromContainer<Logger>(container, 'logger').warn(
-        'MCPAdapter: channelService unavailable, channel tools disabled',
-        { error: channelServiceResult.error.message },
-      );
     }
 
     return new MCPAdapter({
@@ -738,7 +740,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
       config,
       orchestrationService: getFromContainer<OrchestrationService>(container, 'orchestrationService'),
       pipelineRepository: getFromContainer<PipelineRepository>(container, 'pipelineRepository'),
-      channelService,
+      channelService: preResolvedChannelService,
     });
   });
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -707,10 +707,26 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   });
 
   // Register MCP adapter
-  container.registerSingleton('mcpAdapter', () => {
+  // ARCHITECTURE: channelService is async (ChannelManager.create()), so the mcpAdapter
+  // factory must be async too. container.registerSingleton() supports async factories
+  // via container.resolve() (not container.get()). channelService is optional — if
+  // resolution fails, MCPAdapter is still created with channelService: undefined.
+  container.registerSingleton('mcpAdapter', async () => {
     const taskManagerResult = container.get<TaskManager>('taskManager');
     if (!taskManagerResult.ok) {
       throw new Error(`Failed to get taskManager for MCPAdapter: ${taskManagerResult.error.message}`);
+    }
+
+    // Resolve channelService (async factory). Absent in test environments or if bootstrap failed.
+    let channelService: ChannelService | undefined;
+    const channelServiceResult = await container.resolve<ChannelService>('channelService');
+    if (channelServiceResult.ok) {
+      channelService = channelServiceResult.value;
+    } else {
+      getFromContainer<Logger>(container, 'logger').warn(
+        'MCPAdapter: channelService unavailable, channel tools disabled',
+        { error: channelServiceResult.error.message },
+      );
     }
 
     return new MCPAdapter({
@@ -722,6 +738,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
       config,
       orchestrationService: getFromContainer<OrchestrationService>(container, 'orchestrationService'),
       pipelineRepository: getFromContainer<PipelineRepository>(container, 'pipelineRepository'),
+      channelService,
     });
   });
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -777,19 +777,22 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
     // Skipped in cli mode (no tmux sessions are managed by CLI commands).
     // DECISION: resolve() is required here (not get()) because ChannelManager.create() is async
     // (subscribes to events). container.get() rejects async factories before instantiation.
-    container.resolve<ChannelService>('channelService').then((channelServiceResult) => {
-      if (!channelServiceResult.ok) {
-        logger.error('Failed to resolve ChannelService for recovery', channelServiceResult.error);
-        return;
-      }
-      channelServiceResult.value.recoverChannels().then((result) => {
-        if (!result.ok) {
-          logger.error('Channel recovery failed', result.error);
+    container
+      .resolve<ChannelService>('channelService')
+      .then((channelServiceResult) => {
+        if (!channelServiceResult.ok) {
+          logger.error('Failed to resolve ChannelService for recovery', channelServiceResult.error);
+          return;
         }
+        channelServiceResult.value.recoverChannels().then((result) => {
+          if (!result.ok) {
+            logger.error('Channel recovery failed', result.error);
+          }
+        });
+      })
+      .catch((e: unknown) => {
+        logger.error('Unexpected error in channel recovery', e instanceof Error ? e : new Error(String(e)));
       });
-    }).catch((e: unknown) => {
-      logger.error('Unexpected error in channel recovery', e instanceof Error ? e : new Error(String(e)));
-    });
   } else {
     logger.info(`Skipping recovery (mode=${mode})`);
   }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -713,7 +713,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
   // so the pre-resolve is intentionally skipped to avoid ChannelManager.create() latency.
   // channelService is optional — if resolution fails, MCPAdapter is created without it.
   let preResolvedChannelService: ChannelService | undefined;
-  if (!skipProxy) {
+  if (mode !== 'cli') {
     // 'server' or 'run' modes — pre-resolve so the factory below is synchronous
     const channelServiceResult = await container.resolve<ChannelService>('channelService');
     if (channelServiceResult.ok) {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -787,6 +787,8 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
           logger.error('Channel recovery failed', result.error);
         }
       });
+    }).catch((e: unknown) => {
+      logger.error('Unexpected error in channel recovery', e instanceof Error ? e : new Error(String(e)));
     });
   } else {
     logger.info(`Skipping recovery (mode=${mode})`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   listAgents,
 } from './cli/commands/agents.js';
 import { cancelTask } from './cli/commands/cancel.js';
+import { handleChannelCommand } from './cli/commands/channel.js';
 import { configPath, configReset, configSet, configShow } from './cli/commands/config.js';
 import { showHelp } from './cli/commands/help.js';
 import { initCommand } from './cli/commands/init.js';
@@ -20,6 +21,7 @@ import { getTaskLogs } from './cli/commands/logs.js';
 import { handleLoopCommand } from './cli/commands/loop.js';
 import { handleMcpStart, handleMcpTest, showConfig } from './cli/commands/mcp.js';
 import { migrateCommand } from './cli/commands/migrate.js';
+import { handleMsgCommand } from './cli/commands/msg.js';
 import { handleOrchestrateCommand } from './cli/commands/orchestrate.js';
 import { handlePipelineCommand } from './cli/commands/pipeline.js';
 import { handleResumeCommand } from './cli/commands/resume.js';
@@ -286,6 +288,10 @@ if (mainCommand === 'mcp') {
   await handleOrchestrateCommand(subCommand, args.slice(2));
 } else if (mainCommand === 'loop') {
   await handleLoopCommand(subCommand, args.slice(2));
+} else if (mainCommand === 'channel') {
+  await handleChannelCommand(subCommand, args.slice(2));
+} else if (mainCommand === 'msg') {
+  await handleMsgCommand(args.slice(1));
 } else if (mainCommand === 'agents') {
   if (subCommand === 'list' || !subCommand) {
     await listAgents();

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -1,0 +1,591 @@
+/**
+ * Channel CLI commands
+ *
+ * ARCHITECTURE: Provides CLI surface for the channel service layer (Phase 7).
+ * Pure argument parsing functions are exported for testability; subcommand
+ * handlers are side-effecting and not exported.
+ *
+ * ADR-001: Channel name validation uses CHANNEL_NAME_REGEX to ensure channel
+ * names are valid tmux session name suffixes (no transformation required).
+ */
+
+import { AGENT_PROVIDERS, isAgentProvider } from '../../core/agents.js';
+import { CHANNEL_NAME_REGEX, ChannelId, ChannelStatus, type CommunicationMode } from '../../core/domain.js';
+import type { ChannelRepository } from '../../core/interfaces.js';
+import { err, ok, type Result } from '../../core/result.js';
+import { validatePath } from '../../utils/validation.js';
+import { exitOnError, exitOnNull, withReadOnlyContext, withServices } from '../services.js';
+import * as ui from '../ui.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Parsed member from --member name:agent[:prompt] flag.
+ * Prompt may contain colons — split on first two colons only.
+ */
+interface ParsedMember {
+  readonly name: string;
+  readonly agent: string;
+  readonly systemPrompt?: string;
+}
+
+/**
+ * Single-agent channel creation (--agent flag, no --member flags).
+ * Member name equals channel name; no mode or maxRounds required.
+ */
+interface ParsedChannelCreateSingle {
+  readonly mode: 'single';
+  readonly name: string;
+  readonly agent: string;
+  readonly topic?: string;
+  readonly workingDirectory?: string;
+  readonly systemPrompt?: string;
+}
+
+/**
+ * Multi-agent channel creation (one or more --member flags).
+ * Requires --max-rounds; accepts --mode.
+ */
+interface ParsedChannelCreateMulti {
+  readonly mode: 'multi';
+  readonly name: string;
+  readonly members: readonly ParsedMember[];
+  readonly communicationMode?: CommunicationMode;
+  readonly maxRounds: number;
+  readonly topic?: string;
+  readonly workingDirectory?: string;
+}
+
+export type ParsedChannelCreate = ParsedChannelCreateSingle | ParsedChannelCreateMulti;
+
+// ─── Pure parsing functions ────────────────────────────────────────────────────
+
+/**
+ * Parse and validate channel create arguments.
+ * ARCHITECTURE: Pure function — no side effects, returns Result for testability.
+ *
+ * Two modes:
+ * - Single-agent: --agent <provider> flag present, no --member flags.
+ *   Member name = channel name. No --mode or --max-rounds required.
+ * - Multi-agent: --member name:agent[:prompt] flags. Requires --max-rounds.
+ *   Accepts --mode broadcast|directed|round-robin.
+ * Mutual exclusion: --agent + --member together → error.
+ */
+export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedChannelCreate, string> {
+  // First positional argument is the channel name
+  const positional: string[] = [];
+  const members: ParsedMember[] = [];
+  let agentFlag: string | undefined;
+  let communicationMode: CommunicationMode | undefined;
+  let maxRounds: number | undefined;
+  let topic: string | undefined;
+  let workingDirectory: string | undefined;
+  let systemPrompt: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+
+    if ((arg === '--agent' || arg === '-a') && next !== undefined) {
+      agentFlag = next;
+      i++;
+    } else if (arg === '--member' && next !== undefined) {
+      const memberResult = parseMemberFlag(next);
+      if (!memberResult.ok) return memberResult;
+      members.push(memberResult.value);
+      i++;
+    } else if (arg === '--mode' && next !== undefined) {
+      if (next !== 'broadcast' && next !== 'directed' && next !== 'round-robin') {
+        return err(`--mode must be broadcast, directed, or round-robin (got "${next}")`);
+      }
+      communicationMode = next as CommunicationMode;
+      i++;
+    } else if (arg === '--max-rounds' && next !== undefined) {
+      const n = Number(next);
+      if (!Number.isInteger(n) || n < 1 || n > 10000) {
+        return err('--max-rounds must be an integer between 1 and 10000');
+      }
+      maxRounds = n;
+      i++;
+    } else if (arg === '--topic' && next !== undefined) {
+      topic = next;
+      i++;
+    } else if ((arg === '--working-directory' || arg === '-w') && next !== undefined) {
+      workingDirectory = next;
+      i++;
+    } else if (arg === '--system-prompt' && next !== undefined) {
+      systemPrompt = next;
+      i++;
+    } else if (arg.startsWith('-')) {
+      return err(`Unknown flag: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const channelName = positional[0];
+  if (!channelName) {
+    return err('Usage: beat channel create <name> --agent <provider> | --member name:agent[:prompt]...');
+  }
+
+  // Validate channel name
+  if (!CHANNEL_NAME_REGEX.test(channelName)) {
+    return err(
+      `Invalid channel name "${channelName}": must be lowercase alphanumeric with interior hyphens, max 64 chars`,
+    );
+  }
+
+  // Mutual exclusion: --agent + --member
+  if (agentFlag !== undefined && members.length > 0) {
+    return err('--agent and --member are mutually exclusive. Use --agent for single-agent, --member for multi-agent.');
+  }
+
+  // Single-agent mode
+  if (agentFlag !== undefined) {
+    if (!isAgentProvider(agentFlag)) {
+      return err(`Unknown agent: "${agentFlag}". Available agents: ${AGENT_PROVIDERS.join(', ')}`);
+    }
+    if (maxRounds !== undefined) {
+      return err('--max-rounds is only valid for multi-agent channels (--member). Use --agent for single-agent.');
+    }
+    if (communicationMode !== undefined) {
+      return err('--mode is only valid for multi-agent channels (--member). Use --agent for single-agent.');
+    }
+    return ok({
+      mode: 'single' as const,
+      name: channelName,
+      agent: agentFlag,
+      topic,
+      workingDirectory,
+      systemPrompt,
+    });
+  }
+
+  // Multi-agent mode
+  if (members.length === 0) {
+    return err('Provide --agent <provider> for single-agent or --member name:agent[:prompt] for multi-agent channels.');
+  }
+
+  if (maxRounds === undefined) {
+    return err('--max-rounds is required for multi-agent channels');
+  }
+
+  // Validate all member agents
+  for (const member of members) {
+    if (!isAgentProvider(member.agent)) {
+      return err(
+        `Unknown agent "${member.agent}" for member "${member.name}". Available: ${AGENT_PROVIDERS.join(', ')}`,
+      );
+    }
+    if (!CHANNEL_NAME_REGEX.test(member.name)) {
+      return err(
+        `Invalid member name "${member.name}": must be lowercase alphanumeric with interior hyphens, max 64 chars`,
+      );
+    }
+  }
+
+  // --system-prompt is single-agent only
+  if (systemPrompt !== undefined) {
+    return err(
+      '--system-prompt is only valid for single-agent channels (--agent). Use --member name:agent:prompt for per-member prompts.',
+    );
+  }
+
+  return ok({
+    mode: 'multi' as const,
+    name: channelName,
+    members,
+    communicationMode,
+    maxRounds,
+    topic,
+    workingDirectory,
+  });
+}
+
+/**
+ * Parse a --member flag value: name:agent[:prompt]
+ * Prompt may contain colons — split on first colon only after agent.
+ */
+function parseMemberFlag(value: string): Result<ParsedMember, string> {
+  // Split on first colon to get name
+  const firstColon = value.indexOf(':');
+  if (firstColon === -1) {
+    return err(`--member requires format "name:agent[:prompt]", got "${value}"`);
+  }
+
+  const name = value.slice(0, firstColon);
+  const rest = value.slice(firstColon + 1);
+
+  if (!name) {
+    return err(`--member name cannot be empty in "${value}"`);
+  }
+
+  // Split rest on first colon to get agent and optional prompt
+  const secondColon = rest.indexOf(':');
+  let agent: string;
+  let systemPrompt: string | undefined;
+
+  if (secondColon === -1) {
+    agent = rest;
+  } else {
+    agent = rest.slice(0, secondColon);
+    const promptPart = rest.slice(secondColon + 1);
+    systemPrompt = promptPart || undefined;
+  }
+
+  if (!agent) {
+    return err(`--member agent cannot be empty in "${value}"`);
+  }
+
+  return ok({ name, agent, systemPrompt });
+}
+
+// ─── Subcommand router ────────────────────────────────────────────────────────
+
+export async function handleChannelCommand(subCmd: string | undefined, channelArgs: string[]): Promise<void> {
+  if (subCmd === 'list') {
+    await handleChannelList(channelArgs);
+    return;
+  }
+  if (subCmd === 'status') {
+    await handleChannelStatus(channelArgs);
+    return;
+  }
+  if (subCmd === 'destroy') {
+    await handleChannelDestroy(channelArgs);
+    return;
+  }
+  if (subCmd === 'pause') {
+    await handleChannelPause(channelArgs);
+    return;
+  }
+  if (subCmd === 'resume') {
+    await handleChannelResume(channelArgs);
+    return;
+  }
+
+  // Default: create (subCmd is the channel name or a flag)
+  const createArgs = subCmd ? [subCmd, ...channelArgs] : channelArgs;
+  await handleChannelCreate(createArgs);
+}
+
+// ─── Resolve channel by ID or name ───────────────────────────────────────────
+
+/**
+ * Resolve a channel ID or name string to a ChannelId.
+ * IDs start with 'ch-'; names are resolved via findByName().
+ */
+async function resolveChannelId(idOrName: string, channelRepository: ChannelRepository): Promise<ChannelId | null> {
+  if (idOrName.startsWith('ch-')) {
+    return ChannelId(idOrName);
+  }
+  const result = await channelRepository.findByName(idOrName);
+  if (!result.ok) return null;
+  if (!result.value) return null;
+  return result.value.id;
+}
+
+// ─── Create ──────────────────────────────────────────────────────────────────
+
+async function handleChannelCreate(args: string[]): Promise<void> {
+  const parsed = parseChannelCreateArgs(args);
+  if (!parsed.ok) {
+    ui.error(parsed.error);
+    process.exit(1);
+  }
+  const createArgs = parsed.value;
+
+  const s = ui.createSpinner();
+  s.start('Creating channel...');
+  const { channelService } = await withServices(s);
+
+  if (!channelService) {
+    s.stop('Failed');
+    ui.error('Channel service unavailable. Ensure the server is properly configured.');
+    process.exit(1);
+  }
+
+  let result;
+  if (createArgs.mode === 'single') {
+    result = await channelService.createChannel({
+      name: createArgs.name,
+      members: [
+        {
+          name: createArgs.name,
+          agent: createArgs.agent as import('../../core/agents.js').AgentProvider,
+          systemPrompt: createArgs.systemPrompt,
+        },
+      ],
+      topic: createArgs.topic,
+      workingDirectory: createArgs.workingDirectory,
+    });
+  } else {
+    result = await channelService.createChannel({
+      name: createArgs.name,
+      members: createArgs.members.map((m) => ({
+        name: m.name,
+        agent: m.agent as import('../../core/agents.js').AgentProvider,
+        systemPrompt: m.systemPrompt,
+      })),
+      communicationMode: createArgs.communicationMode,
+      maxRounds: createArgs.maxRounds,
+      topic: createArgs.topic,
+      workingDirectory: createArgs.workingDirectory,
+    });
+  }
+
+  const channel = exitOnError(result, s, 'Failed to create channel');
+  s.stop('Channel created');
+
+  ui.success(`Channel created: ${channel.id}`);
+  const details = [`Name: ${channel.name}`, `Members: ${channel.members.length}`, `Status: ${channel.status}`];
+  if (channel.communicationMode) details.push(`Mode: ${channel.communicationMode}`);
+  if (channel.maxRounds !== undefined) details.push(`Max rounds: ${channel.maxRounds}`);
+  ui.info(details.join(' | '));
+  process.exit(0);
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+async function handleChannelList(args: string[]): Promise<void> {
+  let statusFilter: string | undefined;
+  let limit: number | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = args[i + 1];
+    if (arg === '--status' && next) {
+      statusFilter = next;
+      i++;
+    } else if (arg === '--limit' && next) {
+      limit = parseInt(next, 10);
+      i++;
+    }
+  }
+
+  const validStatuses = Object.values(ChannelStatus);
+  let statusValue: ChannelStatus | undefined;
+  if (statusFilter) {
+    const normalized = statusFilter.toLowerCase();
+    statusValue = validStatuses.find((v) => v === normalized);
+    if (!statusValue) {
+      ui.error(`Invalid status: ${statusFilter}. Valid values: ${validStatuses.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  const s = ui.createSpinner();
+  s.start('Fetching channels...');
+  const ctx = withReadOnlyContext(s);
+  s.stop('Ready');
+
+  try {
+    const result = statusValue
+      ? await ctx.channelRepository.findByStatus(statusValue, limit)
+      : await ctx.channelRepository.findAll(limit);
+    const channels = exitOnError(result, undefined, 'Failed to list channels');
+
+    if (channels.length === 0) {
+      ui.info('No channels found');
+    } else {
+      for (const ch of channels) {
+        const memberSummary = ch.members.map((m) => m.name).join(', ');
+        ui.step(
+          `${ui.dim(ch.id)}  ${ui.colorStatus(ch.status.padEnd(10))}  ${ch.name}  members: ${ch.members.length} (${memberSummary})`,
+        );
+      }
+      ui.info(`${channels.length} channel${channels.length === 1 ? '' : 's'}`);
+    }
+  } finally {
+    ctx.close();
+  }
+  process.exit(0);
+}
+
+// ─── Status ───────────────────────────────────────────────────────────────────
+
+async function handleChannelStatus(args: string[]): Promise<void> {
+  const idOrName = args[0];
+  if (!idOrName) {
+    ui.error('Usage: beat channel status <channel-id|name>');
+    process.exit(1);
+  }
+
+  const s = ui.createSpinner();
+  s.start('Fetching channel...');
+  const ctx = withReadOnlyContext(s);
+  s.stop('Ready');
+
+  try {
+    const channelId = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!channelId) {
+      const findResult = await ctx.channelRepository.findByName(idOrName);
+      if (!findResult.ok) {
+        ui.error(`Failed to look up channel: ${findResult.error.message}`);
+        process.exit(1);
+      }
+    }
+
+    const resolvedId = channelId;
+    if (!resolvedId) {
+      ui.error(`Channel not found: ${idOrName}`);
+      process.exit(1);
+    }
+
+    const channelResult = await ctx.channelRepository.findById(resolvedId);
+    const channel = exitOnNull(
+      exitOnError(channelResult, undefined, 'Failed to get channel'),
+      undefined,
+      `Channel ${idOrName} not found`,
+    );
+
+    const lines: string[] = [];
+    lines.push(`ID:            ${channel.id}`);
+    lines.push(`Name:          ${channel.name}`);
+    lines.push(`Status:        ${ui.colorStatus(channel.status)}`);
+    lines.push(`Members:       ${channel.members.length}`);
+    if (channel.communicationMode) lines.push(`Mode:          ${channel.communicationMode}`);
+    if (channel.maxRounds !== undefined) {
+      lines.push(`Rounds:        ${channel.currentRound}/${channel.maxRounds}`);
+    } else {
+      lines.push(`Round:         ${channel.currentRound}`);
+    }
+    if (channel.topic) lines.push(`Topic:         ${channel.topic}`);
+    lines.push(`Created:       ${new Date(channel.createdAt).toISOString()}`);
+
+    if (channel.members.length > 0) {
+      lines.push('Members:');
+      for (const m of channel.members) {
+        lines.push(`  ${m.name}  ${m.agent}  ${ui.colorStatus(m.status)}`);
+      }
+    }
+
+    ui.note(lines.join('\n'), 'Channel Details');
+  } finally {
+    ctx.close();
+  }
+  process.exit(0);
+}
+
+// ─── Destroy ─────────────────────────────────────────────────────────────────
+
+async function handleChannelDestroy(args: string[]): Promise<void> {
+  const idOrName = args[0];
+  if (!idOrName) {
+    ui.error('Usage: beat channel destroy <channel-id|name> [reason]');
+    process.exit(1);
+  }
+  const reason = args.slice(1).join(' ') || undefined;
+
+  const s = ui.createSpinner();
+  s.start('Destroying channel...');
+  const { channelService } = await withServices(s);
+
+  if (!channelService) {
+    s.stop('Failed');
+    ui.error('Channel service unavailable.');
+    process.exit(1);
+  }
+
+  // Resolve name → ID if needed
+  const ctx = withReadOnlyContext();
+  let channelId: ChannelId;
+  try {
+    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!resolved) {
+      s.stop('Not found');
+      ui.error(`Channel not found: ${idOrName}`);
+      process.exit(1);
+    }
+    channelId = resolved;
+  } finally {
+    ctx.close();
+  }
+
+  const result = await channelService.destroyChannel(channelId, reason ? 'user-requested' : 'user-requested');
+  exitOnError(result, s, 'Failed to destroy channel');
+  s.stop('Destroyed');
+  ui.success(`Channel ${idOrName} destroyed`);
+  if (reason) ui.info(`Reason: ${reason}`);
+  process.exit(0);
+}
+
+// ─── Pause ───────────────────────────────────────────────────────────────────
+
+async function handleChannelPause(args: string[]): Promise<void> {
+  const idOrName = args[0];
+  if (!idOrName) {
+    ui.error('Usage: beat channel pause <channel-id|name>');
+    process.exit(1);
+  }
+
+  const s = ui.createSpinner();
+  s.start('Pausing channel...');
+  const { channelService } = await withServices(s);
+
+  if (!channelService) {
+    s.stop('Failed');
+    ui.error('Channel service unavailable.');
+    process.exit(1);
+  }
+
+  const ctx = withReadOnlyContext();
+  let channelId: ChannelId;
+  try {
+    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!resolved) {
+      s.stop('Not found');
+      ui.error(`Channel not found: ${idOrName}`);
+      process.exit(1);
+    }
+    channelId = resolved;
+  } finally {
+    ctx.close();
+  }
+
+  const result = await channelService.pauseChannel(channelId);
+  exitOnError(result, s, 'Failed to pause channel');
+  s.stop('Paused');
+  ui.success(`Channel ${idOrName} paused`);
+  process.exit(0);
+}
+
+// ─── Resume ──────────────────────────────────────────────────────────────────
+
+async function handleChannelResume(args: string[]): Promise<void> {
+  const idOrName = args[0];
+  if (!idOrName) {
+    ui.error('Usage: beat channel resume <channel-id|name>');
+    process.exit(1);
+  }
+
+  const s = ui.createSpinner();
+  s.start('Resuming channel...');
+  const { channelService } = await withServices(s);
+
+  if (!channelService) {
+    s.stop('Failed');
+    ui.error('Channel service unavailable.');
+    process.exit(1);
+  }
+
+  const ctx = withReadOnlyContext();
+  let channelId: ChannelId;
+  try {
+    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!resolved) {
+      s.stop('Not found');
+      ui.error(`Channel not found: ${idOrName}`);
+      process.exit(1);
+    }
+    channelId = resolved;
+  } finally {
+    ctx.close();
+  }
+
+  const result = await channelService.resumeChannel(channelId);
+  exitOnError(result, s, 'Failed to resume channel');
+  s.stop('Resumed');
+  ui.success(`Channel ${idOrName} resumed`);
+  process.exit(0);
+}

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -118,6 +118,9 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
       workingDirectory = pathResult.value;
       i++;
     } else if (arg === '--system-prompt' && next !== undefined) {
+      if (next.length > 100_000) {
+        return err('--system-prompt must be at most 100,000 characters');
+      }
       systemPrompt = next;
       i++;
     } else if (arg.startsWith('-')) {
@@ -293,24 +296,6 @@ async function resolveChannelId(idOrName: string, channelRepository: ChannelRepo
   return result.value.id;
 }
 
-/**
- * Resolve a channel ID using a transient read-only context, then close it.
- * Exits the process if not found.
- */
-async function resolveChannelIdOrExit(idOrName: string): Promise<ChannelId> {
-  const ctx = withReadOnlyContext();
-  try {
-    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
-    if (!resolved) {
-      ui.error(`Channel not found: ${idOrName}`);
-      process.exit(1);
-    }
-    return resolved;
-  } finally {
-    ctx.close();
-  }
-}
-
 // ─── Create ──────────────────────────────────────────────────────────────────
 
 async function handleChannelCreate(args: string[]): Promise<void> {
@@ -323,7 +308,8 @@ async function handleChannelCreate(args: string[]): Promise<void> {
 
   const s = ui.createSpinner();
   s.start('Creating channel...');
-  const { channelService } = await withServices(s);
+  const { resolveChannelService } = await withServices(s);
+  const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');
@@ -384,7 +370,12 @@ async function handleChannelList(args: string[]): Promise<void> {
       statusFilter = next;
       i++;
     } else if (arg === '--limit' && next) {
-      limit = parseInt(next, 10);
+      const n = parseInt(next, 10);
+      if (isNaN(n) || n < 1 || n > 100) {
+        ui.error('--limit must be an integer between 1 and 100');
+        process.exit(1);
+      }
+      limit = n;
       i++;
     }
   }
@@ -494,11 +485,15 @@ async function handleChannelDestroy(args: string[]): Promise<void> {
     ui.error('Usage: beat channel destroy <channel-id|name> [reason]');
     process.exit(1);
   }
-  const reason = args.slice(1).join(' ') || undefined;
+  // ARCHITECTURE: reason is a user-visible display string only; destroyChannel()
+  // accepts a typed ChannelDestroyReason enum ('user-requested' | 'max-rounds-reached' |
+  // 'all-members-crashed'), so the free-form CLI input cannot be passed to the service.
+  const displayReason = args.slice(1).join(' ') || undefined;
 
   const s = ui.createSpinner();
   s.start('Destroying channel...');
-  const { channelService } = await withServices(s);
+  const { container, resolveChannelService } = await withServices(s);
+  const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');
@@ -506,12 +501,20 @@ async function handleChannelDestroy(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const channelId = await resolveChannelIdOrExit(idOrName);
+  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
+  const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
+  const channelId = await resolveChannelId(idOrName, channelRepository);
+  if (!channelId) {
+    s.stop('Not found');
+    ui.error(`Channel not found: ${idOrName}`);
+    process.exit(1);
+  }
+
   const result = await channelService.destroyChannel(channelId, 'user-requested');
   exitOnError(result, s, 'Failed to destroy channel');
   s.stop('Destroyed');
   ui.success(`Channel ${idOrName} destroyed`);
-  if (reason) ui.info(`Reason: ${reason}`);
+  if (displayReason) ui.info(`Reason: ${displayReason}`);
   process.exit(0);
 }
 
@@ -526,7 +529,8 @@ async function handleChannelPause(args: string[]): Promise<void> {
 
   const s = ui.createSpinner();
   s.start('Pausing channel...');
-  const { channelService } = await withServices(s);
+  const { container, resolveChannelService } = await withServices(s);
+  const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');
@@ -534,7 +538,15 @@ async function handleChannelPause(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const channelId = await resolveChannelIdOrExit(idOrName);
+  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
+  const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
+  const channelId = await resolveChannelId(idOrName, channelRepository);
+  if (!channelId) {
+    s.stop('Not found');
+    ui.error(`Channel not found: ${idOrName}`);
+    process.exit(1);
+  }
+
   const result = await channelService.pauseChannel(channelId);
   exitOnError(result, s, 'Failed to pause channel');
   s.stop('Paused');
@@ -553,7 +565,8 @@ async function handleChannelResume(args: string[]): Promise<void> {
 
   const s = ui.createSpinner();
   s.start('Resuming channel...');
-  const { channelService } = await withServices(s);
+  const { container, resolveChannelService } = await withServices(s);
+  const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');
@@ -561,7 +574,15 @@ async function handleChannelResume(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const channelId = await resolveChannelIdOrExit(idOrName);
+  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
+  const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
+  const channelId = await resolveChannelId(idOrName, channelRepository);
+  if (!channelId) {
+    s.stop('Not found');
+    ui.error(`Channel not found: ${idOrName}`);
+    process.exit(1);
+  }
+
   const result = await channelService.resumeChannel(channelId);
   exitOnError(result, s, 'Failed to resume channel');
   s.stop('Resumed');

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -267,8 +267,12 @@ export async function handleChannelCommand(subCmd: string | undefined, channelAr
     await handleChannelResume(channelArgs);
     return;
   }
+  if (subCmd === 'create') {
+    await handleChannelCreate(channelArgs);
+    return;
+  }
 
-  // Default: create (subCmd is the channel name or a flag)
+  // Default: subCmd is the channel name (e.g. `beat channel advisor --agent claude`)
   const createArgs = subCmd ? [subCmd, ...channelArgs] : channelArgs;
   await handleChannelCreate(createArgs);
 }
@@ -412,8 +416,10 @@ async function handleChannelList(args: string[]): Promise<void> {
     } else {
       for (const ch of channels) {
         const memberSummary = ch.members.map((m) => m.name).join(', ');
+        const mode = ch.communicationMode ?? 'n/a';
+        const rounds = ch.maxRounds ? `${ch.currentRound ?? 0}/${ch.maxRounds}` : 'n/a';
         ui.step(
-          `${ui.dim(ch.id)}  ${ui.colorStatus(ch.status.padEnd(10))}  ${ch.name}  members: ${ch.members.length} (${memberSummary})`,
+          `${ui.dim(ch.id)}  ${ui.colorStatus(ch.status.padEnd(10))}  ${ch.name.padEnd(20)}  ${mode.padEnd(12)}  ${rounds.padEnd(8)}  members: ${ch.members.length} (${memberSummary})`,
         );
       }
       ui.info(`${channels.length} channel${channels.length === 1 ? '' : 's'}`);

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -9,7 +9,7 @@
  * names are valid tmux session name suffixes (no transformation required).
  */
 
-import { AGENT_PROVIDERS, isAgentProvider } from '../../core/agents.js';
+import { AGENT_PROVIDERS, type AgentProvider, isAgentProvider } from '../../core/agents.js';
 import { CHANNEL_NAME_REGEX, ChannelId, ChannelStatus, type CommunicationMode } from '../../core/domain.js';
 import type { ChannelRepository } from '../../core/interfaces.js';
 import { err, ok, type Result } from '../../core/result.js';
@@ -111,7 +111,11 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
       topic = next;
       i++;
     } else if ((arg === '--working-directory' || arg === '-w') && next !== undefined) {
-      workingDirectory = next;
+      const pathResult = validatePath(next);
+      if (!pathResult.ok) {
+        return err(`Invalid working directory: ${pathResult.error.message}`);
+      }
+      workingDirectory = pathResult.value;
       i++;
     } else if (arg === '--system-prompt' && next !== undefined) {
       systemPrompt = next;
@@ -285,6 +289,24 @@ async function resolveChannelId(idOrName: string, channelRepository: ChannelRepo
   return result.value.id;
 }
 
+/**
+ * Resolve a channel ID using a transient read-only context, then close it.
+ * Exits the process if not found.
+ */
+async function resolveChannelIdOrExit(idOrName: string): Promise<ChannelId> {
+  const ctx = withReadOnlyContext();
+  try {
+    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!resolved) {
+      ui.error(`Channel not found: ${idOrName}`);
+      process.exit(1);
+    }
+    return resolved;
+  } finally {
+    ctx.close();
+  }
+}
+
 // ─── Create ──────────────────────────────────────────────────────────────────
 
 async function handleChannelCreate(args: string[]): Promise<void> {
@@ -312,7 +334,7 @@ async function handleChannelCreate(args: string[]): Promise<void> {
       members: [
         {
           name: createArgs.name,
-          agent: createArgs.agent as import('../../core/agents.js').AgentProvider,
+          agent: createArgs.agent as AgentProvider,
           systemPrompt: createArgs.systemPrompt,
         },
       ],
@@ -324,7 +346,7 @@ async function handleChannelCreate(args: string[]): Promise<void> {
       name: createArgs.name,
       members: createArgs.members.map((m) => ({
         name: m.name,
-        agent: m.agent as import('../../core/agents.js').AgentProvider,
+        agent: m.agent as AgentProvider,
         systemPrompt: m.systemPrompt,
       })),
       communicationMode: createArgs.communicationMode,
@@ -419,20 +441,11 @@ async function handleChannelStatus(args: string[]): Promise<void> {
   try {
     const channelId = await resolveChannelId(idOrName, ctx.channelRepository);
     if (!channelId) {
-      const findResult = await ctx.channelRepository.findByName(idOrName);
-      if (!findResult.ok) {
-        ui.error(`Failed to look up channel: ${findResult.error.message}`);
-        process.exit(1);
-      }
-    }
-
-    const resolvedId = channelId;
-    if (!resolvedId) {
       ui.error(`Channel not found: ${idOrName}`);
       process.exit(1);
     }
 
-    const channelResult = await ctx.channelRepository.findById(resolvedId);
+    const channelResult = await ctx.channelRepository.findById(channelId);
     const channel = exitOnNull(
       exitOnError(channelResult, undefined, 'Failed to get channel'),
       undefined,
@@ -487,22 +500,8 @@ async function handleChannelDestroy(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Resolve name → ID if needed
-  const ctx = withReadOnlyContext();
-  let channelId: ChannelId;
-  try {
-    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
-    if (!resolved) {
-      s.stop('Not found');
-      ui.error(`Channel not found: ${idOrName}`);
-      process.exit(1);
-    }
-    channelId = resolved;
-  } finally {
-    ctx.close();
-  }
-
-  const result = await channelService.destroyChannel(channelId, reason ? 'user-requested' : 'user-requested');
+  const channelId = await resolveChannelIdOrExit(idOrName);
+  const result = await channelService.destroyChannel(channelId, 'user-requested');
   exitOnError(result, s, 'Failed to destroy channel');
   s.stop('Destroyed');
   ui.success(`Channel ${idOrName} destroyed`);
@@ -529,20 +528,7 @@ async function handleChannelPause(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const ctx = withReadOnlyContext();
-  let channelId: ChannelId;
-  try {
-    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
-    if (!resolved) {
-      s.stop('Not found');
-      ui.error(`Channel not found: ${idOrName}`);
-      process.exit(1);
-    }
-    channelId = resolved;
-  } finally {
-    ctx.close();
-  }
-
+  const channelId = await resolveChannelIdOrExit(idOrName);
   const result = await channelService.pauseChannel(channelId);
   exitOnError(result, s, 'Failed to pause channel');
   s.stop('Paused');
@@ -569,20 +555,7 @@ async function handleChannelResume(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const ctx = withReadOnlyContext();
-  let channelId: ChannelId;
-  try {
-    const resolved = await resolveChannelId(idOrName, ctx.channelRepository);
-    if (!resolved) {
-      s.stop('Not found');
-      ui.error(`Channel not found: ${idOrName}`);
-      process.exit(1);
-    }
-    channelId = resolved;
-  } finally {
-    ctx.close();
-  }
-
+  const channelId = await resolveChannelIdOrExit(idOrName);
   const result = await channelService.resumeChannel(channelId);
   exitOnError(result, s, 'Failed to resume channel');
   s.stop('Resumed');

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -358,34 +358,23 @@ async function handleChannelCreate(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  let result;
-  if (createArgs.mode === 'single') {
-    result = await channelService.createChannel({
-      name: createArgs.name,
-      members: [
-        {
-          name: createArgs.name,
-          agent: createArgs.agent as AgentProvider,
-          systemPrompt: createArgs.systemPrompt,
-        },
-      ],
-      topic: createArgs.topic,
-      workingDirectory: createArgs.workingDirectory,
-    });
-  } else {
-    result = await channelService.createChannel({
-      name: createArgs.name,
-      members: createArgs.members.map((m) => ({
-        name: m.name,
-        agent: m.agent as AgentProvider,
-        systemPrompt: m.systemPrompt,
-      })),
-      communicationMode: createArgs.communicationMode,
-      maxRounds: createArgs.maxRounds,
-      topic: createArgs.topic,
-      workingDirectory: createArgs.workingDirectory,
-    });
-  }
+  const members =
+    createArgs.mode === 'single'
+      ? [{ name: createArgs.name, agent: createArgs.agent as AgentProvider, systemPrompt: createArgs.systemPrompt }]
+      : createArgs.members.map((m) => ({
+          name: m.name,
+          agent: m.agent as AgentProvider,
+          systemPrompt: m.systemPrompt,
+        }));
+
+  const result = await channelService.createChannel({
+    name: createArgs.name,
+    members,
+    communicationMode: createArgs.mode === 'multi' ? createArgs.communicationMode : undefined,
+    maxRounds: createArgs.mode === 'multi' ? createArgs.maxRounds : undefined,
+    topic: createArgs.topic,
+    workingDirectory: createArgs.workingDirectory,
+  });
 
   const channel = exitOnError(result, s, 'Failed to create channel');
   s.stop('Channel created');

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -60,19 +60,23 @@ export type ParsedChannelCreate = ParsedChannelCreateSingle | ParsedChannelCreat
 
 // ─── Pure parsing functions ────────────────────────────────────────────────────
 
+/** Raw flag values extracted from argv before semantic validation. */
+interface TokenizedChannelCreateFlags {
+  readonly positional: readonly string[];
+  readonly agentFlag: string | undefined;
+  readonly members: readonly ParsedMember[];
+  readonly communicationMode: CommunicationMode | undefined;
+  readonly maxRounds: number | undefined;
+  readonly topic: string | undefined;
+  readonly workingDirectory: string | undefined;
+  readonly systemPrompt: string | undefined;
+}
+
 /**
- * Parse and validate channel create arguments.
- * ARCHITECTURE: Pure function — no side effects, returns Result for testability.
- *
- * Two modes:
- * - Single-agent: --agent <provider> flag present, no --member flags.
- *   Member name = channel name. No --mode or --max-rounds required.
- * - Multi-agent: --member name:agent[:prompt] flags. Requires --max-rounds.
- *   Accepts --mode broadcast|directed|round-robin.
- * Mutual exclusion: --agent + --member together → error.
+ * Phase 1: Tokenize raw argv into typed flag values with per-flag syntax checks.
+ * No cross-flag semantic rules are applied here.
  */
-export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedChannelCreate, string> {
-  // First positional argument is the channel name
+function tokenizeChannelCreateFlags(args: readonly string[]): Result<TokenizedChannelCreateFlags, string> {
   const positional: string[] = [];
   const members: ParsedMember[] = [];
   let agentFlag: string | undefined;
@@ -108,6 +112,9 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
       maxRounds = n;
       i++;
     } else if (arg === '--topic' && next !== undefined) {
+      if (next.length > 262_144) {
+        return err('--topic must be at most 262,144 characters');
+      }
       topic = next;
       i++;
     } else if ((arg === '--working-directory' || arg === '-w') && next !== undefined) {
@@ -130,19 +137,28 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
     }
   }
 
-  const channelName = positional[0];
+  return ok({ positional, agentFlag, members, communicationMode, maxRounds, topic, workingDirectory, systemPrompt });
+}
+
+/**
+ * Phase 2: Apply semantic validation rules to tokenized flags.
+ * Enforces cross-flag constraints: mutual exclusion, required fields per mode,
+ * channel name format, agent provider validity, and member name format.
+ */
+function validateChannelCreateFlags(tokens: TokenizedChannelCreateFlags): Result<ParsedChannelCreate, string> {
+  const { agentFlag, members, communicationMode, maxRounds, topic, workingDirectory, systemPrompt } = tokens;
+
+  const channelName = tokens.positional[0];
   if (!channelName) {
     return err('Usage: beat channel create <name> --agent <provider> | --member name:agent[:prompt]...');
   }
 
-  // Validate channel name
   if (!CHANNEL_NAME_REGEX.test(channelName)) {
     return err(
       `Invalid channel name "${channelName}": must be lowercase alphanumeric with interior hyphens, max 64 chars`,
     );
   }
 
-  // Mutual exclusion: --agent + --member
   if (agentFlag !== undefined && members.length > 0) {
     return err('--agent and --member are mutually exclusive. Use --agent for single-agent, --member for multi-agent.');
   }
@@ -158,14 +174,7 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
     if (communicationMode !== undefined) {
       return err('--mode is only valid for multi-agent channels (--member). Use --agent for single-agent.');
     }
-    return ok({
-      mode: 'single' as const,
-      name: channelName,
-      agent: agentFlag,
-      topic,
-      workingDirectory,
-      systemPrompt,
-    });
+    return ok({ mode: 'single' as const, name: channelName, agent: agentFlag, topic, workingDirectory, systemPrompt });
   }
 
   // Multi-agent mode
@@ -177,7 +186,6 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
     return err('--max-rounds is required for multi-agent channels');
   }
 
-  // Validate all member agents
   for (const member of members) {
     if (!isAgentProvider(member.agent)) {
       return err(
@@ -191,7 +199,6 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
     }
   }
 
-  // --system-prompt is single-agent only
   if (systemPrompt !== undefined) {
     return err(
       '--system-prompt is only valid for single-agent channels (--agent). Use --member name:agent:prompt for per-member prompts.',
@@ -207,6 +214,26 @@ export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedCh
     topic,
     workingDirectory,
   });
+}
+
+/**
+ * Parse and validate channel create arguments.
+ * ARCHITECTURE: Pure function — no side effects, returns Result for testability.
+ *
+ * Two modes:
+ * - Single-agent: --agent <provider> flag present, no --member flags.
+ *   Member name = channel name. No --mode or --max-rounds required.
+ * - Multi-agent: --member name:agent[:prompt] flags. Requires --max-rounds.
+ *   Accepts --mode broadcast|directed|round-robin.
+ * Mutual exclusion: --agent + --member together → error.
+ *
+ * Composed from two phases: tokenizeChannelCreateFlags (argv → raw tokens)
+ * then validateChannelCreateFlags (tokens → typed ParsedChannelCreate).
+ */
+export function parseChannelCreateArgs(args: readonly string[]): Result<ParsedChannelCreate, string> {
+  const tokensResult = tokenizeChannelCreateFlags(args);
+  if (!tokensResult.ok) return tokensResult;
+  return validateChannelCreateFlags(tokensResult.value);
 }
 
 /**
@@ -249,6 +276,11 @@ function parseMemberFlag(value: string): Result<ParsedMember, string> {
 
 // ─── Subcommand router ────────────────────────────────────────────────────────
 
+/**
+ * Route channel subcommands to their handlers.
+ * Subcommands: create, list, status, destroy, pause, resume.
+ * Invoked from src/cli.ts as the primary entry point for `beat channel ...`.
+ */
 export async function handleChannelCommand(subCmd: string | undefined, channelArgs: string[]): Promise<void> {
   if (subCmd === 'list') {
     await handleChannelList(channelArgs);
@@ -285,15 +317,23 @@ export async function handleChannelCommand(subCmd: string | undefined, channelAr
 /**
  * Resolve a channel ID or name string to a ChannelId.
  * IDs start with 'ch-'; names are resolved via findByName().
+ *
+ * Returns:
+ * - ok(ChannelId) when found
+ * - ok(null) when not found (name lookup returned no row)
+ * - err(Error) when the repository call itself fails (DB error)
  */
-async function resolveChannelId(idOrName: string, channelRepository: ChannelRepository): Promise<ChannelId | null> {
+async function resolveChannelId(
+  idOrName: string,
+  channelRepository: ChannelRepository,
+): Promise<Result<ChannelId | null, Error>> {
   if (idOrName.startsWith('ch-')) {
-    return ChannelId(idOrName);
+    return ok(ChannelId(idOrName));
   }
   const result = await channelRepository.findByName(idOrName);
-  if (!result.ok) return null;
-  if (!result.value) return null;
-  return result.value.id;
+  if (!result.ok) return err(result.error);
+  if (!result.value) return ok(null);
+  return ok(result.value.id);
 }
 
 // ─── Create ──────────────────────────────────────────────────────────────────
@@ -308,11 +348,12 @@ async function handleChannelCreate(args: string[]): Promise<void> {
 
   const s = ui.createSpinner();
   s.start('Creating channel...');
-  const { resolveChannelService } = await withServices(s);
+  const { container, resolveChannelService } = await withServices(s);
   const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');
+    await container.dispose();
     ui.error('Channel service unavailable. Ensure the server is properly configured.');
     process.exit(1);
   }
@@ -436,7 +477,12 @@ async function handleChannelStatus(args: string[]): Promise<void> {
   s.stop('Ready');
 
   try {
-    const channelId = await resolveChannelId(idOrName, ctx.channelRepository);
+    const channelIdResult = await resolveChannelId(idOrName, ctx.channelRepository);
+    if (!channelIdResult.ok) {
+      ui.error(`Failed to look up channel: ${channelIdResult.error.message}`);
+      process.exit(1);
+    }
+    const channelId = channelIdResult.value;
     if (!channelId) {
       ui.error(`Channel not found: ${idOrName}`);
       process.exit(1);
@@ -498,15 +544,24 @@ async function resolveChannelOp(
 
   if (!channelService) {
     s.stop('Failed');
+    await container.dispose();
     ui.error('Channel service unavailable.');
     process.exit(1);
   }
 
   const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
   const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
-  const channelId = await resolveChannelId(idOrName, channelRepository);
+  const channelIdResult = await resolveChannelId(idOrName, channelRepository);
+  if (!channelIdResult.ok) {
+    s.stop('Failed');
+    await container.dispose();
+    ui.error(`Failed to look up channel: ${channelIdResult.error.message}`);
+    process.exit(1);
+  }
+  const channelId = channelIdResult.value;
   if (!channelId) {
     s.stop('Not found');
+    await container.dispose();
     ui.error(`Channel not found: ${idOrName}`);
     process.exit(1);
   }

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -499,7 +499,7 @@ async function handleChannelStatus(args: string[]): Promise<void> {
     lines.push(`ID:            ${channel.id}`);
     lines.push(`Name:          ${channel.name}`);
     lines.push(`Status:        ${ui.colorStatus(channel.status)}`);
-    lines.push(`Members:       ${channel.members.length}`);
+    lines.push(`Member count:  ${channel.members.length}`);
     if (channel.communicationMode) lines.push(`Mode:          ${channel.communicationMode}`);
     if (channel.maxRounds !== undefined) {
       lines.push(`Rounds:        ${channel.currentRound}/${channel.maxRounds}`);
@@ -510,6 +510,7 @@ async function handleChannelStatus(args: string[]): Promise<void> {
     lines.push(`Created:       ${new Date(channel.createdAt).toISOString()}`);
 
     if (channel.members.length > 0) {
+      lines.push('');
       lines.push('Members:');
       for (const m of channel.members) {
         lines.push(`  ${m.name}  ${m.agent}  ${ui.colorStatus(m.status)}`);
@@ -574,20 +575,15 @@ async function resolveChannelOp(
 async function handleChannelDestroy(args: string[]): Promise<void> {
   const idOrName = args[0];
   if (!idOrName) {
-    ui.error('Usage: beat channel destroy <channel-id|name> [reason]');
+    ui.error('Usage: beat channel destroy <channel-id|name>');
     process.exit(1);
   }
-  // ARCHITECTURE: reason is a user-visible display string only; destroyChannel()
-  // accepts a typed ChannelDestroyReason enum ('user-requested' | 'max-rounds-reached' |
-  // 'all-members-crashed'), so the free-form CLI input cannot be passed to the service.
-  const displayReason = args.slice(1).join(' ') || undefined;
 
   const { channelService, channelId, s } = await resolveChannelOp(idOrName, 'Destroying channel...');
   const result = await channelService.destroyChannel(channelId, 'user-requested');
   exitOnError(result, s, 'Failed to destroy channel');
   s.stop('Destroyed');
   ui.success(`Channel ${idOrName} destroyed`);
-  if (displayReason) ui.info(`Reason: ${displayReason}`);
   process.exit(0);
 }
 

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -11,7 +11,7 @@
 
 import { AGENT_PROVIDERS, type AgentProvider, isAgentProvider } from '../../core/agents.js';
 import { CHANNEL_NAME_REGEX, ChannelId, ChannelStatus, type CommunicationMode } from '../../core/domain.js';
-import type { ChannelRepository } from '../../core/interfaces.js';
+import type { ChannelRepository, ChannelService } from '../../core/interfaces.js';
 import { err, ok, type Result } from '../../core/result.js';
 import { validatePath } from '../../utils/validation.js';
 import { exitOnError, exitOnNull, withReadOnlyContext, withServices } from '../services.js';
@@ -477,21 +477,22 @@ async function handleChannelStatus(args: string[]): Promise<void> {
   process.exit(0);
 }
 
-// ─── Destroy ─────────────────────────────────────────────────────────────────
+// ─── Shared setup for mutation commands ──────────────────────────────────────
 
-async function handleChannelDestroy(args: string[]): Promise<void> {
-  const idOrName = args[0];
-  if (!idOrName) {
-    ui.error('Usage: beat channel destroy <channel-id|name> [reason]');
-    process.exit(1);
-  }
-  // ARCHITECTURE: reason is a user-visible display string only; destroyChannel()
-  // accepts a typed ChannelDestroyReason enum ('user-requested' | 'max-rounds-reached' |
-  // 'all-members-crashed'), so the free-form CLI input cannot be passed to the service.
-  const displayReason = args.slice(1).join(' ') || undefined;
-
+/**
+ * Bootstrap channelService and resolve a channel ID or name to a ChannelId.
+ * Exits the process on any error.
+ */
+async function resolveChannelOp(
+  idOrName: string,
+  spinnerMsg: string,
+): Promise<{
+  channelService: ChannelService;
+  channelId: ChannelId;
+  s: ReturnType<typeof ui.createSpinner>;
+}> {
   const s = ui.createSpinner();
-  s.start('Destroying channel...');
+  s.start(spinnerMsg);
   const { container, resolveChannelService } = await withServices(s);
   const channelService = await resolveChannelService();
 
@@ -510,6 +511,23 @@ async function handleChannelDestroy(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  return { channelService, channelId, s };
+}
+
+// ─── Destroy ─────────────────────────────────────────────────────────────────
+
+async function handleChannelDestroy(args: string[]): Promise<void> {
+  const idOrName = args[0];
+  if (!idOrName) {
+    ui.error('Usage: beat channel destroy <channel-id|name> [reason]');
+    process.exit(1);
+  }
+  // ARCHITECTURE: reason is a user-visible display string only; destroyChannel()
+  // accepts a typed ChannelDestroyReason enum ('user-requested' | 'max-rounds-reached' |
+  // 'all-members-crashed'), so the free-form CLI input cannot be passed to the service.
+  const displayReason = args.slice(1).join(' ') || undefined;
+
+  const { channelService, channelId, s } = await resolveChannelOp(idOrName, 'Destroying channel...');
   const result = await channelService.destroyChannel(channelId, 'user-requested');
   exitOnError(result, s, 'Failed to destroy channel');
   s.stop('Destroyed');
@@ -527,26 +545,7 @@ async function handleChannelPause(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const s = ui.createSpinner();
-  s.start('Pausing channel...');
-  const { container, resolveChannelService } = await withServices(s);
-  const channelService = await resolveChannelService();
-
-  if (!channelService) {
-    s.stop('Failed');
-    ui.error('Channel service unavailable.');
-    process.exit(1);
-  }
-
-  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
-  const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
-  const channelId = await resolveChannelId(idOrName, channelRepository);
-  if (!channelId) {
-    s.stop('Not found');
-    ui.error(`Channel not found: ${idOrName}`);
-    process.exit(1);
-  }
-
+  const { channelService, channelId, s } = await resolveChannelOp(idOrName, 'Pausing channel...');
   const result = await channelService.pauseChannel(channelId);
   exitOnError(result, s, 'Failed to pause channel');
   s.stop('Paused');
@@ -563,26 +562,7 @@ async function handleChannelResume(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const s = ui.createSpinner();
-  s.start('Resuming channel...');
-  const { container, resolveChannelService } = await withServices(s);
-  const channelService = await resolveChannelService();
-
-  if (!channelService) {
-    s.stop('Failed');
-    ui.error('Channel service unavailable.');
-    process.exit(1);
-  }
-
-  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
-  const channelRepository = exitOnError(channelRepositoryResult, s, 'Failed to get channel repository');
-  const channelId = await resolveChannelId(idOrName, channelRepository);
-  if (!channelId) {
-    s.stop('Not found');
-    ui.error(`Channel not found: ${idOrName}`);
-    process.exit(1);
-  }
-
+  const { channelService, channelId, s } = await resolveChannelOp(idOrName, 'Resuming channel...');
   const result = await channelService.resumeChannel(channelId);
   exitOnError(result, s, 'Failed to resume channel');
   s.stop('Resumed');

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -173,6 +173,18 @@ ${bold('Examples:')}
   # Resume failed task with context
   beat resume <task-id> --context "Try a different approach"
 
+  # Channels (single-agent and multi-agent)
+  beat channel advisor --agent claude                              # Single-agent channel
+  beat channel debate --member alice:claude --member bob:codex --max-rounds 10
+  beat channel debate --mode round-robin --topic "Review this PR"
+  beat channel list --status active
+  beat channel status advisor
+  beat channel pause advisor
+  beat channel resume advisor
+  beat channel destroy advisor "work complete"
+  beat msg advisor "What do you think about this approach?"
+  beat msg debate/alice "Focus on security concerns"
+
   # Configuration
   beat config show
   beat config set timeout 300000

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -112,6 +112,28 @@ ${bold('Loop Commands:')}
   ${cyan('loop resume')} <loop-id>               Resume a paused loop
   ${cyan('loop cancel')} <loop-id> [--cancel-tasks] [reason]
 
+${bold('Channel Commands:')}
+  ${cyan('channel')} <name> --agent <provider>              Create single-agent channel
+    --topic TEXT                              Initial topic delivered to member
+    -w, --working-directory DIR              Working directory for session
+    --system-prompt TEXT                     System prompt for the member
+
+  ${cyan('channel')} <name> --member name:agent[:prompt]... Create multi-agent channel
+    --member name:agent[:prompt]             Repeatable; prompt may contain colons
+    --mode broadcast|directed|round-robin    Routing strategy (default: broadcast)
+    --max-rounds N                           Max rounds before COMPLETED (required)
+    --topic TEXT                             Initial topic (broadcast to all)
+    -w, --working-directory DIR              Working directory for sessions
+
+  ${cyan('channel list')} [--status active|paused|...] [--limit N]
+  ${cyan('channel status')} <channel-id|name>
+  ${cyan('channel destroy')} <channel-id|name> [reason]
+  ${cyan('channel pause')} <channel-id|name>
+  ${cyan('channel resume')} <channel-id|name>
+
+  ${cyan('msg')} <channel-name>[/<member-name>] <message...>
+                               Send a message to a channel or specific member
+
 ${bold('Configuration:')}
   ${cyan('config show')}                Show current configuration (resolved values)
   ${cyan('config set')} <key> <value>   Set a config value (persisted to ~/.autobeat/config.json)

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -83,11 +83,20 @@ export function parseMsgArgs(args: readonly string[]): Result<ParsedMsgArgs, str
     );
   }
 
+  if (memberName !== undefined && !CHANNEL_NAME_REGEX.test(memberName)) {
+    return err(
+      `Invalid member name "${memberName}": must be lowercase alphanumeric with interior hyphens, max 64 chars`,
+    );
+  }
+
   return ok({ channelName, memberName, message });
 }
 
 // ─── Handler ──────────────────────────────────────────────────────────────────
 
+/**
+ * Handle `beat msg <target> <message...>` — send a message to a channel or specific member.
+ */
 export async function handleMsgCommand(args: string[]): Promise<void> {
   const parsed = parseMsgArgs(args);
   if (!parsed.ok) {
@@ -129,21 +138,15 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
   }
 
   // Fast-fail on terminal and paused statuses before calling the service
-  if (channel.status === ChannelStatus.DESTROYED) {
+  const REJECTED_STATUSES: Partial<Record<ChannelStatus, string>> = {
+    [ChannelStatus.DESTROYED]: `Channel "${channelName}" is destroyed. Create a new channel with: beat channel create ${channelName} ...`,
+    [ChannelStatus.COMPLETED]: `Channel "${channelName}" has completed and no longer accepts messages.`,
+    [ChannelStatus.PAUSED]: `Channel "${channelName}" is paused. Resume with: beat channel resume ${channelName}`,
+  };
+  const rejection = REJECTED_STATUSES[channel.status];
+  if (rejection) {
     s.stop('Failed');
-    ui.error(
-      `Channel "${channelName}" is destroyed. Create a new channel with: beat channel create ${channelName} ...`,
-    );
-    process.exit(1);
-  }
-  if (channel.status === ChannelStatus.COMPLETED) {
-    s.stop('Failed');
-    ui.error(`Channel "${channelName}" has completed and no longer accepts messages.`);
-    process.exit(1);
-  }
-  if (channel.status === ChannelStatus.PAUSED) {
-    s.stop('Failed');
-    ui.error(`Channel "${channelName}" is paused. Resume with: beat channel resume ${channelName}`);
+    ui.error(rejection);
     process.exit(1);
   }
 

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -130,7 +130,9 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
   }
 
   if (channelStatus === ChannelStatus.PAUSED) {
-    ui.info(`Note: channel "${channelName}" is paused. Message will be queued.`);
+    s.stop('Failed');
+    ui.error(`Channel "${channelName}" is paused. Resume with: beat channel resume ${channelName}`);
+    process.exit(1);
   }
 
   const result = await channelService.sendMessage(channelId, message, memberName);

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -98,7 +98,8 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
 
   const s = ui.createSpinner();
   s.start('Sending message...');
-  const { container, channelService } = await withServices(s);
+  const { container, resolveChannelService } = await withServices(s);
+  const channelService = await resolveChannelService();
 
   if (!channelService) {
     s.stop('Failed');

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -11,9 +11,13 @@
  */
 
 import { CHANNEL_NAME_REGEX, type ChannelId, ChannelStatus } from '../../core/domain.js';
+import type { ChannelRepository } from '../../core/interfaces.js';
 import { err, ok, type Result } from '../../core/result.js';
-import { exitOnError, withReadOnlyContext, withServices } from '../services.js';
+import { exitOnError, withServices } from '../services.js';
 import * as ui from '../ui.js';
+
+/** Maximum message length aligned with MCP SendMessage tool (256 KB). */
+const MAX_MESSAGE_LENGTH = 262144;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -48,6 +52,10 @@ export function parseMsgArgs(args: readonly string[]): Result<ParsedMsgArgs, str
     return err('Message text is required. Usage: beat msg <target> <message...>');
   }
   const message = messageWords.join(' ');
+
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    return err(`Message too long: ${message.length} chars (max ${MAX_MESSAGE_LENGTH}). Split into shorter messages.`);
+  }
 
   // Split target on first '/' only
   const slashIndex = target.indexOf('/');
@@ -88,40 +96,9 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
   }
   const { channelName, memberName, message } = parsed.value;
 
-  // Resolve channel name → ID via read-only context
-  const ctx = withReadOnlyContext();
-  let channelId: ChannelId;
-  let channelStatus: ChannelStatus;
-  try {
-    const channelResult = await ctx.channelRepository.findByName(channelName);
-    const channel = exitOnError(channelResult, undefined, `Failed to look up channel "${channelName}"`);
-
-    if (!channel) {
-      ui.error(`Channel "${channelName}" not found`);
-      process.exit(1);
-    }
-
-    // Fast-fail on terminal statuses before calling the service
-    if (channel.status === ChannelStatus.DESTROYED) {
-      ui.error(
-        `Channel "${channelName}" is destroyed. Create a new channel with: beat channel create ${channelName} ...`,
-      );
-      process.exit(1);
-    }
-    if (channel.status === ChannelStatus.COMPLETED) {
-      ui.error(`Channel "${channelName}" has completed and no longer accepts messages.`);
-      process.exit(1);
-    }
-
-    channelId = channel.id;
-    channelStatus = channel.status;
-  } finally {
-    ctx.close();
-  }
-
   const s = ui.createSpinner();
   s.start('Sending message...');
-  const { channelService } = await withServices(s);
+  const { container, channelService } = await withServices(s);
 
   if (!channelService) {
     s.stop('Failed');
@@ -129,11 +106,47 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  if (channelStatus === ChannelStatus.PAUSED) {
+  // Resolve channel name → ID using the same connection as the service call.
+  // ARCHITECTURE: Reading from the container avoids a second DB connection and
+  // eliminates the TOCTOU window where channel status could change between the
+  // read-only lookup and the subsequent service call.
+  const channelRepositoryResult = container.get<ChannelRepository>('channelRepository');
+  if (!channelRepositoryResult.ok) {
+    s.stop('Failed');
+    ui.error(`Failed to get channel repository: ${channelRepositoryResult.error.message}`);
+    process.exit(1);
+  }
+  const channelRepository = channelRepositoryResult.value;
+
+  const channelResult = await channelRepository.findByName(channelName);
+  const channel = exitOnError(channelResult, s, `Failed to look up channel "${channelName}"`);
+
+  if (!channel) {
+    s.stop('Failed');
+    ui.error(`Channel "${channelName}" not found`);
+    process.exit(1);
+  }
+
+  // Fast-fail on terminal and paused statuses before calling the service
+  if (channel.status === ChannelStatus.DESTROYED) {
+    s.stop('Failed');
+    ui.error(
+      `Channel "${channelName}" is destroyed. Create a new channel with: beat channel create ${channelName} ...`,
+    );
+    process.exit(1);
+  }
+  if (channel.status === ChannelStatus.COMPLETED) {
+    s.stop('Failed');
+    ui.error(`Channel "${channelName}" has completed and no longer accepts messages.`);
+    process.exit(1);
+  }
+  if (channel.status === ChannelStatus.PAUSED) {
     s.stop('Failed');
     ui.error(`Channel "${channelName}" is paused. Resume with: beat channel resume ${channelName}`);
     process.exit(1);
   }
+
+  const channelId: ChannelId = channel.id;
 
   const result = await channelService.sendMessage(channelId, message, memberName);
   exitOnError(result, s, 'Failed to send message');

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -1,0 +1,147 @@
+/**
+ * msg CLI command — send a message to a channel member.
+ *
+ * Usage:
+ *   beat msg <channel-name>[/<member-name>] <message text...>
+ *
+ * ARCHITECTURE: Pure parsing function exported for testability;
+ * handler is side-effecting and not exported.
+ *
+ * ADR-001: Channel name validated against CHANNEL_NAME_REGEX.
+ */
+
+import { CHANNEL_NAME_REGEX, ChannelStatus } from '../../core/domain.js';
+import { err, ok, type Result } from '../../core/result.js';
+import { exitOnError, withReadOnlyContext, withServices } from '../services.js';
+import * as ui from '../ui.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ParsedMsgArgs {
+  /** Channel name (validated against CHANNEL_NAME_REGEX) */
+  readonly channelName: string;
+  /** Optional target member name */
+  readonly memberName?: string;
+  /** Message text */
+  readonly message: string;
+}
+
+// ─── Pure parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse msg command arguments.
+ * ARCHITECTURE: Pure function — no side effects, returns Result for testability.
+ *
+ * Syntax: <channel-name>[/<member-name>] <message text...>
+ * - Split target on first '/' only
+ * - Empty member after '/' is an error
+ * - Message is args[1..] joined with spaces
+ */
+export function parseMsgArgs(args: readonly string[]): Result<ParsedMsgArgs, string> {
+  const target = args[0];
+  if (!target) {
+    return err('Usage: beat msg <channel-name>[/<member-name>] <message text...>');
+  }
+
+  const messageWords = args.slice(1);
+  if (messageWords.length === 0) {
+    return err('Message text is required. Usage: beat msg <target> <message...>');
+  }
+  const message = messageWords.join(' ');
+
+  // Split target on first '/' only
+  const slashIndex = target.indexOf('/');
+  let channelName: string;
+  let memberName: string | undefined;
+
+  if (slashIndex === -1) {
+    channelName = target;
+  } else {
+    channelName = target.slice(0, slashIndex);
+    const memberPart = target.slice(slashIndex + 1);
+    if (!memberPart) {
+      return err(`Empty member name after '/' in "${target}". Use: channel-name/member-name`);
+    }
+    memberName = memberPart;
+  }
+
+  if (!channelName) {
+    return err(`Channel name cannot be empty in target "${target}"`);
+  }
+
+  if (!CHANNEL_NAME_REGEX.test(channelName)) {
+    return err(
+      `Invalid channel name "${channelName}": must be lowercase alphanumeric with interior hyphens, max 64 chars`,
+    );
+  }
+
+  return ok({ channelName, memberName, message });
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export async function handleMsgCommand(args: string[]): Promise<void> {
+  const parsed = parseMsgArgs(args);
+  if (!parsed.ok) {
+    ui.error(parsed.error);
+    process.exit(1);
+  }
+  const { channelName, memberName, message } = parsed.value;
+
+  // Resolve channel name → ID via read-only context
+  const ctx = withReadOnlyContext();
+  let channelId: string;
+  let channelStatus: ChannelStatus;
+  try {
+    const channelResult = await ctx.channelRepository.findByName(channelName);
+    const channel = exitOnError(channelResult, undefined, `Failed to look up channel "${channelName}"`);
+
+    if (!channel) {
+      ui.error(`Channel "${channelName}" not found`);
+      process.exit(1);
+    }
+
+    // Fast-fail on terminal statuses before calling the service
+    if (channel.status === ChannelStatus.DESTROYED) {
+      ui.error(
+        `Channel "${channelName}" is destroyed. Create a new channel with: beat channel create ${channelName} ...`,
+      );
+      process.exit(1);
+    }
+    if (channel.status === ChannelStatus.COMPLETED) {
+      ui.error(`Channel "${channelName}" has completed and no longer accepts messages.`);
+      process.exit(1);
+    }
+
+    channelId = channel.id;
+    channelStatus = channel.status;
+  } finally {
+    ctx.close();
+  }
+
+  const s = ui.createSpinner();
+  s.start('Sending message...');
+  const { channelService } = await withServices(s);
+
+  if (!channelService) {
+    s.stop('Failed');
+    ui.error('Channel service unavailable.');
+    process.exit(1);
+  }
+
+  if (channelStatus === ChannelStatus.PAUSED) {
+    ui.info(`Note: channel "${channelName}" is paused. Message will be queued.`);
+  }
+
+  const result = await channelService.sendMessage(
+    channelId as import('../../core/domain.js').ChannelId,
+    message,
+    memberName,
+  );
+  exitOnError(result, s, 'Failed to send message');
+  s.stop('Sent');
+
+  const target = memberName ? `${channelName}/${memberName}` : channelName;
+  ui.success(`Message sent to ${target}`);
+  process.exit(0);
+}

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -10,7 +10,7 @@
  * ADR-001: Channel name validated against CHANNEL_NAME_REGEX.
  */
 
-import { CHANNEL_NAME_REGEX, ChannelStatus } from '../../core/domain.js';
+import { CHANNEL_NAME_REGEX, type ChannelId, ChannelStatus } from '../../core/domain.js';
 import { err, ok, type Result } from '../../core/result.js';
 import { exitOnError, withReadOnlyContext, withServices } from '../services.js';
 import * as ui from '../ui.js';
@@ -90,7 +90,7 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
 
   // Resolve channel name → ID via read-only context
   const ctx = withReadOnlyContext();
-  let channelId: string;
+  let channelId: ChannelId;
   let channelStatus: ChannelStatus;
   try {
     const channelResult = await ctx.channelRepository.findByName(channelName);
@@ -133,11 +133,7 @@ export async function handleMsgCommand(args: string[]): Promise<void> {
     ui.info(`Note: channel "${channelName}" is paused. Message will be queued.`);
   }
 
-  const result = await channelService.sendMessage(
-    channelId as import('../../core/domain.js').ChannelId,
-    message,
-    memberName,
-  );
+  const result = await channelService.sendMessage(channelId, message, memberName);
   exitOnError(result, s, 'Failed to send message');
   s.stop('Sent');
 

--- a/src/cli/dashboard/index.tsx
+++ b/src/cli/dashboard/index.tsx
@@ -14,6 +14,7 @@ import { render } from 'ink';
 import React from 'react';
 import { bootstrap } from '../../bootstrap.js';
 import type {
+  ChannelRepository,
   LoopRepository,
   LoopService,
   OrchestrationRepository,
@@ -85,6 +86,7 @@ export async function startDashboard(): Promise<void> {
   const outputRepository = container.get<OutputRepository>('outputRepository');
   const usageRepository = container.get<UsageRepository>('usageRepository');
   const pipelineRepository = container.get<PipelineRepository>('pipelineRepository');
+  const channelRepository = container.get<ChannelRepository>('channelRepository');
 
   if (
     !taskRepository.ok ||
@@ -94,7 +96,8 @@ export async function startDashboard(): Promise<void> {
     !workerRepository.ok ||
     !outputRepository.ok ||
     !usageRepository.ok ||
-    !pipelineRepository.ok
+    !pipelineRepository.ok ||
+    !channelRepository.ok
   ) {
     process.stderr.write('Error: Failed to resolve repositories from container\n');
     process.exit(1);
@@ -111,6 +114,7 @@ export async function startDashboard(): Promise<void> {
     outputRepository: outputRepository.value,
     usageRepository: usageRepository.value,
     pipelineRepository: pipelineRepository.value,
+    channelRepository: channelRepository.value,
     close: () => {
       /* handled by container.dispose() in cleanup() */
     },

--- a/src/cli/read-only-context.ts
+++ b/src/cli/read-only-context.ts
@@ -18,6 +18,7 @@
 
 import { loadConfiguration } from '../core/configuration.js';
 import type {
+  ChannelRepository,
   LoopRepository,
   OrchestrationRepository,
   OutputRepository,
@@ -28,6 +29,7 @@ import type {
   WorkerRepository,
 } from '../core/interfaces.js';
 import { Result, tryCatch } from '../core/result.js';
+import { SQLiteChannelRepository } from '../implementations/channel-repository.js';
 import { Database } from '../implementations/database.js';
 import { SQLiteLoopRepository } from '../implementations/loop-repository.js';
 import { SQLiteOrchestrationRepository } from '../implementations/orchestration-repository.js';
@@ -47,6 +49,7 @@ export interface ReadOnlyContext {
   readonly workerRepository: WorkerRepository;
   readonly usageRepository: UsageRepository;
   readonly pipelineRepository: PipelineRepository;
+  readonly channelRepository: ChannelRepository;
   close(): void;
 }
 
@@ -66,6 +69,7 @@ export function createReadOnlyContext(): Result<ReadOnlyContext> {
     const workerRepository = new SQLiteWorkerRepository(database);
     const usageRepository = new SQLiteUsageRepository(database);
     const pipelineRepository = new SQLitePipelineRepository(database);
+    const channelRepository = new SQLiteChannelRepository(database);
 
     return {
       taskRepository,
@@ -76,6 +80,7 @@ export function createReadOnlyContext(): Result<ReadOnlyContext> {
       workerRepository,
       usageRepository,
       pipelineRepository,
+      channelRepository,
       close: () => database.close(),
     };
   });

--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -64,6 +64,10 @@ export function withReadOnlyContext(s?: Spinner): ReadOnlyContext {
  *
  * Used for mutation commands that need the full event-driven pipeline.
  * Skips recovery and schedule executor — only the MCP server daemon needs those.
+ *
+ * ARCHITECTURE: channelService is resolved lazily via `resolveChannelService()`.
+ * Non-channel commands never call it and pay zero ChannelManager.create() cost.
+ * Channel commands call it once; subsequent calls return the cached singleton.
  */
 export async function withServices(s?: Spinner): Promise<{
   container: Container;
@@ -71,7 +75,7 @@ export async function withServices(s?: Spinner): Promise<{
   scheduleService: ScheduleService;
   loopService: LoopService;
   orchestrationService: OrchestrationService;
-  channelService?: ChannelService;
+  resolveChannelService: () => Promise<ChannelService | undefined>;
 }> {
   s?.message('Initializing...');
   const container = exitOnError(await bootstrap({ mode: 'cli' }), s, 'Bootstrap failed', 'Initialization failed');
@@ -100,16 +104,15 @@ export async function withServices(s?: Spinner): Promise<{
     'Initialization failed',
   );
 
-  // ARCHITECTURE: channelService is optional — resolution failure must not block other commands.
-  // ChannelManager.create() is async, so resolve() (not get()) is required here.
-  // On failure, log a warning and continue; channel mutation commands check for undefined.
-  let channelService: ChannelService | undefined;
-  const channelServiceResult = await container.resolve<ChannelService>('channelService');
-  if (channelServiceResult.ok) {
-    channelService = channelServiceResult.value;
-  } else {
-    ui.info(`Warning: Channel service unavailable: ${channelServiceResult.error.message}`);
-  }
+  // ARCHITECTURE: Lazy resolver — ChannelManager.create() is async and only needed by
+  // channel mutation commands. Non-channel commands (cancel, retry, resume, etc.) never
+  // call this and pay no startup cost. The container caches the singleton on first call.
+  const resolveChannelService = async (): Promise<ChannelService | undefined> => {
+    const result = await container.resolve<ChannelService>('channelService');
+    if (result.ok) return result.value;
+    ui.info(`Warning: Channel service unavailable: ${result.error.message}`);
+    return undefined;
+  };
 
-  return { container, taskManager, scheduleService, loopService, orchestrationService, channelService };
+  return { container, taskManager, scheduleService, loopService, orchestrationService, resolveChannelService };
 }

--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -1,6 +1,12 @@
 import { bootstrap } from '../bootstrap.js';
 import type { Container } from '../core/container.js';
-import type { LoopService, OrchestrationService, ScheduleService, TaskManager } from '../core/interfaces.js';
+import type {
+  ChannelService,
+  LoopService,
+  OrchestrationService,
+  ScheduleService,
+  TaskManager,
+} from '../core/interfaces.js';
 import type { Result } from '../core/result.js';
 import { createReadOnlyContext, type ReadOnlyContext } from './read-only-context.js';
 import type { Spinner } from './ui.js';
@@ -65,6 +71,7 @@ export async function withServices(s?: Spinner): Promise<{
   scheduleService: ScheduleService;
   loopService: LoopService;
   orchestrationService: OrchestrationService;
+  channelService?: ChannelService;
 }> {
   s?.message('Initializing...');
   const container = exitOnError(await bootstrap({ mode: 'cli' }), s, 'Bootstrap failed', 'Initialization failed');
@@ -93,5 +100,16 @@ export async function withServices(s?: Spinner): Promise<{
     'Initialization failed',
   );
 
-  return { container, taskManager, scheduleService, loopService, orchestrationService };
+  // ARCHITECTURE: channelService is optional — resolution failure must not block other commands.
+  // ChannelManager.create() is async, so resolve() (not get()) is required here.
+  // On failure, log a warning and continue; channel mutation commands check for undefined.
+  let channelService: ChannelService | undefined;
+  const channelServiceResult = await container.resolve<ChannelService>('channelService');
+  if (channelServiceResult.ok) {
+    channelService = channelServiceResult.value;
+  } else {
+    ui.info(`Warning: Channel service unavailable: ${channelServiceResult.error.message}`);
+  }
+
+  return { container, taskManager, scheduleService, loopService, orchestrationService, channelService };
 }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1069,7 +1069,7 @@ export interface ChannelService {
   /**
    * Deliver a message to the channel from an external caller.
    * targetMember — if provided, deliver to that specific member only.
-   * Returns err(INVALID_INPUT) if channel is paused or target member unknown.
+   * Returns err(INVALID_INPUT) if channel is paused, completed, or target member unknown.
    */
   sendMessage(channelId: ChannelId, message: string, targetMember?: string): Promise<Result<void>>;
   /** Fetch a channel by ID. Returns null if not found. */

--- a/src/services/channel-manager.ts
+++ b/src/services/channel-manager.ts
@@ -428,7 +428,12 @@ export class ChannelManager implements ChannelService {
 
     let dispatchError: Error | undefined;
     let delivered = false;
+    // Cancellation token: set to true if drain times out before the closure
+    // executes. The closure checks this flag before dispatching so a timed-out
+    // send does not dispatch after the caller has already received an error.
+    let cancelled = false;
     queue.enqueue(async () => {
+      if (cancelled) return;
       const dispatchResult = await this.dispatchMessage(channel, message, targetMember);
       delivered = true;
       if (!dispatchResult.ok) {
@@ -453,14 +458,15 @@ export class ChannelManager implements ChannelService {
     await queue.drain(10_000);
 
     // Guard against drain timeout racing the enqueued task: if the closure never
-    // ran (drain expired before execution), return an explicit error rather than
-    // silently reporting ok() for an undelivered message.
+    // ran (drain expired before execution), cancel it and return an explicit error
+    // rather than silently reporting ok() for an undelivered message.
     // ARCHITECTURE: SerialQueue is constructed internally (not injected), so the
     // 10-second drain timeout cannot be shortened in tests without making
     // drainTimeoutMs injectable. This guard is verified by inspection — mock
     // tmuxConnector resolves synchronously so drain() always completes before the
     // timeout in unit tests. A slow-connector test would require a design change.
     if (!delivered) {
+      cancelled = true;
       return err(new AutobeatError(ErrorCode.INVALID_INPUT, `Message delivery timed out for channel '${channelId}'`));
     }
     if (dispatchError) return err(dispatchError);

--- a/src/services/channel-manager.ts
+++ b/src/services/channel-manager.ts
@@ -400,6 +400,9 @@ export class ChannelManager implements ChannelService {
     if (!channel || channel.status === ChannelStatus.DESTROYED) {
       return err(new AutobeatError(ErrorCode.INVALID_INPUT, `Channel '${channelId}' not found or destroyed`));
     }
+    if (channel.status === ChannelStatus.COMPLETED) {
+      return err(new AutobeatError(ErrorCode.INVALID_INPUT, `Channel '${channelId}' is completed`));
+    }
 
     // Validate targetMember before queuing (fast-fail, no async work needed).
     if (targetMember !== undefined) {
@@ -732,6 +735,15 @@ export class ChannelManager implements ChannelService {
           ErrorCode.INVALID_INPUT,
           'Multi-agent channels (≥2 members) require maxRounds to be specified',
         ),
+      );
+    }
+
+    // 5b. Validate maxRounds range when provided
+    if (request.maxRounds !== undefined && (request.maxRounds < 1 || request.maxRounds > 10000)) {
+      return err(
+        new AutobeatError(ErrorCode.INVALID_INPUT, `maxRounds must be between 1 and 10000 (got ${request.maxRounds})`, {
+          maxRounds: request.maxRounds,
+        }),
       );
     }
 

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -4090,6 +4090,20 @@ describe('MCPAdapter - Channel Handlers', () => {
       const result = await adapter.callTool('DestroyChannel', { channelId: 'ch-abc' });
       expect(result.isError).toBe(true);
     });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('DestroyChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on empty channelId', async () => {
+      const result = await adapter.callTool('DestroyChannel', { channelId: '' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
   });
 
   describe('ChannelStatus', () => {
@@ -4110,6 +4124,28 @@ describe('MCPAdapter - Channel Handlers', () => {
       const response = JSON.parse(result.content[0].text);
       expect(response.error).toContain('not found');
     });
+
+    it('propagates service error', async () => {
+      mockChannelService.setGetResult(err(new Error('DB connection lost')));
+      const result = await adapter.callTool('ChannelStatus', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('DB connection lost');
+    });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('ChannelStatus', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on empty channelId', async () => {
+      const result = await adapter.callTool('ChannelStatus', { channelId: '' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
   });
 
   describe('ListChannels', () => {
@@ -4129,6 +4165,28 @@ describe('MCPAdapter - Channel Handlers', () => {
     it('passes limit to service', async () => {
       await adapter.callTool('ListChannels', { limit: 5 });
       expect(mockChannelService.listChannelsCalls[0]?.limit).toBe(5);
+    });
+
+    it('propagates service error', async () => {
+      mockChannelService.setListResult(err(new Error('Repository unavailable')));
+      const result = await adapter.callTool('ListChannels', {});
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('Repository unavailable');
+    });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('ListChannels', {});
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on invalid status filter', async () => {
+      const result = await adapter.callTool('ListChannels', { status: 'unknown-status' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
     });
   });
 
@@ -4161,6 +4219,23 @@ describe('MCPAdapter - Channel Handlers', () => {
       });
       expect(result.isError).toBe(true);
     });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('SendChannelMessage', {
+        channelId: 'ch-abc',
+        message: 'hello',
+      });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on empty message', async () => {
+      const result = await adapter.callTool('SendChannelMessage', { channelId: 'ch-abc', message: '' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
   });
 
   describe('PauseChannel', () => {
@@ -4177,6 +4252,20 @@ describe('MCPAdapter - Channel Handlers', () => {
       const result = await adapter.callTool('PauseChannel', { channelId: 'ch-abc' });
       expect(result.isError).toBe(true);
     });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('PauseChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on empty channelId', async () => {
+      const result = await adapter.callTool('PauseChannel', { channelId: '' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
   });
 
   describe('ResumeChannel', () => {
@@ -4192,6 +4281,20 @@ describe('MCPAdapter - Channel Handlers', () => {
       mockChannelService.setResumeResult(err(new Error('Not PAUSED')));
       const result = await adapter.callTool('ResumeChannel', { channelId: 'ch-abc' });
       expect(result.isError).toBe(true);
+    });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('ResumeChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('returns validation error on empty channelId', async () => {
+      const result = await adapter.callTool('ResumeChannel', { channelId: '' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
     });
   });
 });

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -3701,3 +3701,497 @@ describe('ConfigureAgent — runtime + proxy integration via callTool()', () => 
     expect(response.warning).toContain('mutually exclusive');
   });
 });
+
+// ─── Channel tool tests ───────────────────────────────────────────────────────
+
+import {
+  ChannelStatusSchema,
+  CreateChannelSchema,
+  DestroyChannelSchema,
+  ListChannelsSchema,
+  PauseChannelSchema,
+  ResumeChannelSchema,
+  SendChannelMessageSchema,
+} from '../../../src/adapters/mcp-adapter';
+import type { Channel, ChannelCreateRequest, ChannelMember } from '../../../src/core/domain';
+import { ChannelId, ChannelMemberStatus, ChannelStatus, createChannel } from '../../../src/core/domain';
+import type { ChannelService } from '../../../src/core/interfaces';
+
+/**
+ * Mock ChannelService for MCP adapter channel tool tests.
+ */
+class MockChannelService implements ChannelService {
+  createChannelCalls: ChannelCreateRequest[] = [];
+  destroyChannelCalls: Array<{ channelId: ChannelId; reason?: string }> = [];
+  pauseChannelCalls: ChannelId[] = [];
+  resumeChannelCalls: ChannelId[] = [];
+  sendMessageCalls: Array<{ channelId: ChannelId; message: string; targetMember?: string }> = [];
+  getChannelCalls: ChannelId[] = [];
+  listChannelsCalls: Array<{ status?: ChannelStatus; limit?: number; offset?: number }> = [];
+
+  private createResult: Result<Channel> = ok(this.makeChannel());
+  private destroyResult: Result<void> = ok(undefined);
+  private pauseResult: Result<void> = ok(undefined);
+  private resumeResult: Result<void> = ok(undefined);
+  private sendResult: Result<void> = ok(undefined);
+  private getResult: Result<Channel | null> = ok(this.makeChannel());
+  private listResult: Result<readonly Channel[]> = ok([]);
+
+  makeChannel(overrides?: Partial<Channel>): Channel {
+    const base = createChannel({
+      name: 'test-channel',
+      members: [{ name: 'test-channel', agent: 'claude' as import('../../../src/core/agents').AgentProvider }],
+    });
+    return overrides ? { ...base, ...overrides } : base;
+  }
+
+  setCreateResult(r: Result<Channel>) {
+    this.createResult = r;
+  }
+  setDestroyResult(r: Result<void>) {
+    this.destroyResult = r;
+  }
+  setPauseResult(r: Result<void>) {
+    this.pauseResult = r;
+  }
+  setResumeResult(r: Result<void>) {
+    this.resumeResult = r;
+  }
+  setSendResult(r: Result<void>) {
+    this.sendResult = r;
+  }
+  setGetResult(r: Result<Channel | null>) {
+    this.getResult = r;
+  }
+  setListResult(r: Result<readonly Channel[]>) {
+    this.listResult = r;
+  }
+
+  async createChannel(request: ChannelCreateRequest): Promise<Result<Channel>> {
+    this.createChannelCalls.push(request);
+    return this.createResult;
+  }
+
+  async destroyChannel(
+    channelId: ChannelId,
+    reason?: import('../../../src/core/events/events').ChannelDestroyReason,
+  ): Promise<Result<void>> {
+    this.destroyChannelCalls.push({ channelId, reason });
+    return this.destroyResult;
+  }
+
+  async pauseChannel(channelId: ChannelId): Promise<Result<void>> {
+    this.pauseChannelCalls.push(channelId);
+    return this.pauseResult;
+  }
+
+  async resumeChannel(channelId: ChannelId): Promise<Result<void>> {
+    this.resumeChannelCalls.push(channelId);
+    return this.resumeResult;
+  }
+
+  async sendMessage(channelId: ChannelId, message: string, targetMember?: string): Promise<Result<void>> {
+    this.sendMessageCalls.push({ channelId, message, targetMember });
+    return this.sendResult;
+  }
+
+  async getChannel(channelId: ChannelId): Promise<Result<Channel | null>> {
+    this.getChannelCalls.push(channelId);
+    return this.getResult;
+  }
+
+  async getChannelByName(_name: string): Promise<Result<Channel | null>> {
+    return this.getResult;
+  }
+
+  async listChannels(status?: ChannelStatus, limit?: number, offset?: number): Promise<Result<readonly Channel[]>> {
+    this.listChannelsCalls.push({ status, limit, offset });
+    return this.listResult;
+  }
+
+  async recoverChannels(): Promise<Result<void>> {
+    return ok(undefined);
+  }
+
+  dispose(): void {
+    /* no-op */
+  }
+
+  reset() {
+    this.createChannelCalls = [];
+    this.destroyChannelCalls = [];
+    this.pauseChannelCalls = [];
+    this.resumeChannelCalls = [];
+    this.sendMessageCalls = [];
+    this.getChannelCalls = [];
+    this.listChannelsCalls = [];
+    this.createResult = ok(this.makeChannel());
+    this.destroyResult = ok(undefined);
+    this.pauseResult = ok(undefined);
+    this.resumeResult = ok(undefined);
+    this.sendResult = ok(undefined);
+    this.getResult = ok(this.makeChannel());
+    this.listResult = ok([]);
+  }
+}
+
+/** Build an MCPAdapter with a MockChannelService injected. */
+function makeChannelAdapter(channelService?: ChannelService): MCPAdapter {
+  return new MCPAdapter({
+    taskManager: new MockTaskManager(),
+    logger: new MockLogger(),
+    scheduleService: stubScheduleService,
+    loopService: stubLoopService,
+    agentRegistry: undefined,
+    config: testConfig,
+    channelService,
+  });
+}
+
+describe('MCPAdapter - Channel Schemas', () => {
+  describe('CreateChannelSchema', () => {
+    it('accepts valid single-member channel', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'my-channel',
+        members: [{ name: 'my-channel', agent: 'claude' }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts valid multi-member channel with all fields', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'code-review',
+        members: [
+          { name: 'author', agent: 'claude', systemPrompt: 'You write code.' },
+          { name: 'reviewer', agent: 'codex' },
+        ],
+        communicationMode: 'round-robin',
+        maxRounds: 20,
+        topic: 'Review auth module',
+        workingDirectory: '/tmp/project',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid channel name', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'My Channel',
+        members: [{ name: 'member', agent: 'claude' }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects members array exceeding 10', () => {
+      const members = Array.from({ length: 11 }, (_, i) => ({ name: `m${i}`, agent: 'claude' }));
+      const result = CreateChannelSchema.safeParse({ name: 'ch', members });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects maxRounds of 0', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'ch',
+        members: [{ name: 'm', agent: 'claude' }],
+        maxRounds: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects maxRounds above 10000', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'ch',
+        members: [{ name: 'm', agent: 'claude' }],
+        maxRounds: 10001,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid communicationMode', () => {
+      const result = CreateChannelSchema.safeParse({
+        name: 'ch',
+        members: [{ name: 'm', agent: 'claude' }],
+        communicationMode: 'gossip',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty members array', () => {
+      const result = CreateChannelSchema.safeParse({ name: 'ch', members: [] });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('DestroyChannelSchema', () => {
+    it('accepts channelId', () => {
+      expect(DestroyChannelSchema.safeParse({ channelId: 'ch-abc' }).success).toBe(true);
+    });
+    it('accepts channelId with reason', () => {
+      expect(DestroyChannelSchema.safeParse({ channelId: 'ch-abc', reason: 'done' }).success).toBe(true);
+    });
+    it('rejects empty channelId', () => {
+      expect(DestroyChannelSchema.safeParse({ channelId: '' }).success).toBe(false);
+    });
+  });
+
+  describe('ChannelStatusSchema', () => {
+    it('accepts valid channelId', () => {
+      expect(ChannelStatusSchema.safeParse({ channelId: 'ch-abc' }).success).toBe(true);
+    });
+    it('rejects empty channelId', () => {
+      expect(ChannelStatusSchema.safeParse({ channelId: '' }).success).toBe(false);
+    });
+  });
+
+  describe('ListChannelsSchema', () => {
+    it('accepts no filters', () => {
+      expect(ListChannelsSchema.safeParse({}).success).toBe(true);
+    });
+    it('accepts valid status filter', () => {
+      expect(ListChannelsSchema.safeParse({ status: 'active' }).success).toBe(true);
+    });
+    it('rejects invalid status filter', () => {
+      expect(ListChannelsSchema.safeParse({ status: 'unknown' }).success).toBe(false);
+    });
+    it('rejects limit above 100', () => {
+      expect(ListChannelsSchema.safeParse({ limit: 101 }).success).toBe(false);
+    });
+  });
+
+  describe('SendChannelMessageSchema', () => {
+    it('accepts minimal valid input', () => {
+      expect(SendChannelMessageSchema.safeParse({ channelId: 'ch-abc', message: 'hello' }).success).toBe(true);
+    });
+    it('accepts with targetMember', () => {
+      expect(
+        SendChannelMessageSchema.safeParse({ channelId: 'ch-abc', message: 'hi', targetMember: 'alice' }).success,
+      ).toBe(true);
+    });
+    it('rejects empty message', () => {
+      expect(SendChannelMessageSchema.safeParse({ channelId: 'ch-abc', message: '' }).success).toBe(false);
+    });
+    it('rejects message exceeding 256KB', () => {
+      const huge = 'x'.repeat(262_145);
+      expect(SendChannelMessageSchema.safeParse({ channelId: 'ch-abc', message: huge }).success).toBe(false);
+    });
+  });
+
+  describe('PauseChannelSchema', () => {
+    it('accepts valid channelId', () => {
+      expect(PauseChannelSchema.safeParse({ channelId: 'ch-abc' }).success).toBe(true);
+    });
+    it('rejects empty channelId', () => {
+      expect(PauseChannelSchema.safeParse({ channelId: '' }).success).toBe(false);
+    });
+  });
+
+  describe('ResumeChannelSchema', () => {
+    it('accepts valid channelId', () => {
+      expect(ResumeChannelSchema.safeParse({ channelId: 'ch-abc' }).success).toBe(true);
+    });
+    it('rejects missing channelId', () => {
+      expect(ResumeChannelSchema.safeParse({}).success).toBe(false);
+    });
+  });
+});
+
+describe('MCPAdapter - Channel Handlers', () => {
+  let mockChannelService: MockChannelService;
+  let adapter: MCPAdapter;
+
+  beforeEach(() => {
+    mockChannelService = new MockChannelService();
+    adapter = makeChannelAdapter(mockChannelService);
+  });
+
+  afterEach(() => {
+    mockChannelService.reset();
+  });
+
+  describe('CreateChannel', () => {
+    it('returns success response on channel creation', async () => {
+      const result = await adapter.callTool('CreateChannel', {
+        name: 'test-channel',
+        members: [{ name: 'test-channel', agent: 'claude' }],
+      });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.channelId).toBeDefined();
+      expect(response.name).toBe('test-channel');
+    });
+
+    it('passes createChannel request to service', async () => {
+      await adapter.callTool('CreateChannel', {
+        name: 'my-ch',
+        members: [{ name: 'member1', agent: 'claude' }],
+        maxRounds: 10,
+      });
+      expect(mockChannelService.createChannelCalls).toHaveLength(1);
+      expect(mockChannelService.createChannelCalls[0]?.name).toBe('my-ch');
+      expect(mockChannelService.createChannelCalls[0]?.maxRounds).toBe(10);
+    });
+
+    it('returns validation error on invalid name', async () => {
+      const result = await adapter.callTool('CreateChannel', {
+        name: 'Invalid Name!',
+        members: [{ name: 'member', agent: 'claude' }],
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
+
+    it('returns service unavailable when channelService is undefined', async () => {
+      const adapterNoChannel = makeChannelAdapter(undefined);
+      const result = await adapterNoChannel.callTool('CreateChannel', {
+        name: 'my-channel',
+        members: [{ name: 'member', agent: 'claude' }],
+      });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('unavailable');
+    });
+
+    it('rejects invalid workingDirectory path', async () => {
+      const result = await adapter.callTool('CreateChannel', {
+        name: 'my-channel',
+        members: [{ name: 'member', agent: 'claude' }],
+        workingDirectory: 'relative/path',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid working directory');
+    });
+
+    it('propagates service error', async () => {
+      mockChannelService.setCreateResult(err(new Error('Name collision')));
+      const result = await adapter.callTool('CreateChannel', {
+        name: 'my-channel',
+        members: [{ name: 'member', agent: 'claude' }],
+      });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('Name collision');
+    });
+  });
+
+  describe('DestroyChannel', () => {
+    it('returns success on destroy', async () => {
+      const result = await adapter.callTool('DestroyChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+    });
+
+    it('passes channelId to service', async () => {
+      await adapter.callTool('DestroyChannel', { channelId: 'ch-abc123' });
+      expect(mockChannelService.destroyChannelCalls[0]?.channelId).toBe('ch-abc123');
+    });
+
+    it('returns error on service failure', async () => {
+      mockChannelService.setDestroyResult(err(new Error('Not found')));
+      const result = await adapter.callTool('DestroyChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('ChannelStatus', () => {
+    it('returns channel details on success', async () => {
+      const result = await adapter.callTool('ChannelStatus', { channelId: 'ch-abc' });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.channel).toBeDefined();
+      expect(response.channel.name).toBe('test-channel');
+      expect(response.channel.members).toHaveLength(1);
+    });
+
+    it('returns error when channel not found', async () => {
+      mockChannelService.setGetResult(ok(null));
+      const result = await adapter.callTool('ChannelStatus', { channelId: 'ch-notfound' });
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('not found');
+    });
+  });
+
+  describe('ListChannels', () => {
+    it('returns empty list when no channels', async () => {
+      const result = await adapter.callTool('ListChannels', {});
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.count).toBe(0);
+    });
+
+    it('passes status filter to service', async () => {
+      await adapter.callTool('ListChannels', { status: 'active' });
+      expect(mockChannelService.listChannelsCalls[0]?.status).toBe(ChannelStatus.ACTIVE);
+    });
+
+    it('passes limit to service', async () => {
+      await adapter.callTool('ListChannels', { limit: 5 });
+      expect(mockChannelService.listChannelsCalls[0]?.limit).toBe(5);
+    });
+  });
+
+  describe('SendChannelMessage', () => {
+    it('returns success on message delivery', async () => {
+      const result = await adapter.callTool('SendChannelMessage', {
+        channelId: 'ch-abc',
+        message: 'hello world',
+      });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.target).toBe('all');
+    });
+
+    it('passes targetMember to service', async () => {
+      await adapter.callTool('SendChannelMessage', {
+        channelId: 'ch-abc',
+        message: 'hello alice',
+        targetMember: 'alice',
+      });
+      expect(mockChannelService.sendMessageCalls[0]?.targetMember).toBe('alice');
+    });
+
+    it('returns error on service failure', async () => {
+      mockChannelService.setSendResult(err(new Error('Channel paused')));
+      const result = await adapter.callTool('SendChannelMessage', {
+        channelId: 'ch-abc',
+        message: 'hello',
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('PauseChannel', () => {
+    it('returns success on pause', async () => {
+      const result = await adapter.callTool('PauseChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.status).toBe('paused');
+    });
+
+    it('returns error on service failure', async () => {
+      mockChannelService.setPauseResult(err(new Error('Not ACTIVE')));
+      const result = await adapter.callTool('PauseChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('ResumeChannel', () => {
+    it('returns success on resume', async () => {
+      const result = await adapter.callTool('ResumeChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(true);
+      expect(response.status).toBe('active');
+    });
+
+    it('returns error on service failure', async () => {
+      mockChannelService.setResumeResult(err(new Error('Not PAUSED')));
+      const result = await adapter.callTool('ResumeChannel', { channelId: 'ch-abc' });
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/tests/unit/adapters/mcp-adapter.test.ts
+++ b/tests/unit/adapters/mcp-adapter.test.ts
@@ -3925,7 +3925,7 @@ describe('MCPAdapter - Channel Schemas', () => {
       expect(DestroyChannelSchema.safeParse({ channelId: 'ch-abc' }).success).toBe(true);
     });
     it('accepts channelId with reason', () => {
-      expect(DestroyChannelSchema.safeParse({ channelId: 'ch-abc', reason: 'done' }).success).toBe(true);
+      expect(DestroyChannelSchema.safeParse({ channelId: 'ch-abc', reason: 'user-requested' }).success).toBe(true);
     });
     it('rejects empty channelId', () => {
       expect(DestroyChannelSchema.safeParse({ channelId: '' }).success).toBe(false);

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -7,6 +7,8 @@
 import { describe, expect, it } from 'vitest';
 import { type ParsedChannelCreate, parseChannelCreateArgs } from '../../../src/cli/commands/channel';
 
+const cwd = process.cwd();
+
 describe('parseChannelCreateArgs', () => {
   // ─── Single-agent mode ──────────────────────────────────────────────────────
 
@@ -28,7 +30,7 @@ describe('parseChannelCreateArgs', () => {
         '--topic',
         'analyze this codebase',
         '--working-directory',
-        '/tmp',
+        cwd,
         '--system-prompt',
         'You are a helpful assistant',
       ]);
@@ -37,7 +39,7 @@ describe('parseChannelCreateArgs', () => {
       const val = result.value as { mode: string; topic?: string; workingDirectory?: string; systemPrompt?: string };
       expect(val.mode).toBe('single');
       expect(val.topic).toBe('analyze this codebase');
-      expect(val.workingDirectory).toBe('/tmp');
+      expect(val.workingDirectory).toBe(cwd);
       expect(val.systemPrompt).toBe('You are a helpful assistant');
     });
 
@@ -331,7 +333,7 @@ describe('parseChannelCreateArgs', () => {
         '--topic',
         'Build a REST API',
         '--working-directory',
-        '/tmp',
+        cwd,
       ]);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
@@ -351,7 +353,7 @@ describe('parseChannelCreateArgs', () => {
       expect(val.communicationMode).toBe('directed');
       expect(val.maxRounds).toBe(50);
       expect(val.topic).toBe('Build a REST API');
-      expect(val.workingDirectory).toBe('/tmp');
+      expect(val.workingDirectory).toBe(cwd);
     });
   });
 });

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -307,6 +307,54 @@ describe('parseChannelCreateArgs', () => {
     });
   });
 
+  // ─── system-prompt length validation ─────────────────────────────────────────
+
+  describe('--system-prompt length validation', () => {
+    it('accepts system-prompt at the 100,000 character limit', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--system-prompt', 'a'.repeat(100_000)]);
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects system-prompt exceeding 100,000 characters', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--system-prompt', 'a'.repeat(100_001)]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('100,000');
+    });
+  });
+
+  // ─── working-directory validation ─────────────────────────────────────────────
+
+  describe('--working-directory validation', () => {
+    it('rejects a path that traverses outside the working directory', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--working-directory', '../../etc/passwd']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid working directory');
+    });
+  });
+
+  // ─── Shorthand flags ──────────────────────────────────────────────────────────
+
+  describe('shorthand flags', () => {
+    it('accepts -a as shorthand for --agent', () => {
+      const result = parseChannelCreateArgs(['my-channel', '-a', 'claude']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.mode).toBe('single');
+      if (result.value.mode !== 'single') return;
+      expect(result.value.agent).toBe('claude');
+    });
+
+    it('accepts -w as shorthand for --working-directory', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '-w', cwd]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      if (result.value.mode !== 'single') return;
+      expect(result.value.workingDirectory).toBe(cwd);
+    });
+  });
+
   // ─── Unknown flags ───────────────────────────────────────────────────────────
 
   describe('unknown flags', () => {

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -318,6 +318,22 @@ describe('parseChannelCreateArgs', () => {
     });
   });
 
+  // ─── Topic length validation ──────────────────────────────────────────────────
+
+  describe('--topic length validation', () => {
+    it('accepts topic within the 262,144 character limit', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--topic', 'a'.repeat(262_144)]);
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects topic exceeding 262,144 characters', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--topic', 'a'.repeat(262_145)]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('262,144');
+    });
+  });
+
   // ─── Combined flags (integration) ────────────────────────────────────────────
 
   describe('combined flags', () => {

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Tests for channel CLI command parsing.
+ * ARCHITECTURE: Tests pure parsing functions — no side effects, no process.exit().
+ * Pattern follows parse-loop-create-args test style.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { type ParsedChannelCreate, parseChannelCreateArgs } from '../../../src/cli/commands/channel';
+
+describe('parseChannelCreateArgs', () => {
+  // ─── Single-agent mode ──────────────────────────────────────────────────────
+
+  describe('single-agent mode (--agent flag)', () => {
+    it('returns valid single-agent parsed args with minimal flags', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.mode).toBe('single');
+      expect(result.value.name).toBe('my-channel');
+      expect((result.value as { agent: string }).agent).toBe('claude');
+    });
+
+    it('accepts all single-agent optional flags', () => {
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--agent',
+        'claude',
+        '--topic',
+        'analyze this codebase',
+        '--working-directory',
+        '/tmp',
+        '--system-prompt',
+        'You are a helpful assistant',
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const val = result.value as { mode: string; topic?: string; workingDirectory?: string; systemPrompt?: string };
+      expect(val.mode).toBe('single');
+      expect(val.topic).toBe('analyze this codebase');
+      expect(val.workingDirectory).toBe('/tmp');
+      expect(val.systemPrompt).toBe('You are a helpful assistant');
+    });
+
+    it('accepts codex as agent', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'codex']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect((result.value as { agent: string }).agent).toBe('codex');
+    });
+
+    it('rejects unknown agent provider', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'gpt4']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('gpt4');
+      expect(result.error).toContain('Unknown agent');
+    });
+
+    it('rejects --max-rounds with single-agent mode', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--max-rounds', '10']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('--max-rounds');
+      expect(result.error).toContain('single-agent');
+    });
+
+    it('rejects --mode with single-agent mode', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--mode', 'broadcast']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('--mode');
+    });
+  });
+
+  // ─── Multi-agent mode ───────────────────────────────────────────────────────
+
+  describe('multi-agent mode (--member flags)', () => {
+    it('returns valid multi-agent parsed args with required flags', () => {
+      const result = parseChannelCreateArgs([
+        'code-review',
+        '--member',
+        'author:claude',
+        '--member',
+        'reviewer:codex',
+        '--max-rounds',
+        '10',
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.mode).toBe('multi');
+      const val = result.value as { members: Array<{ name: string; agent: string; systemPrompt?: string }> };
+      expect(val.members).toHaveLength(2);
+      expect(val.members[0]).toMatchObject({ name: 'author', agent: 'claude' });
+      expect(val.members[1]).toMatchObject({ name: 'reviewer', agent: 'codex' });
+    });
+
+    it('parses member with prompt containing colons', () => {
+      const result = parseChannelCreateArgs([
+        'debug-channel',
+        '--member',
+        'debugger:claude:You are a debugger: be precise.',
+        '--max-rounds',
+        '5',
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const val = result.value as { members: Array<{ name: string; agent: string; systemPrompt?: string }> };
+      expect(val.members[0]?.systemPrompt).toBe('You are a debugger: be precise.');
+    });
+
+    it('accepts valid communication mode', () => {
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--member',
+        'agent1:claude',
+        '--mode',
+        'round-robin',
+        '--max-rounds',
+        '20',
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const val = result.value as { communicationMode?: string };
+      expect(val.communicationMode).toBe('round-robin');
+    });
+
+    it('accepts broadcast and directed modes', () => {
+      for (const mode of ['broadcast', 'directed'] as const) {
+        const result = parseChannelCreateArgs([
+          'my-channel',
+          '--member',
+          'agent1:claude',
+          '--mode',
+          mode,
+          '--max-rounds',
+          '5',
+        ]);
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        const val = result.value as { communicationMode?: string };
+        expect(val.communicationMode).toBe(mode);
+      }
+    });
+
+    it('rejects invalid communication mode', () => {
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--member',
+        'agent1:claude',
+        '--mode',
+        'gossip',
+        '--max-rounds',
+        '5',
+      ]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('broadcast, directed, or round-robin');
+    });
+
+    it('rejects --max-rounds missing for multi-agent', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--member', 'agent2:codex']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('--max-rounds');
+    });
+
+    it('rejects --system-prompt with multi-agent mode', () => {
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--member',
+        'agent1:claude',
+        '--max-rounds',
+        '5',
+        '--system-prompt',
+        'global prompt',
+      ]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('--system-prompt');
+    });
+  });
+
+  // ─── Mutual exclusion ───────────────────────────────────────────────────────
+
+  describe('mutual exclusion: --agent + --member', () => {
+    it('rejects combining --agent with --member', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--member', 'other:codex']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('mutually exclusive');
+    });
+  });
+
+  // ─── Member format edge cases ───────────────────────────────────────────────
+
+  describe('--member format edge cases', () => {
+    it('rejects member missing colon separator', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'nameonly', '--max-rounds', '5']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('name:agent');
+    });
+
+    it('rejects empty member name', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', ':claude', '--max-rounds', '5']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('empty');
+    });
+
+    it('rejects empty agent in member', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'name:', '--max-rounds', '5']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('empty');
+    });
+
+    it('rejects unknown agent in member', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:unknownprovider', '--max-rounds', '5']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('unknownprovider');
+    });
+
+    it('member without prompt has undefined systemPrompt', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '5']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const val = result.value as { members: Array<{ systemPrompt?: string }> };
+      expect(val.members[0]?.systemPrompt).toBeUndefined();
+    });
+  });
+
+  // ─── Channel name validation ─────────────────────────────────────────────────
+
+  describe('channel name validation', () => {
+    it('accepts valid lowercase alphanumeric names', () => {
+      for (const name of ['abc', 'my-channel', 'a1b2c3', 'code-review-2024']) {
+        const result = parseChannelCreateArgs([name, '--agent', 'claude']);
+        expect(result.ok).toBe(true);
+      }
+    });
+
+    it('rejects names with uppercase letters', () => {
+      const result = parseChannelCreateArgs(['MyChannel', '--agent', 'claude']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid channel name');
+    });
+
+    it('rejects names starting with hyphen', () => {
+      const result = parseChannelCreateArgs(['-my-channel', '--agent', 'claude']);
+      // Note: -my-channel will be treated as a flag, not a positional arg
+      // The parsing will either see it as an unknown flag or as no channel name
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects names with spaces', () => {
+      const result = parseChannelCreateArgs(['my channel', '--agent', 'claude']);
+      // 'my channel' as one string is passed; only the first word is the channel name
+      // The second word becomes an unknown flag → error, or name doesn't match regex
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects empty channel name', () => {
+      const result = parseChannelCreateArgs(['--agent', 'claude']);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ─── maxRounds range validation ──────────────────────────────────────────────
+
+  describe('maxRounds range validation', () => {
+    it('accepts valid maxRounds values', () => {
+      for (const n of ['1', '100', '10000']) {
+        const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', n]);
+        expect(result.ok).toBe(true);
+      }
+    });
+
+    it('rejects maxRounds of 0', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '0']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('1 and 10000');
+    });
+
+    it('rejects negative maxRounds', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '-1']);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects maxRounds above 10000', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '10001']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('10000');
+    });
+
+    it('rejects non-integer maxRounds', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '5.5']);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ─── Unknown flags ───────────────────────────────────────────────────────────
+
+  describe('unknown flags', () => {
+    it('rejects unknown flags', () => {
+      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--unknown-flag', 'value']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Unknown flag');
+    });
+  });
+
+  // ─── Combined flags (integration) ────────────────────────────────────────────
+
+  describe('combined flags', () => {
+    it('parses all valid multi-agent flags together', () => {
+      const result = parseChannelCreateArgs([
+        'full-channel',
+        '--member',
+        'writer:claude:You write code.',
+        '--member',
+        'reviewer:codex',
+        '--mode',
+        'directed',
+        '--max-rounds',
+        '50',
+        '--topic',
+        'Build a REST API',
+        '--working-directory',
+        '/tmp',
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.mode).toBe('multi');
+      const val = result.value as {
+        name: string;
+        members: Array<{ name: string; agent: string; systemPrompt?: string }>;
+        communicationMode?: string;
+        maxRounds: number;
+        topic?: string;
+        workingDirectory?: string;
+      };
+      expect(val.name).toBe('full-channel');
+      expect(val.members).toHaveLength(2);
+      expect(val.members[0]?.systemPrompt).toBe('You write code.');
+      expect(val.members[1]?.systemPrompt).toBeUndefined();
+      expect(val.communicationMode).toBe('directed');
+      expect(val.maxRounds).toBe(50);
+      expect(val.topic).toBe('Build a REST API');
+      expect(val.workingDirectory).toBe('/tmp');
+    });
+  });
+});

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -311,12 +311,24 @@ describe('parseChannelCreateArgs', () => {
 
   describe('--system-prompt length validation', () => {
     it('accepts system-prompt at the 100,000 character limit', () => {
-      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--system-prompt', 'a'.repeat(100_000)]);
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--agent',
+        'claude',
+        '--system-prompt',
+        'a'.repeat(100_000),
+      ]);
       expect(result.ok).toBe(true);
     });
 
     it('rejects system-prompt exceeding 100,000 characters', () => {
-      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--system-prompt', 'a'.repeat(100_001)]);
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--agent',
+        'claude',
+        '--system-prompt',
+        'a'.repeat(100_001),
+      ]);
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.error).toContain('100,000');
@@ -327,7 +339,13 @@ describe('parseChannelCreateArgs', () => {
 
   describe('--working-directory validation', () => {
     it('rejects a path that traverses outside the working directory', () => {
-      const result = parseChannelCreateArgs(['my-channel', '--agent', 'claude', '--working-directory', '../../etc/passwd']);
+      const result = parseChannelCreateArgs([
+        'my-channel',
+        '--agent',
+        'claude',
+        '--working-directory',
+        '../../etc/passwd',
+      ]);
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.error).toContain('Invalid working directory');

--- a/tests/unit/cli/channel.test.ts
+++ b/tests/unit/cli/channel.test.ts
@@ -19,7 +19,8 @@ describe('parseChannelCreateArgs', () => {
       if (!result.ok) return;
       expect(result.value.mode).toBe('single');
       expect(result.value.name).toBe('my-channel');
-      expect((result.value as { agent: string }).agent).toBe('claude');
+      if (result.value.mode !== 'single') return;
+      expect(result.value.agent).toBe('claude');
     });
 
     it('accepts all single-agent optional flags', () => {
@@ -36,18 +37,19 @@ describe('parseChannelCreateArgs', () => {
       ]);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      const val = result.value as { mode: string; topic?: string; workingDirectory?: string; systemPrompt?: string };
-      expect(val.mode).toBe('single');
-      expect(val.topic).toBe('analyze this codebase');
-      expect(val.workingDirectory).toBe(cwd);
-      expect(val.systemPrompt).toBe('You are a helpful assistant');
+      expect(result.value.mode).toBe('single');
+      if (result.value.mode !== 'single') return;
+      expect(result.value.topic).toBe('analyze this codebase');
+      expect(result.value.workingDirectory).toBe(cwd);
+      expect(result.value.systemPrompt).toBe('You are a helpful assistant');
     });
 
     it('accepts codex as agent', () => {
       const result = parseChannelCreateArgs(['my-channel', '--agent', 'codex']);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect((result.value as { agent: string }).agent).toBe('codex');
+      if (result.value.mode !== 'single') return;
+      expect(result.value.agent).toBe('codex');
     });
 
     it('rejects unknown agent provider', () => {
@@ -90,10 +92,10 @@ describe('parseChannelCreateArgs', () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.mode).toBe('multi');
-      const val = result.value as { members: Array<{ name: string; agent: string; systemPrompt?: string }> };
-      expect(val.members).toHaveLength(2);
-      expect(val.members[0]).toMatchObject({ name: 'author', agent: 'claude' });
-      expect(val.members[1]).toMatchObject({ name: 'reviewer', agent: 'codex' });
+      if (result.value.mode !== 'multi') return;
+      expect(result.value.members).toHaveLength(2);
+      expect(result.value.members[0]).toMatchObject({ name: 'author', agent: 'claude' });
+      expect(result.value.members[1]).toMatchObject({ name: 'reviewer', agent: 'codex' });
     });
 
     it('parses member with prompt containing colons', () => {
@@ -106,8 +108,8 @@ describe('parseChannelCreateArgs', () => {
       ]);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      const val = result.value as { members: Array<{ name: string; agent: string; systemPrompt?: string }> };
-      expect(val.members[0]?.systemPrompt).toBe('You are a debugger: be precise.');
+      if (result.value.mode !== 'multi') return;
+      expect(result.value.members[0]?.systemPrompt).toBe('You are a debugger: be precise.');
     });
 
     it('accepts valid communication mode', () => {
@@ -122,8 +124,8 @@ describe('parseChannelCreateArgs', () => {
       ]);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      const val = result.value as { communicationMode?: string };
-      expect(val.communicationMode).toBe('round-robin');
+      if (result.value.mode !== 'multi') return;
+      expect(result.value.communicationMode).toBe('round-robin');
     });
 
     it('accepts broadcast and directed modes', () => {
@@ -139,8 +141,8 @@ describe('parseChannelCreateArgs', () => {
         ]);
         expect(result.ok).toBe(true);
         if (!result.ok) return;
-        const val = result.value as { communicationMode?: string };
-        expect(val.communicationMode).toBe(mode);
+        if (result.value.mode !== 'multi') return;
+        expect(result.value.communicationMode).toBe(mode);
       }
     });
 
@@ -228,8 +230,8 @@ describe('parseChannelCreateArgs', () => {
       const result = parseChannelCreateArgs(['my-channel', '--member', 'agent1:claude', '--max-rounds', '5']);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      const val = result.value as { members: Array<{ systemPrompt?: string }> };
-      expect(val.members[0]?.systemPrompt).toBeUndefined();
+      if (result.value.mode !== 'multi') return;
+      expect(result.value.members[0]?.systemPrompt).toBeUndefined();
     });
   });
 
@@ -338,22 +340,15 @@ describe('parseChannelCreateArgs', () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.mode).toBe('multi');
-      const val = result.value as {
-        name: string;
-        members: Array<{ name: string; agent: string; systemPrompt?: string }>;
-        communicationMode?: string;
-        maxRounds: number;
-        topic?: string;
-        workingDirectory?: string;
-      };
-      expect(val.name).toBe('full-channel');
-      expect(val.members).toHaveLength(2);
-      expect(val.members[0]?.systemPrompt).toBe('You write code.');
-      expect(val.members[1]?.systemPrompt).toBeUndefined();
-      expect(val.communicationMode).toBe('directed');
-      expect(val.maxRounds).toBe(50);
-      expect(val.topic).toBe('Build a REST API');
-      expect(val.workingDirectory).toBe(cwd);
+      if (result.value.mode !== 'multi') return;
+      expect(result.value.name).toBe('full-channel');
+      expect(result.value.members).toHaveLength(2);
+      expect(result.value.members[0]?.systemPrompt).toBe('You write code.');
+      expect(result.value.members[1]?.systemPrompt).toBeUndefined();
+      expect(result.value.communicationMode).toBe('directed');
+      expect(result.value.maxRounds).toBe(50);
+      expect(result.value.topic).toBe('Build a REST API');
+      expect(result.value.workingDirectory).toBe(cwd);
     });
   });
 });

--- a/tests/unit/cli/msg.test.ts
+++ b/tests/unit/cli/msg.test.ts
@@ -81,6 +81,25 @@ describe('parseMsgArgs', () => {
     });
   });
 
+  // ─── Message length validation ───────────────────────────────────────────────
+
+  describe('message length validation', () => {
+    it('accepts message at exactly the limit', () => {
+      const message = 'a'.repeat(262144);
+      const result = parseMsgArgs(['ch', message]);
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects message exceeding 262144 chars', () => {
+      const message = 'a'.repeat(262145);
+      const result = parseMsgArgs(['ch', message]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Message too long');
+      expect(result.error).toContain('262145');
+    });
+  });
+
   // ─── Channel name validation ─────────────────────────────────────────────────
 
   describe('channel name validation', () => {

--- a/tests/unit/cli/msg.test.ts
+++ b/tests/unit/cli/msg.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for msg CLI command parsing.
+ * ARCHITECTURE: Tests pure parseMsgArgs — no side effects, no process.exit().
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseMsgArgs } from '../../../src/cli/commands/msg';
+
+describe('parseMsgArgs', () => {
+  // ─── Basic target parsing ────────────────────────────────────────────────────
+
+  describe('basic target parsing', () => {
+    it('parses channel-only target', () => {
+      const result = parseMsgArgs(['my-channel', 'hello world']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.channelName).toBe('my-channel');
+      expect(result.value.memberName).toBeUndefined();
+      expect(result.value.message).toBe('hello world');
+    });
+
+    it('parses channel/member target', () => {
+      const result = parseMsgArgs(['my-channel/alice', 'hello alice']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.channelName).toBe('my-channel');
+      expect(result.value.memberName).toBe('alice');
+      expect(result.value.message).toBe('hello alice');
+    });
+
+    it('joins multi-word message with spaces', () => {
+      const result = parseMsgArgs(['ch', 'this', 'is', 'a', 'multi-word', 'message']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.message).toBe('this is a multi-word message');
+    });
+  });
+
+  // ─── Slash delimiter ─────────────────────────────────────────────────────────
+
+  describe('/ delimiter behavior', () => {
+    it('splits on first slash only (member name may contain slashes in theory)', () => {
+      // member name is everything after the first slash
+      const result = parseMsgArgs(['ch/member', 'msg']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.channelName).toBe('ch');
+      expect(result.value.memberName).toBe('member');
+    });
+
+    it('rejects empty member name after slash', () => {
+      const result = parseMsgArgs(['my-channel/', 'hello']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Empty member name');
+    });
+
+    it('handles no slash correctly', () => {
+      const result = parseMsgArgs(['my-channel', 'hello']);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.memberName).toBeUndefined();
+    });
+  });
+
+  // ─── Message extraction ──────────────────────────────────────────────────────
+
+  describe('message extraction', () => {
+    it('rejects missing message', () => {
+      const result = parseMsgArgs(['my-channel']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Message text is required');
+    });
+
+    it('rejects empty args', () => {
+      const result = parseMsgArgs([]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Usage');
+    });
+  });
+
+  // ─── Channel name validation ─────────────────────────────────────────────────
+
+  describe('channel name validation', () => {
+    it('accepts valid channel names', () => {
+      for (const name of ['abc', 'my-channel', 'a1b2c3']) {
+        const result = parseMsgArgs([name, 'message']);
+        expect(result.ok).toBe(true);
+      }
+    });
+
+    it('rejects channel names with uppercase letters', () => {
+      const result = parseMsgArgs(['MyChannel', 'message']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid channel name');
+    });
+
+    it('rejects channel names with spaces', () => {
+      // 'my channel' split by shell would be 'my' as target and 'channel message' as message
+      // But if passed as a single string: the split would produce an invalid channel name
+      const result = parseMsgArgs(['my channel/member', 'message']);
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/tests/unit/cli/msg.test.ts
+++ b/tests/unit/cli/msg.test.ts
@@ -124,4 +124,37 @@ describe('parseMsgArgs', () => {
       expect(result.ok).toBe(false);
     });
   });
+
+  // ─── Member name validation ──────────────────────────────────────────────────
+
+  describe('member name validation', () => {
+    it('accepts valid member names', () => {
+      for (const member of ['alice', 'bob-2', 'agent1']) {
+        const result = parseMsgArgs([`my-channel/${member}`, 'hello']);
+        expect(result.ok).toBe(true);
+      }
+    });
+
+    it('rejects member names with uppercase letters', () => {
+      const result = parseMsgArgs(['my-channel/Alice', 'hello']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid member name');
+    });
+
+    it('rejects member names with spaces', () => {
+      const result = parseMsgArgs(['my-channel/alice bob', 'hello']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid member name');
+    });
+
+    it('rejects member names that are too long', () => {
+      const longName = 'a'.repeat(65);
+      const result = parseMsgArgs([`my-channel/${longName}`, 'hello']);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('Invalid member name');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `beat channel` CLI subcommands (create, list, status, destroy, pause, resume) and `beat msg` for sending messages to channels or specific members
- Exposes the Phase 7 channel service layer through 7 new MCP tools: `CreateChannel`, `DestroyChannel`, `ChannelStatus`, `ListChannels`, `SendChannelMessage`, `PauseChannel`, `ResumeChannel`
- All tools and commands degrade gracefully when the channel service is unavailable

## Changes

**Service layer hardening**
- `ChannelManager.validateCreateRequest()` rejects `maxRounds` outside [1, 10000]
- `ChannelManager.sendMessage()` blocks delivery to COMPLETED channels

**CLI commands** (`src/cli/commands/channel.ts`, `msg.ts`)
- `parseChannelCreateArgs`: pure parsing function — single-agent (`--agent`) and multi-agent (`--member`) modes, mutual exclusion, channel name regex, maxRounds range, unknown flag rejection
- `parseMsgArgs`: pure parsing function — `channel[/member] message...` target syntax
- Subcommand handlers use `withServices()` (mutations) and `withReadOnlyContext()` (queries)
- `resolveChannelId()` helper: accepts both `ch-<uuid>` IDs and channel names

**MCP tools** (`src/adapters/mcp-adapter.ts`)
- 7 new `callTool()` cases each with Zod schema validation and `channelService` guard
- `CreateChannel` validates `workingDirectory` as absolute path (path traversal prevention)
- `bootstrap.ts`: mcpAdapter factory is now `async` to resolve `channelService` via `container.resolve()` (required because `ChannelManager.create()` is async)
- Updated MCP instructions to document channel orchestration patterns

**Dashboard fix**
- `src/cli/dashboard/index.tsx`: adds `channelRepository` to the manually-constructed `ReadOnlyContext` (required after `ReadOnlyContext` interface gained the field)

**Tests** (52 new tests)
- `tests/unit/cli/channel.test.ts`: 31 tests for `parseChannelCreateArgs`
- `tests/unit/cli/msg.test.ts`: 11 tests for `parseMsgArgs`
- `tests/unit/adapters/mcp-adapter.test.ts`: 10 schema tests + schema-validated handler integration tests for all 7 tools

## Breaking Changes

None. Channel tools are additive; `channelService` is optional in `MCPAdapterDeps` and all tools return a graceful error if unavailable.

## Reviewer Focus Areas

- `src/bootstrap.ts`: async factory for `mcpAdapter` — verify the `container.resolve()` call correctly handles `channelService` unavailability without blocking server startup
- `src/adapters/mcp-adapter.ts` `handleCreateChannel`: the `path.isAbsolute()` check for `workingDirectory` is intentionally stricter than other handlers (channel sessions are long-lived; relative paths resolved against server cwd would be misleading)
- `src/cli/services.ts` `withServices()`: optional `channelService` returned as `channelService?: ChannelService` — confirm graceful degradation path is correct for all channel CLI subcommands