### PR TITLE
fix(tmux): switch prompt delivery from sendKeys to pasteContent + sendControlKeys(Enter)

### DIFF
--- a/.devflow/decisions/decisions.md
+++ b/.devflow/decisions/decisions.md
@@ -1,4 +1,4 @@
-<!-- TL;DR: 3 decisions. Key: ADR-001, ADR-002, ADR-003 -->
+<!-- TL;DR: 6 decisions. Key: ADR-001, ADR-002, ADR-003, ADR-004, ADR-005, ADR-006 -->
 # Architecture Decision Records
 
 Explicit design choices and trade-offs made during development.
@@ -26,3 +26,27 @@ Explicit design choices and trade-offs made during development.
 - **Rationale**: Keeps PR scope bounded and avoids scope creep on already-large feature PRs. A GitHub issue provides a durable record that a reply comment alone would not — it cannot be forgotten and can be prioritized, assigned, and referenced in future work.
 - **Status**: Active
 - **Source**: sidecar:obs_e2c7b3
+
+## ADR-004: tmux prompt delivery uses pasteContent + sendControlKeys('Enter'), not sendKeys -l with \n suffix
+
+- **Context**: Stop hook / full interactive mode implementation — autobeat spawns tmux sessions to run Claude Code and Codex; prompts must be delivered and submitted
+- **Decision**: Deliver prompts via `pasteContent` (tmux load-buffer/paste-buffer) followed by a separate `sendControlKeys('Enter')` call — never via `sendKeys -l` with a trailing `\n`
+- **Rationale**: `tmux send-keys -l` runs in literal mode, which sends `\n` as the raw byte `0x0A` into the TUI's input buffer, not as an Enter keypress. The TUI receives the prompt text but never submits it. Using `pasteContent` + `sendControlKeys('Enter')` (without `-l`) sends the literal prompt safely and then fires the actual key binding for submission. This pattern was already established in `channel-manager.ts:968-983` — the fix unified all delivery sites to use the same mechanism.
+- **Status**: Active
+- **Source**: sidecar:2e5714e4
+
+## ADR-005: Code review convergence is judged by issue nature, not issue count
+
+- **Context**: 3 rounds of code review on the stop hook PR produced issue counts of 18 → 22 → 20 — not converging by count
+- **Decision**: Stop iterating code review cycles when the *nature* of findings converges to marginal improvements (documentation accuracy, `satisfies` annotations, minor extractions) with zero regressions from prior cycle's fixes — regardless of whether the raw count has decreased
+- **Rationale**: Issue count is a noisy signal; LLM reviewers are stochastic and will always find something. The meaningful signal is: (1) zero regressions from the most recent fix cycle, (2) remaining issues are hardening/polish rather than correctness gaps, (3) prior regression reviewer gave APPROVED. Stopping at this point avoids diminishing-returns churn while ensuring safety and correctness.
+- **Status**: Active
+- **Source**: sidecar:36c1ccff
+
+## ADR-006: CI formatting/linting failures are caught pre-push with biome check; not post-push via CI failure
+
+- **Context**: PR #198 CI failed on a biome formatting issue (ternary layout); required an extra push to fix
+- **Decision**: Run `npm run check` (biome format+lint) locally before committing and pushing to avoid a CI round-trip for cosmetic failures
+- **Rationale**: Biome formatting is deterministic and can always be validated locally. A CI failure for a formatting issue burns time on a round-trip push+wait cycle that adds no value. The pattern is already established in the project (`biome check --write` or `npm run check`).
+- **Status**: Active
+- **Source**: sidecar:17a3b878

--- a/src/cli/commands/orchestrate-interactive.ts
+++ b/src/cli/commands/orchestrate-interactive.ts
@@ -4,7 +4,7 @@
  * Interactive mode has distinct lifecycle (tmux session + attach, no loop, SIGINT coordination).
  *
  * Phase 5: Migrated from child_process spawnInteractive() to tmux sessions.
- * Flow: buildTmuxCommand() → tmuxConnector.spawn() → tmuxConnector.sendKeys()
+ * Flow: buildTmuxCommand() → tmuxConnector.spawn() → tmuxConnector.pasteContent() + sendControlKeys('Enter')
  *   → tmux attach-session (stdio: 'inherit') → session liveness check → finalize
  */
 

--- a/src/cli/commands/orchestrate-interactive.ts
+++ b/src/cli/commands/orchestrate-interactive.ts
@@ -261,10 +261,16 @@ async function spawnAndDeliverPrompt(ctx: SpawnPromptContext): Promise<SpawnedSe
 
   const handle = spawnResult.value;
 
-  // Deliver the initial prompt via send-keys (the session is now alive and ready).
-  const sendKeysResult = tmuxConnector.sendKeys(handle, tmuxPrompt);
-  if (!sendKeysResult.ok) {
-    return failWith(`Failed to deliver prompt to tmux session: ${sendKeysResult.error.message}`, handle);
+  // Deliver the initial prompt via pasteContent + Enter (the session is now alive and ready).
+  // pasteContent uses tmux load-buffer/paste-buffer to inject the full prompt without the
+  // send-keys literal-mode limitations that prevent trailing newlines from being submitted.
+  const pasteResult = tmuxConnector.pasteContent(handle, tmuxPrompt);
+  if (!pasteResult.ok) {
+    return failWith(`Failed to deliver prompt to tmux session: ${pasteResult.error.message}`, handle);
+  }
+  const enterResult = tmuxConnector.sendControlKeys(handle, 'Enter');
+  if (!enterResult.ok) {
+    return failWith(`Failed to submit prompt to tmux session: ${enterResult.error.message}`, handle);
   }
 
   return { handle, agentState, exitPromise };

--- a/src/cli/commands/orchestrate-interactive.ts
+++ b/src/cli/commands/orchestrate-interactive.ts
@@ -188,10 +188,10 @@ interface SpawnPromptContext {
 
 /**
  * Build the tmux config (stripping AUTOBEAT_WORKER), spawn the session, and deliver
- * the initial prompt via send-keys.
+ * the initial prompt via pasteContent + Enter.
  *
  * Calls process.exit(1) on any failure (CLI pattern — null is never returned).
- * On failure after spawn (send-keys), destroys the session before exiting.
+ * On failure after spawn (pasteContent/Enter), destroys the session before exiting.
  */
 async function spawnAndDeliverPrompt(ctx: SpawnPromptContext): Promise<SpawnedSession> {
   const { tmuxConnector, adapter, orchestration, orchestrationService, container } = ctx;

--- a/src/core/tmux-types.ts
+++ b/src/core/tmux-types.ts
@@ -22,7 +22,7 @@ import type { Result } from './result.js';
 
 /**
  * Handle to a live tmux session.
- * Returned from TmuxConnectorPort.spawn(); passed back to destroy/sendKeys/isAlive.
+ * Returned from TmuxConnectorPort.spawn(); passed back to destroy/pasteContent/sendControlKeys/isAlive.
  */
 export interface TmuxHandle {
   /** Full session name (e.g. "beat-task-abc123") */
@@ -207,7 +207,7 @@ export interface TmuxConnectorPort {
    * 4. Restart the staleness timer
    *
    * Must be called AFTER setEnvironment(AUTOBEAT_TASK_ID) and the /clear settle delay,
-   * and BEFORE sendKeys(prompt) so watchers are ready before any output arrives.
+   * and BEFORE pasteContent(prompt) so watchers are ready before any output arrives.
    *
    * Returns err() if the task directory cannot be created.
    */

--- a/src/implementations/event-driven-worker-pool.ts
+++ b/src/implementations/event-driven-worker-pool.ts
@@ -232,7 +232,7 @@ export class EventDrivenWorkerPool implements WorkerPool {
     const adapter = adapterResult.value;
 
     // Step 4: Build tmux config
-    // All tasks use interactive mode with the prompt delivered via sendKeys.
+    // All tasks use interactive mode with the prompt delivered via pasteContent + Enter.
     // Persistent sessions (loops) reuse the session across iterations.
     const psk = task.persistentSessionKey;
     const buildResult = adapter.buildTmuxCommand({
@@ -392,12 +392,22 @@ export class EventDrivenWorkerPool implements WorkerPool {
     }
 
     // Step 3: Send /clear to reset agent context
-    const clearResult = this.tmuxConnector.sendKeys(handle, '/clear\n');
+    const clearResult = this.tmuxConnector.sendKeys(handle, '/clear');
     if (!clearResult.ok) {
       this.logger.warn('Failed to send /clear to persistent session — destroying, will spawn fresh', {
         taskId: task.id,
         key,
         error: clearResult.error.message,
+      });
+      this.cleanupPersistentSession(key);
+      return ok(null);
+    }
+    const clearEnterResult = this.tmuxConnector.sendControlKeys(handle, 'Enter');
+    if (!clearEnterResult.ok) {
+      this.logger.warn('Failed to send Enter after /clear — destroying, will spawn fresh', {
+        taskId: task.id,
+        key,
+        error: clearEnterResult.error.message,
       });
       this.cleanupPersistentSession(key);
       return ok(null);
@@ -445,7 +455,7 @@ export class EventDrivenWorkerPool implements WorkerPool {
    *    d. Clean up flushingInProgress for the old task ID
    *    e. Atomically update DB registration from old task ID to new task ID
    * 7. Restart flushing, heartbeat, and timeout timers
-   * 8. Send new prompt via sendKeys
+   * 8. Send new prompt via pasteContent + Enter
    * 9. Release reuse lock
    *
    * DESIGN DECISION: On any failure, fall through to fresh spawn by destroying the stale
@@ -493,18 +503,29 @@ export class EventDrivenWorkerPool implements WorkerPool {
         this.remapExistingWorkerForReuse(worker, task, workerId, entry);
       }
 
-      // Step 8: Worker state is now fully remapped. If sendKeys fails, clean up the
-      // WorkerState (clears timers and removes from maps) before destroying the session,
-      // preventing orphaned callbacks from firing against the new task ID.
+      // Step 8: Worker state is now fully remapped. If pasteContent or Enter fails, clean
+      // up the WorkerState (clears timers and removes from maps) before destroying the
+      // session, preventing orphaned callbacks from firing against the new task ID.
       // Use worker.id (not the destructured workerId) because reRegisterWorkerForReuse
       // creates a new WorkerState with a new ID and updates entry.workerId, making the
       // locally destructured workerId stale for the re-registration branch.
-      const sendResult = this.tmuxConnector.sendKeys(handle, prompt + '\n');
-      if (!sendResult.ok) {
-        this.logger.warn('Failed to send prompt to reused session — destroying, will spawn fresh', {
+      const pasteResult = this.tmuxConnector.pasteContent(handle, prompt);
+      if (!pasteResult.ok) {
+        this.logger.warn('Failed to paste prompt to reused session — destroying, will spawn fresh', {
           taskId: task.id,
           key,
-          error: sendResult.error.message,
+          error: pasteResult.error.message,
+        });
+        this.cleanupWorkerState(worker.id, task.id);
+        this.cleanupPersistentSession(key);
+        return ok(null);
+      }
+      const enterResult = this.tmuxConnector.sendControlKeys(handle, 'Enter');
+      if (!enterResult.ok) {
+        this.logger.warn('Failed to send Enter after prompt to reused session — destroying, will spawn fresh', {
+          taskId: task.id,
+          key,
+          error: enterResult.error.message,
         });
         this.cleanupWorkerState(worker.id, task.id);
         this.cleanupPersistentSession(key);
@@ -683,16 +704,30 @@ export class EventDrivenWorkerPool implements WorkerPool {
     // Step 9: Start periodic output flushing
     this.startFlushing(worker);
 
-    // Step 10: Send prompt via sendKeys. All sessions use interactive mode;
-    // prompt is always present (delivered via send-keys, not baked into args).
-    const sendResult = this.tmuxConnector.sendKeys(handle, prompt + '\n');
-    if (!sendResult.ok) {
+    // Step 10: Send prompt via pasteContent + Enter. All sessions use interactive mode;
+    // prompt is always present (delivered via load-buffer/paste-buffer, not baked into args).
+    // pasteContent loads the prompt into a tmux buffer and pastes it, ensuring the full
+    // prompt text is injected without send-keys literal-mode limitations. The subsequent
+    // sendControlKeys('Enter') submits the prompt to Claude Code's input handler.
+    const pasteResult = this.tmuxConnector.pasteContent(handle, prompt);
+    if (!pasteResult.ok) {
       this.cleanupWorkerState(worker.id, task.id);
-      this.destroySessionWithWarning(handle, 'sendKeys failure');
+      this.destroySessionWithWarning(handle, 'pasteContent failure');
       return err(
         new AutobeatError(
           ErrorCode.WORKER_SPAWN_FAILED,
-          `Failed to send prompt to tmux session: ${sendResult.error.message}`,
+          `Failed to paste prompt to tmux session: ${pasteResult.error.message}`,
+        ),
+      );
+    }
+    const enterResult = this.tmuxConnector.sendControlKeys(handle, 'Enter');
+    if (!enterResult.ok) {
+      this.cleanupWorkerState(worker.id, task.id);
+      this.destroySessionWithWarning(handle, 'sendControlKeys Enter failure');
+      return err(
+        new AutobeatError(
+          ErrorCode.WORKER_SPAWN_FAILED,
+          `Failed to submit prompt to tmux session: ${enterResult.error.message}`,
         ),
       );
     }

--- a/src/implementations/event-driven-worker-pool.ts
+++ b/src/implementations/event-driven-worker-pool.ts
@@ -423,7 +423,7 @@ export class EventDrivenWorkerPool implements WorkerPool {
     // iteration's ID. In normal operation the agent has not received its prompt yet at
     // this point, so no callback should fire — but the ordering makes the invariant
     // explicit. Then create new task directory and start new watchers via prepareForReuse().
-    // This must happen BEFORE the worker remap and BEFORE sendKeys(prompt) so that the
+    // This must happen BEFORE the worker remap and BEFORE pasteContent(prompt) so that the
     // connector's watchers are ready to receive output as soon as the agent starts.
     entry.taskIdRef.current = task.id;
     const reuseCallbacks = this.createCallbacks(entry.taskIdRef);

--- a/src/implementations/tmux/tmux-connector.ts
+++ b/src/implementations/tmux/tmux-connector.ts
@@ -377,7 +377,7 @@ export class TmuxConnector implements TmuxConnectorPort {
    * 4. Restart the staleness timer
    *
    * Must be called AFTER setEnvironment(AUTOBEAT_TASK_ID) and the /clear settle
-   * delay, and BEFORE sendKeys(prompt) so watchers are ready before output arrives.
+   * delay, and BEFORE pasteContent(prompt) so watchers are ready before output arrives.
    *
    * Returns err() if the task directory cannot be created (caller falls through
    * to fresh spawn by calling cleanupPersistentSession then spawning fresh).
@@ -1033,7 +1033,7 @@ export class TmuxConnector implements TmuxConnectorPort {
     // DESIGN DECISION: Persistent sessions are "parked" rather than destroyed when a
     // sentinel fires — the tmux session stays alive between loop iterations. WorkerPool
     // calls prepareForReuse() on the next iteration to set up new watchers and task
-    // directory, then sendKeys() to deliver the next prompt.
+    // directory, then pasteContent() + sendControlKeys(Enter) to deliver the next prompt.
     if (session.persistent) {
       // Set state to 'parked' BEFORE flushPendingFiles so that any in-flight staleness
       // timer ticks that fire during the flush see state !== 'active' and return early.

--- a/tests/unit/implementations/event-driven-worker-pool.test.ts
+++ b/tests/unit/implementations/event-driven-worker-pool.test.ts
@@ -165,12 +165,21 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(tmuxConnector.spawn).toHaveBeenCalled();
     });
 
-    it('calls tmuxConnector.sendKeys to deliver prompt after spawn', async () => {
+    it('calls tmuxConnector.pasteContent to deliver prompt after spawn', async () => {
       const task = buildTask((f) => f.withPrompt('run tests'));
       await pool.spawn(task);
-      expect(tmuxConnector.sendKeys).toHaveBeenCalledWith(
+      expect(tmuxConnector.pasteContent).toHaveBeenCalledWith(
         expect.objectContaining({ sessionName: expect.stringContaining('beat-') }),
         expect.stringContaining('run tests'),
+      );
+    });
+
+    it('calls tmuxConnector.sendControlKeys(Enter) after pasteContent to submit prompt', async () => {
+      const task = buildTask((f) => f.withPrompt('run tests'));
+      await pool.spawn(task);
+      expect(tmuxConnector.sendControlKeys).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: expect.stringContaining('beat-') }),
+        'Enter',
       );
     });
   });
@@ -357,16 +366,16 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(result.ok).toBe(false);
     });
 
-    it('cleans up when sendKeys fails after spawn (step 10 failure)', async () => {
-      (tmuxConnector.sendKeys as ReturnType<typeof vi.fn>).mockReturnValueOnce(
-        err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'send failed')),
+    it('cleans up when pasteContent fails after spawn (step 10 failure)', async () => {
+      (tmuxConnector.pasteContent as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'paste failed')),
       );
 
       const task = buildTask();
       const result = await pool.spawn(task);
 
       expect(result.ok).toBe(false);
-      // Session should be destroyed on sendKeys failure
+      // Session should be destroyed on pasteContent failure
       expect(tmuxConnector.destroy).toHaveBeenCalled();
       // Worker should not be registered
       expect(pool.getWorkerCount()).toBe(0);
@@ -882,10 +891,14 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
         'AUTOBEAT_TASK_ID',
         task2.id,
       );
-      // sendKeys called for /clear and for the prompt
+      // sendKeys called for /clear (fixed string, not via pasteContent)
       const sendKeysCalls = (tmuxConnector.sendKeys as ReturnType<typeof vi.fn>).mock.calls;
-      expect(sendKeysCalls.some(([, keys]: [unknown, string]) => keys === '/clear\n')).toBe(true);
-      expect(sendKeysCalls.some(([, keys]: [unknown, string]) => keys.includes('iteration 2'))).toBe(true);
+      expect(sendKeysCalls.some(([, keys]: [unknown, string]) => keys === '/clear')).toBe(true);
+      // pasteContent called for the iteration prompt
+      expect(tmuxConnector.pasteContent).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionName: expect.stringContaining('beat-') }),
+        expect.stringContaining('iteration 2'),
+      );
 
       // Behavioral outcome: the worker must be reachable via the new task ID, not the old one.
       const workerForTask2 = pool.getWorkerForTask(task2.id);
@@ -938,7 +951,7 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(tmuxConnector.spawn).toHaveBeenCalledTimes(2);
       // /clear NOT sent because the session was dead and a fresh spawn happened
       const sendKeysCalls = (tmuxConnector.sendKeys as ReturnType<typeof vi.fn>).mock.calls;
-      expect(sendKeysCalls.some(([, keys]: [unknown, string]) => keys === '/clear\n')).toBe(false);
+      expect(sendKeysCalls.some(([, keys]: [unknown, string]) => keys === '/clear')).toBe(false);
     });
 
     it('cleanupPersistentSession destroys the session and removes it from the map', async () => {
@@ -1262,8 +1275,8 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(workerRepository.updateTaskId).toHaveBeenCalledWith(expect.objectContaining({ taskId: task2.id }));
     });
 
-    it('B1-2: sendKeys failure on reuse cleans up WorkerState (falls through to fresh spawn)', async () => {
-      // B1-2: if sendKeys fails after worker state is remapped, cleanupWorkerState must be
+    it('B1-2: pasteContent failure on reuse cleans up WorkerState (falls through to fresh spawn)', async () => {
+      // B1-2: if pasteContent fails after worker state is remapped, cleanupWorkerState must be
       // called to clear timers and remove the worker from maps — preventing orphaned callbacks.
       // The call falls through to a fresh spawn.
       const task1 = buildPersistentTask('loop-sendkeys-fail', (f) => f.withPrompt('iter 1'));
@@ -1271,14 +1284,10 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
 
       await pool.spawn(task1);
 
-      // Make sendKeys fail on the prompt send inside reuseSession.
-      // The mock is installed AFTER task1's spawn, so call counts restart from 0.
-      // sendKeys call order from this point: (1) /clear in reuseSession,
-      // (2) task2 prompt in reuseSession — fail on call 2.
-      // Subsequent calls (fresh spawn prompt) must succeed so the fallback completes.
-      (tmuxConnector.sendKeys as ReturnType<typeof vi.fn>)
-        .mockReturnValueOnce(ok(undefined)) // call 1: /clear succeeds
-        .mockReturnValueOnce(err(new Error('pipe broken'))); // call 2: prompt fails → fallthrough
+      // Make pasteContent fail on the prompt delivery inside reuseSession.
+      // sendKeys is still used for /clear (which succeeds via default mock).
+      // pasteContent failure on task2's prompt triggers fallthrough.
+      (tmuxConnector.pasteContent as ReturnType<typeof vi.fn>).mockReturnValueOnce(err(new Error('pipe broken')));
 
       const [spawnResult] = await Promise.all([pool.spawn(task2), vi.advanceTimersByTimeAsync(400)]);
 
@@ -1292,10 +1301,10 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
 
     // ─── Phase B: prepareForReuse ordering ────────────────────────────────────
 
-    it('Phase B: prepareForReuse called after setEnvironment and /clear settle, before sendKeys(prompt)', async () => {
-      // Verify the call ordering: setEnvironment → sendKeys(/clear) → [settle] →
-      // prepareForReuse → sendKeys(prompt). The connector must have watchers ready
-      // before the agent starts processing the new prompt.
+    it('Phase B: prepareForReuse called after setEnvironment and /clear settle, before pasteContent(prompt)', async () => {
+      // Verify the call ordering: setEnvironment → sendKeys(/clear) → sendControlKeys(Enter) →
+      // [settle] → prepareForReuse → pasteContent(prompt) → sendControlKeys(Enter).
+      // The connector must have watchers ready before the agent starts processing the new prompt.
       const task1 = buildPersistentTask('loop-ordering', (f) => f.withPrompt('iter 1'));
       const task2 = buildPersistentTask('loop-ordering', (f) => f.withPrompt('iter 2'));
 
@@ -1308,7 +1317,17 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       });
       vi.mocked(tmuxConnector.sendKeys).mockImplementation((...args) => {
         const keys = args[1] as string;
-        callOrder.push(keys.includes('/clear') ? 'sendKeys(/clear)' : 'sendKeys(prompt)');
+        callOrder.push(keys.includes('/clear') ? 'sendKeys(/clear)' : `sendKeys(${keys})`);
+        return ok(undefined);
+      });
+      vi.mocked(tmuxConnector.sendControlKeys).mockImplementation((...args) => {
+        const keys = args[1] as string;
+        callOrder.push(`sendControlKeys(${keys})`);
+        return ok(undefined);
+      });
+      vi.mocked(tmuxConnector.pasteContent).mockImplementation((...args) => {
+        const content = args[1] as string;
+        callOrder.push(content.includes('iter 2') ? 'pasteContent(prompt)' : `pasteContent(${content})`);
         return ok(undefined);
       });
       vi.mocked(tmuxConnector.prepareForReuse).mockImplementation(() => {
@@ -1321,7 +1340,7 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       const envIdx = callOrder.indexOf('setEnvironment(AUTOBEAT_TASK_ID)');
       const clearIdx = callOrder.indexOf('sendKeys(/clear)');
       const prepareIdx = callOrder.indexOf('prepareForReuse');
-      const promptIdx = callOrder.indexOf('sendKeys(prompt)');
+      const promptIdx = callOrder.indexOf('pasteContent(prompt)');
 
       expect(envIdx).toBeGreaterThanOrEqual(0);
       expect(clearIdx).toBeGreaterThan(envIdx);

--- a/tests/unit/implementations/event-driven-worker-pool.test.ts
+++ b/tests/unit/implementations/event-driven-worker-pool.test.ts
@@ -1428,12 +1428,7 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
 
       // Make prepareForReuse fail
       vi.mocked(tmuxConnector.prepareForReuse).mockReturnValueOnce(
-        err(
-          new (await import('../../../src/core/errors')).AutobeatError(
-            (await import('../../../src/core/errors')).ErrorCode.TMUX_HOOK_FAILED,
-            'dir creation failed',
-          ),
-        ),
+        err(new AutobeatError(ErrorCode.TMUX_HOOK_FAILED, 'dir creation failed')),
       );
 
       const [spawnResult] = await Promise.all([pool.spawn(task2), vi.advanceTimersByTimeAsync(400)]);

--- a/tests/unit/implementations/event-driven-worker-pool.test.ts
+++ b/tests/unit/implementations/event-driven-worker-pool.test.ts
@@ -380,6 +380,23 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       // Worker should not be registered
       expect(pool.getWorkerCount()).toBe(0);
     });
+
+    it('cleans up when sendControlKeys(Enter) fails after pasteContent succeeds (step 10 Enter failure)', async () => {
+      // applies ADR-004: pasteContent + sendControlKeys('Enter') is the canonical delivery
+      // mechanism. Both steps must succeed; failure of the Enter step must roll back.
+      (tmuxConnector.sendControlKeys as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'Enter failed')),
+      );
+
+      const task = buildTask();
+      const result = await pool.spawn(task);
+
+      expect(result.ok).toBe(false);
+      // pasteContent succeeded, so destroy must be called to roll back the spawned session
+      expect(tmuxConnector.destroy).toHaveBeenCalled();
+      // Worker should not be registered
+      expect(pool.getWorkerCount()).toBe(0);
+    });
   });
 
   // ─── AC-7: Output routing ────────────────────────────────────────────────
@@ -1106,6 +1123,27 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(tmuxConnector.spawn).toHaveBeenCalledTimes(2);
     });
 
+    it('sendControlKeys(Enter) failure after /clear in reuse falls through to fresh spawn (prepareSessionForIteration step 3)', async () => {
+      // applies ADR-004: Enter after /clear is required to submit the clear command. If it
+      // fails, cleanupPersistentSession must run and the call falls through to a fresh spawn.
+      const task1 = buildPersistentTask('loop-clear-enter-fail', (f) => f.withPrompt('iter 1'));
+      const task2 = buildPersistentTask('loop-clear-enter-fail', (f) => f.withPrompt('iter 2'));
+
+      await pool.spawn(task1);
+
+      // sendControlKeys is called for Enter after /clear. Make that specific call fail
+      // while leaving all other mock calls (including Enter after prompt paste) at default ok().
+      (tmuxConnector.sendControlKeys as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+        err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'Enter after clear failed')),
+      );
+
+      const result = await pool.spawn(task2);
+
+      // Must succeed — fall through to fresh spawn (cleanupPersistentSession + launchAndRegister)
+      expect(result.ok).toBe(true);
+      expect(tmuxConnector.spawn).toHaveBeenCalledTimes(2);
+    });
+
     // ── B1-1 regression: real-world loop lifecycle ─────────────────────────
 
     it('B1-1: reuses session after previous iteration completed (WorkerState removed by cleanupWorkerState)', async () => {
@@ -1299,6 +1337,33 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       expect(tmuxConnector.destroy).toHaveBeenCalled();
     });
 
+    it('B1-2: sendControlKeys(Enter) failure after pasteContent succeeds on reuse cleans up WorkerState (falls through to fresh spawn)', async () => {
+      // applies ADR-004: pasteContent + sendControlKeys('Enter') are both required for prompt
+      // delivery. If Enter fails after paste succeeds in reuseSession (step 8), cleanupWorkerState
+      // and cleanupPersistentSession must both run to prevent orphaned callbacks, and the call
+      // falls through to a fresh spawn.
+      const task1 = buildPersistentTask('loop-enter-fail-reuse', (f) => f.withPrompt('iter 1'));
+      const task2 = buildPersistentTask('loop-enter-fail-reuse', (f) => f.withPrompt('iter 2'));
+
+      await pool.spawn(task1);
+
+      // sendControlKeys is called twice during reuse: once for Enter after /clear (step 3 in
+      // prepareSessionForIteration) and once for Enter after pasteContent (step 8 in reuseSession).
+      // Let the first call (after /clear) succeed and fail the second (after paste).
+      (tmuxConnector.sendControlKeys as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(ok(undefined)) // Enter after /clear succeeds
+        .mockReturnValueOnce(err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'Enter after paste failed')));
+
+      const [spawnResult] = await Promise.all([pool.spawn(task2), vi.advanceTimersByTimeAsync(400)]);
+
+      // Must fall through to fresh spawn (ok result, 2 total spawns)
+      expect(spawnResult.ok).toBe(true);
+      expect(tmuxConnector.spawn).toHaveBeenCalledTimes(2);
+
+      // The persistent session must be destroyed after cleanupWorkerState
+      expect(tmuxConnector.destroy).toHaveBeenCalled();
+    });
+
     // ─── Phase B: prepareForReuse ordering ────────────────────────────────────
 
     it('Phase B: prepareForReuse called after setEnvironment and /clear settle, before pasteContent(prompt)', async () => {
@@ -1339,13 +1404,20 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
 
       const envIdx = callOrder.indexOf('setEnvironment(AUTOBEAT_TASK_ID)');
       const clearIdx = callOrder.indexOf('sendKeys(/clear)');
+      // sendControlKeys(Enter) appears twice: first after /clear, then after pasteContent(prompt).
+      const clearEnterIdx = callOrder.indexOf('sendControlKeys(Enter)');
       const prepareIdx = callOrder.indexOf('prepareForReuse');
       const promptIdx = callOrder.indexOf('pasteContent(prompt)');
+      const promptEnterIdx = callOrder.lastIndexOf('sendControlKeys(Enter)');
 
       expect(envIdx).toBeGreaterThanOrEqual(0);
       expect(clearIdx).toBeGreaterThan(envIdx);
-      expect(prepareIdx).toBeGreaterThan(clearIdx);
+      // Enter after /clear must follow /clear and precede prepareForReuse
+      expect(clearEnterIdx).toBeGreaterThan(clearIdx);
+      expect(prepareIdx).toBeGreaterThan(clearEnterIdx);
       expect(promptIdx).toBeGreaterThan(prepareIdx);
+      // Enter after prompt paste must follow pasteContent(prompt)
+      expect(promptEnterIdx).toBeGreaterThan(promptIdx);
     });
 
     it('Phase B: prepareForReuse failure falls through to fresh spawn', async () => {

--- a/tests/unit/implementations/event-driven-worker-pool.test.ts
+++ b/tests/unit/implementations/event-driven-worker-pool.test.ts
@@ -1279,8 +1279,8 @@ describe('EventDrivenWorkerPool (Phase 3: tmux)', () => {
       // B1-2: if pasteContent fails after worker state is remapped, cleanupWorkerState must be
       // called to clear timers and remove the worker from maps — preventing orphaned callbacks.
       // The call falls through to a fresh spawn.
-      const task1 = buildPersistentTask('loop-sendkeys-fail', (f) => f.withPrompt('iter 1'));
-      const task2 = buildPersistentTask('loop-sendkeys-fail', (f) => f.withPrompt('iter 2'));
+      const task1 = buildPersistentTask('loop-paste-fail', (f) => f.withPrompt('iter 1'));
+      const task2 = buildPersistentTask('loop-paste-fail', (f) => f.withPrompt('iter 2'));
 
       await pool.spawn(task1);
 


### PR DESCRIPTION
## Summary

- `tmux send-keys -l` with a trailing `\n` sends the newline as the literal byte `0x0A` into the TUI input buffer, **not** as an Enter keypress. Claude Code's readline handler receives the full prompt text but never submits it — tasks stall silently waiting for input that never comes.
- Switches all 4 prompt delivery sites to the `pasteContent` + `sendControlKeys('Enter')` pattern already established in `channel-manager.ts:968-983`.
- Updates tests to assert the new delivery mechanism.

## Changes

**`src/implementations/event-driven-worker-pool.ts`**
- Step 10 (fresh spawn): `sendKeys(handle, prompt + '\n')` → `pasteContent(handle, prompt)` + `sendControlKeys(handle, 'Enter')` with distinct error handling at each step
- Step 8 (session reuse): same substitution; error handling calls `cleanupWorkerState` + `cleanupPersistentSession` + returns `ok(null)` for fallthrough to fresh spawn
- Step 3 (/clear command): `sendKeys(handle, '/clear\n')` → `sendKeys(handle, '/clear')` + `sendControlKeys(handle, 'Enter')` — uses `sendKeys` (not `pasteContent`) because `/clear` is a fixed 6-char string with no special character risk; `sendControlKeys` replaces the literal `\n`

**`src/cli/commands/orchestrate-interactive.ts`**
- Initial prompt delivery: `sendKeys(handle, tmuxPrompt)` → `pasteContent(handle, tmuxPrompt)` + `sendControlKeys(handle, 'Enter')`, using the existing `failWith()` error pattern

**`tests/unit/implementations/event-driven-worker-pool.test.ts`**
- AC-1 assertion updated: `sendKeys` → `pasteContent`, adds `sendControlKeys(Enter)` assertion
- Step 10 failure test: mock target changed from `sendKeys` to `pasteContent`
- Persistent session reuse assertions: `/clear\n` → `/clear`, prompt check moved from `sendKeys` to `pasteContent`
- B1-2 failure test: refactored — `sendKeys` mock sequence replaced with `pasteContent` failure mock (sendKeys now only handles `/clear`)
- Phase B ordering test: tracks `pasteContent(prompt)` instead of `sendKeys(prompt)`, adds `sendControlKeys` tracking in `callOrder`

## Breaking Changes

None. This is an internal implementation change to tmux session management; public API and MCP tools are unchanged.

## Reviewer Focus Areas

- Error handling at each of the 4 sites follows the existing pattern for that site (fresh spawn destroys session + returns `err`; reuse falls through to fresh spawn via `ok(null)`)
- `/clear` keeps `sendKeys` (not `pasteContent`) — rationale: fixed short string, no literal-mode escape risk, existing pattern consistent with tmux slash-command delivery
- Snyk scan: 3 medium findings in pre-existing unchanged files (dashboard, translation proxy, orchestrate.ts) — not regressions from this change