### PR TITLE
fix(recovery): eliminate race that kills freshly-spawned workers in run mode

### DIFF
--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/architecture.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/architecture.md
@@ -1,0 +1,103 @@
+# Architecture Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+**Synthetic TmuxSpawnConfig in prepareForReuse uses dummy fields that bypass type safety** - `src/implementations/tmux/tmux-connector.ts:370-378`
+**Confidence**: 82%
+- Problem: `prepareForReuse()` constructs a synthetic `TmuxSpawnConfig` with `command: ''`, `agentArgs: []`, and `agent: 'claude' as const` to satisfy `buildActiveSession()`. While the comment documents that these fields are not used by `buildActiveSession`, this creates a coupling risk: any future change to `buildActiveSession` that reads `command`, `agentArgs`, or `agent` would silently receive bogus values. The `as const` cast also suppresses the type system's ability to catch this mismatch.
+- Fix: Extract the subset of fields `buildActiveSession` actually needs into a narrower parameter type (e.g. `BuildActiveSessionConfig` with only `taskId`, `sessionsDir`, `staleness?`, `persistent?`). This makes the contract explicit and removes the need for dummy values:
+  ```typescript
+  interface BuildActiveSessionConfig {
+    readonly taskId: TaskId;
+    readonly sessionsDir: string;
+    readonly staleness?: Partial<StalenessConfig>;
+    readonly persistent?: boolean;
+  }
+  ```
+
+### MEDIUM
+
+**Stop hook script does not validate SESSIONS_DIR in the early-exit (empty RESPONSE) path** - `scripts/autobeat-stop-hook.sh:24-35`
+**Confidence**: 84%
+- Problem: Lines 24-35 handle the case where no RESPONSE is extracted. In this path, `SESSIONS_DIR` and `CURRENT_TASK_ID` are used to write a `.exit` sentinel. However, unlike the main path (line 43, 48), this early-exit path does NOT validate `CURRENT_TASK_ID` against `^[a-z0-9][a-z0-9_-]*$` and does NOT validate `SESSIONS_DIR` for path traversal (`..`). This means a malformed task ID or sessions dir could write a sentinel to an unexpected location.
+- Fix: Move the validation checks before both code paths or duplicate them in the early-exit block:
+  ```bash
+  if [ -z "$RESPONSE" ]; then
+    TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+    CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+    [ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
+    SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
+    # Add validation
+    [[ "$CURRENT_TASK_ID" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || exit 0
+    [[ "$SESSIONS_DIR" =~ \.\. ]] && exit 0
+    if [ -n "$CURRENT_TASK_ID" ] && [ -n "$SESSIONS_DIR" ]; then
+      ...
+    fi
+    exit 0
+  fi
+  ```
+
+**Old task directory not cleaned when session is parked — relies on deferred comment but no mechanism** - `src/implementations/tmux/tmux-connector.ts:959-961`
+**Confidence**: 80%
+- Problem: When `triggerExit` parks a persistent session (lines 948-963), the comment at line 960 states "cleanup happens via loggedCleanup on the NEXT iteration's park or when cleanupPersistentSession() is called." However, `prepareForReuse()` (lines 348-406) does NOT call `loggedCleanup` for the old task ID. The only cleanup path is `cleanupPersistentSession()` which is called at loop end — meaning intermediate iteration directories accumulate on disk until the loop finishes. For a loop with 50 iterations, 49 task directories persist simultaneously.
+- Fix: Add a `loggedCleanup` call at the start of `prepareForReuse()` for the previous task's directory. The old taskId can be inferred from the existing `activeSessions` entry (if present) or passed explicitly. Alternatively, document this as intentional (output must remain readable for dashboard/output-repository until loop end) and add a bulk cleanup at loop completion. Either way, the comment at line 960 is inaccurate about "NEXT iteration's park" — that doesn't happen.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`if (prompt)` guard in launchAndRegister is now dead code** - `src/implementations/event-driven-worker-pool.ts:658`
+**Confidence**: 85%
+- Problem: The comment at line 656-657 correctly states "prompt is never empty for a fresh spawn." Since the wrapper pipeline has been removed and all sessions use interactive mode, `prompt` will always be truthy. The `if (prompt)` guard is now dead code that suggests an optional path still exists, which is confusing to future readers.
+- Fix: Remove the `if (prompt)` conditional and always execute `sendKeys`. Add an assertion if desired:
+  ```typescript
+  // All sessions use interactive mode — prompt is always present.
+  const sendResult = this.tmuxConnector.sendKeys(handle, prompt + '\n');
+  ```
+
+**`persistent` parameter accepted but documented as having "no effect" — confusing API surface** - `src/implementations/base-agent-adapter.ts:99-102`
+**Confidence**: 80%
+- Problem: The JSDoc on `buildTmuxCommand` states `persistent` is "accepted for backward compatibility but has no effect." However, the code at line 248 still reads `persistent: !!psk` in `event-driven-worker-pool.ts` and passes it through to `TmuxConnector.spawn()` where it IS used (it sets `session.persistent = true` at line 498 of tmux-connector.ts). The adapter's JSDoc is misleading — `persistent` still has architectural significance at the connector level; it's only meaningless for the adapter's arg-building decision.
+- Fix: Update the JSDoc to clarify that `persistent` no longer affects adapter arg building (all sessions are interactive) but is still passed through for connector-level session lifecycle semantics:
+  ```typescript
+  * The `persistent` flag no longer affects arg building (all sessions use interactive mode)
+  * but is forwarded to TmuxConnector where it controls session lifecycle: persistent sessions
+  * are parked rather than destroyed after sentinel detection.
+  ```
+
+## Pre-existing Issues (Not Blocking)
+
+(none identified at CRITICAL level in unchanged code)
+
+## Suggestions (Lower Confidence)
+
+- **`SessionState` type could be a const enum for exhaustive checking** - `src/implementations/tmux/tmux-connector.ts:102` (Confidence: 65%) — The `SessionState` type is a string union used in comparisons throughout the file. Using a const object with `as const` values would enable exhaustive switch/if-else checking at the type level and prevent typos.
+
+- **Stop hook writes non-atomic `.seq` increment** - `scripts/autobeat-stop-hook.sh:56-58` (Confidence: 70%) — `cat "$SEQ_FILE"` then `echo "$SEQ" > "$SEQ_FILE"` is not atomic. If the hook is called concurrently (unlikely but possible with rapid successive Stop triggers), two invocations could read the same seq value. The risk is low because the Stop hook runs once per agent turn, but adding `flock` (on Linux) or accepting potential duplicates should be documented.
+
+- **`void agent` pattern for unused parameter** - `src/cli/commands/init.ts:657` (Confidence: 62%) — `void agent;` is used to suppress the unused-variable warning for the `agent` parameter in `defaultConfigureHooks()`. Consider using `_agent` prefix naming convention instead, which is the TypeScript ecosystem standard and avoids the runtime expression.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 2 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Architecture Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The architectural changes are well-designed. The removal of the wrapper pipeline is clean: dead code is properly removed, the `SessionState` enum correctly models the three-state lifecycle, and the `prepareForReuse()` method encapsulates connector-internal complexity behind the port boundary (applies ADR-003 pattern — port abstraction over leaked internals). The `TmuxHooksPort.initTaskDirectory()` addition follows ISP — it exposes only what the reuse path needs without coupling to the full setup shim generation.
+
+Conditions for approval:
+1. Fix the validation gap in the Stop hook's early-exit path (MEDIUM/Blocking) — this is a security-adjacent issue that should match the main path's rigor.
+2. Address the misleading JSDoc about `persistent` having "no effect" (Should Fix) — the wording will cause confusion for contributors.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/complexity.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/complexity.md
@@ -1,0 +1,95 @@
+# Complexity Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**`configureAgentHook` idempotency check has 4-level nesting** - `src/cli/commands/init.ts:161-172`
+**Confidence**: 85%
+- Problem: The `alreadyPresent` check uses nested `.some()` with two layers of type narrowing inside, reaching 4 levels of nesting. The inline type guards and double `.some()` make the logic harder to follow at a glance.
+- Fix: Extract the nested hook-presence check into a named predicate function:
+```typescript
+function hasStopHookCommand(stopHooks: unknown[]): boolean {
+  return stopHooks.some((entry) => {
+    if (typeof entry !== 'object' || entry === null) return false;
+    const e = entry as Record<string, unknown>;
+    if (!Array.isArray(e.hooks)) return false;
+    return (e.hooks as unknown[]).some((h) => {
+      if (typeof h !== 'object' || h === null) return false;
+      const hookEntry = h as Record<string, unknown>;
+      return hookEntry.type === 'command' && hookEntry.command === STOP_HOOK_COMMAND;
+    });
+  });
+}
+```
+This makes the calling code `const alreadyPresent = hasStopHookCommand(stopHooks);` and eliminates the inline nesting.
+
+### MEDIUM
+
+**Stop hook shell script duplicates TMUX_SESSION/CURRENT_TASK_ID lookup (lines 25-28 and 38-41)** - `scripts/autobeat-stop-hook.sh:25-41`
+**Confidence**: 82%
+- Problem: The task-ID resolution logic (tmux display-message, tmux show-environment, fallback to env var) appears twice in the script. If the resolution logic needs to change (e.g., a new fallback), both blocks must be updated in lockstep.
+- Fix: Extract into a shell function at the top of the script:
+```bash
+resolve_task_context() {
+  TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+  CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+  [ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
+  SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
+}
+```
+Call `resolve_task_context` once before the early-exit path and once in the main path (or once at the start and reuse the variables).
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`reuseSession` method is 111 lines with 9 sequential steps** - `src/implementations/event-driven-worker-pool.ts:389-499`
+**Confidence**: 82%
+- Problem: Although individual steps are well-commented, the method orchestrates 9 sequential protocol steps with early-exit branches at each. The JSDoc alone is 30+ lines documenting B1-1 through B1-5 fixes. While each step is individually simple, the accumulated mental load of holding all failure modes in mind is significant.
+- Fix: This is a "should-fix while here" observation. The method is already partially decomposed (Steps 6 uses `reRegisterWorkerForReuse` and `remapExistingWorkerForReuse`). The remaining improvement would be grouping Steps 2-4 (env/clear/settle) into a `prepareSessionForNewIteration` helper, reducing reuseSession to ~60 lines. This is not blocking since the step-by-step comments serve as guardrails.
+
+**`remapExistingWorkerForReuse` mixes 5 distinct concerns** - `src/implementations/event-driven-worker-pool.ts:555-624`
+**Confidence**: 80%
+- Problem: This 70-line method handles: (1) flushingInProgress cleanup, (2) taskToWorker map update, (3) taskIdRef mutation, (4) WorkerState field updates, (5) timer lifecycle (clear + restart). Each has a distinct failure domain. Mixing DB writes with timer management in one method increases the blast radius of any future change.
+- Fix: Consider splitting timer lifecycle (clear old + setup new) into a separate `restartTimersForWorker(worker)` helper, reducing this method to ~40 lines of pure state remapping.
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**`tmux-connector.ts` is 1,053 lines** - `src/implementations/tmux/tmux-connector.ts`
+**Confidence**: 85%
+- Problem: File length exceeds the 500-line critical threshold. The class manages session lifecycle, message ordering, staleness detection, and pending-message delivery. This PR added `prepareForReuse` (60 lines) which is well-decomposed but increases the file further. The file was likely already over 500 lines before this PR.
+- Fix: Long-term opportunity — extract the message ordering/delivery logic (deliverPendingMessages, handleMessageFile, forceDeliverRemaining, deliverSingle) into a MessageDeliveryPipeline class. Not blocking for this PR since the new code is well-structured.
+
+**`event-driven-worker-pool.ts` is 1,238 lines** - `src/implementations/event-driven-worker-pool.ts`
+**Confidence**: 85%
+- Problem: File length exceeds the 500-line critical threshold. The class handles spawn, reuse, kill, flushing, timeouts, heartbeats, and cleanup. Both files were large before this PR; the new code adds well-decomposed methods but doesn't reduce the overall cognitive load of navigating these files.
+- Fix: Not actionable for this PR. Future opportunity: extract the persistent session reuse protocol (tryReuseSession, reuseSession, reRegisterWorkerForReuse, remapExistingWorkerForReuse, cleanupPersistentSession) into a PersistentSessionManager collaborator.
+
+## Suggestions (Lower Confidence)
+
+- **`configureAgentHook` could benefit from early-return on missing config file** - `src/cli/commands/init.ts:128-205` (Confidence: 65%) — The function handles both "file exists" and "file doesn't exist" paths with a nested if/try structure. Restructuring as "create empty config if not exists, then proceed uniformly" could flatten the logic, but current structure is acceptable.
+
+- **`defaultConfigureHooks` accepts unused `agent` parameter** - `src/cli/commands/init.ts:656` (Confidence: 70%) — The `void agent` pattern is documented as "for future extensibility" but accepting and voiding a parameter adds slight confusion. Could use an `_agent` prefix instead, though this is purely stylistic.
+
+- **`triggerExit` has 5 parameters including a default boolean** - `src/implementations/tmux/tmux-connector.ts:935-941` (Confidence: 62%) — The `skipTimerRestart = false` parameter is a control flag that changes behavior. An options object or calling `restartSharedStalenessTimer()` explicitly at the call site would be clearer, but the existing pattern is consistent with the batch-exit optimization comment.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | - |
+| Should Fix | - | 0 | 2 | - |
+| Pre-existing | - | - | 2 | - |
+
+**Complexity Score**: 7/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR is a net simplification: it removes 1,187 lines of wrapper pipeline code and replaces it with a cleaner Stop hook architecture. The new code is well-decomposed with good extraction patterns (buildActiveSession, startWatchers, safeCallOnExit, loggedCleanup, etc.) that keep individual methods under 50 lines. The blocking items are minor readability improvements (nested predicate extraction, shell script DRY) that do not affect correctness. The pre-existing file-length issues are informational only and predate this PR.
+
+Conditions: Fix the HIGH-severity nested predicate in `configureAgentHook` before merge. The MEDIUM shell duplication is recommended but not blocking.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/consistency.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/consistency.md
@@ -1,0 +1,94 @@
+# Consistency Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Stale comment references `session.exited` boolean after migration to `SessionState` enum** - `src/implementations/tmux/tmux-connector.ts:526-530`
+**Confidence**: 95%
+- Problem: The sentinel watcher inline comment still references `session.exited` (the old boolean field) and `sets session.exited = true`. The actual code now uses `session.state !== 'active'` and `session.state = 'parked'|'exited'`. This documentation drift makes the comment misleading for readers.
+- Fix: Update the comment to match the new state machine:
+```typescript
+// No debounce needed here: handleSentinel() reads session.state
+// synchronously at the top of the event-loop tick. Because
+// triggerExit() sets session.state to 'parked' or 'exited' before
+// returning, any platform double-fire of the same sentinel file is
+// a no-op — the second callback sees state !== 'active' and returns
+// immediately.
+```
+
+---
+
+**Misleading JSDoc: `persistent` "has no effect" in `buildTmuxCommand` contradicts actual usage** - `src/implementations/base-agent-adapter.ts:99-102`
+**Confidence**: 82%
+- Problem: The JSDoc states "The `persistent` option is accepted for backward compatibility but has no effect". While true that `buildTmuxCommand` itself ignores the option (it no longer branches on it), the option is still consumed by the caller (`EventDrivenWorkerPool.spawn()` at line 276: `psk ? { ...config, persistent: true } : config`). The comment implies the option is vestigial, when in reality it is actively used for session lifecycle management. A reader encountering the option might remove it based on this comment.
+- Fix: Clarify the comment to distinguish adapter-level behavior from caller-level behavior:
+```typescript
+* DECISION: Wrapper pipeline mode (--print/--quiet based) has been removed.
+* All tmux sessions are interactive; output is captured via the Stop hook.
+* The `persistent` option no longer affects CLI arg generation (all sessions
+* use the interactive path), but it is still passed through to
+* TmuxSpawnCoreConfig by the caller for session lifecycle control
+* (park vs destroy on sentinel).
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Duplicated tmux session + task ID resolution block in stop hook** - `scripts/autobeat-stop-hook.sh:24-28` and `scripts/autobeat-stop-hook.sh:38-41`
+**Confidence**: 85%
+- Problem: Lines 24-28 (the empty-response early-exit path) duplicate the session/task-ID resolution logic from lines 38-41 (the main path). Both blocks call `tmux display-message`, `tmux show-environment`, and fall back to `$AUTOBEAT_TASK_ID`. This violates DRY and creates a maintenance risk — if the resolution logic needs updating, both blocks must be changed in lockstep.
+- Fix: Extract the tmux session + task ID resolution into a function at the top of the script:
+```bash
+resolve_task_id() {
+  local session
+  session=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+  local task_id
+  task_id=$(tmux show-environment -t "$session" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+  [ -z "$task_id" ] && task_id="${AUTOBEAT_TASK_ID:-}"
+  echo "$task_id"
+}
+```
+
+---
+
+**Missing TASK_ID validation on early-exit path in stop hook** - `scripts/autobeat-stop-hook.sh:24-35`
+**Confidence**: 90%
+- Problem: The early-exit path (when `$RESPONSE` is empty) resolves `CURRENT_TASK_ID` and writes a `.exit` sentinel without validating the task ID against the regex (`^[a-z0-9][a-z0-9_-]*$`) or checking `SESSIONS_DIR` for path traversal (`..`). The main path (lines 43-48) has these validation checks. This inconsistency means a malformed task ID or hostile sessions dir could write to an arbitrary path on the early-exit path.
+- Fix: Move the validation guards (lines 43, 46, 48) to run before any sentinel write, or refactor both paths to share a common validated-write function.
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **`HookConfigResult.alreadyPresent` field is never populated** - `src/cli/commands/init.ts:62-75` (Confidence: 65%) — The `HookConfigResult` type declares an `alreadyPresent?: boolean` field in the success variant, but `configureAgentHook` returns the same `ok(undefined)` for both idempotent (already present) and fresh configuration. The caller (`defaultConfigureHooks`) never receives this signal. Either populate the field or remove it from the type.
+
+- **`void agent` suppression in `defaultConfigureHooks`** - `src/cli/commands/init.ts:657` (Confidence: 60%) — The `void agent` statement with the comment "agent param is for future extensibility" is an unusual pattern in this codebase where unused params typically use the `_` prefix convention (seen in `_path`, `_jsonSchema`, `_eventType`, `_taskId` throughout). Using `_agent` would be more consistent.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 2 | 0 |
+| Should Fix | 0 | 0 | 2 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Consistency Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR demonstrates strong overall consistency:
+- Pattern migration from `exited: boolean` to `SessionState` enum is applied uniformly across all guard checks in the connector.
+- The wrapper pipeline removal is complete — no stale imports, no dead `WrapperConfig`/`WrapperManifest` types remain in source.
+- `SpawnCallbacks` moved to `core/tmux-types.ts` with proper re-export from `tmux/types.ts` — import graph is clean.
+- New `prepareForReuse()` port method follows the existing port pattern (`Result<void, AutobeatError>` return, JSDoc with DESIGN DECISION annotation, tested via mock fixture).
+- Adapter simplification is symmetric: both Claude and Codex adapters removed `buildWrapperFlags`, `buildArgs`, and `buildInteractiveArgs` identically.
+- `configureAgentHook` follows the project's Result-type error handling pattern.
+- The stop hook validates task IDs against the same regex as `TASK_ID_REGEX` in TypeScript.
+
+The blocking conditions are two stale/misleading comments that should be updated before merge to prevent documentation drift (applies ADR-002 reasoning: explicit documentation prevents future re-raising). The should-fix items strengthen the stop hook's validation consistency.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/performance.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/performance.md
@@ -1,0 +1,74 @@
+# Performance Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Duplicate `tmux display-message` and `tmux show-environment` calls in Stop hook** - `scripts/autobeat-stop-hook.sh:25-27,38-39`
+**Confidence**: 85%
+- Problem: The stop hook calls `tmux display-message -p '#{session_name}'` and `tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID` twice — once on line 25-27 (the empty-RESPONSE fallback path) and once on line 38-39 (the main path). Each `tmux` invocation is a subprocess exec (~5-20ms) called on every single agent turn. Although the two blocks are mutually exclusive (only one path executes per invocation due to the `exit 0` on line 35), the early-exit path (lines 24-35) resolves TMUX_SESSION and CURRENT_TASK_ID but the main path (lines 38-39) recomputes them from scratch rather than reusing the earlier values.
+- Fix: Move the `TMUX_SESSION` and `CURRENT_TASK_ID` resolution above both conditional blocks so it runs exactly once regardless of which path is taken:
+
+```bash
+TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+[ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
+
+SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
+
+if [ -z "$RESPONSE" ]; then
+  # ... write .exit sentinel using already-resolved vars ...
+  exit 0
+fi
+
+# ... rest of main path uses same vars ...
+```
+
+### MEDIUM
+
+**Multiple sequential jq invocations in stop hook hot path** - `scripts/autobeat-stop-hook.sh:10,63-64,74`
+**Confidence**: 82%
+- Problem: The stop hook invokes `jq` up to 4 times sequentially per agent turn (lines 10, 63, 64, 74). Each `jq` invocation forks a process (~2-5ms). On a single agent turn this is ~10-20ms total, which is acceptable for a per-turn hook. However, the same `$HOOK_DATA` is piped to jq multiple times for different fields. A single jq invocation could extract multiple fields at once.
+- Fix: Consolidate the jq calls into a single multi-output extraction where possible. For example, extract both `.last_assistant_message` and `.stop_reason` in one pass:
+
+```bash
+EXTRACTED=$(printf '%s' "$HOOK_DATA" | jq -r '
+  [.last_assistant_message // "", .stop_reason // "end_turn"] | @tsv
+' 2>/dev/null)
+RESPONSE=$(printf '%s' "$EXTRACTED" | cut -f1)
+STOP_REASON=$(printf '%s' "$EXTRACTED" | cut -f2)
+```
+
+This reduces 3 jq forks to 1 on the common path (when `last_assistant_message` is present).
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **300ms hardcoded settle delay in reuseSession** - `src/implementations/event-driven-worker-pool.ts:433` (Confidence: 65%) — The `CLEAR_SETTLE_MS = 300` delay is applied unconditionally on every loop iteration reuse. This is documented as intentional (applies ADR-002 — the 300ms was explicitly upheld in a prior Greptile review), but could benefit from profiling to determine if a lower value (e.g., 100-150ms) is sufficient, or if the settle could be replaced by an ack mechanism. Not blocking since it's an inherited design choice.
+
+- **Stop hook transcript fallback reads last 50 lines** - `scripts/autobeat-stop-hook.sh:15` (Confidence: 62%) — When `last_assistant_message` is empty, the hook falls back to `tail -n 50 "$TRANSCRIPT"` piped to `jq -s`. For very large JSONL transcripts this is acceptable (tail is O(1) from end), but the `jq -s` slurp on 50 lines of JSONL could be slow if lines are very large. Unlikely to be a real issue in practice.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Performance Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The architectural change from wrapper pipeline to Stop hook is a net performance improvement: it eliminates the per-line `jq` call in the wrapper's `while IFS= read -r line` loop (which invoked jq for every stdout line) and replaces it with a single jq invocation per agent turn in the Stop hook. The `prepareForReuse()` path is well-designed — it does minimal synchronous I/O (mkdir + write "0" to .seq file) and avoids any tmux subprocess calls beyond what was already there. The staleness timer's skip-parked-sessions logic (`session.state !== 'active'`) correctly avoids wasted work on intentionally-idle sessions.
+
+The two findings above are minor optimizations to the stop hook shell script — they reduce subprocess forks per turn from ~6-7 to ~3-4 on the hot path. Neither is a correctness issue and both are safe to address in a follow-up.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/regression.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/regression.md
@@ -1,0 +1,60 @@
+# Regression Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Stale comment references `session.exited` boolean after migration to `SessionState` enum** - `src/implementations/tmux/tmux-connector.ts:526-530`
+**Confidence**: 92%
+- Problem: The comment inside `startSentinelWatcher` still references `session.exited` (the old boolean field) instead of `session.state`. Lines 526-530 say: "handleSentinel() reads session.exited synchronously... triggerExit() sets session.exited = true before returning... the second callback sees exited = true". The code itself is correct (it calls `handleSentinel` which checks `session.state !== 'active'`), but the comment describes the old pre-refactor mechanism and will confuse future readers about the actual guard logic.
+- Fix: Update the comment to reference `session.state`:
+```typescript
+// No debounce needed here: handleSentinel() checks session.state !== 'active'
+// synchronously at the top of the event-loop tick. Because
+// triggerExit() sets session.state to 'parked' or 'exited' before returning,
+// any platform double-fire of the same sentinel file is a no-op —
+// the second callback sees state !== 'active' and returns immediately.
+```
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Defensive guard for empty prompt in fresh spawn** - `src/implementations/event-driven-worker-pool.ts:658` (Confidence: 65%) — The `if (prompt)` guard at line 658 is a no-op now that all fresh spawns always return a non-empty prompt from `buildTmuxCommand`. The guard prevents sending an empty string but could mask a bug if the adapter ever returned an empty prompt (agent would start with no instruction). Consider converting to an assertion or removing the conditional to fail fast.
+
+- **Output granularity change is intentional but undocumented in CHANGELOG** - `scripts/autobeat-stop-hook.sh` (Confidence: 62%) — The old wrapper captured every stdout line as a separate OutputMessage; the Stop hook captures only the final assistant response per turn. This means the dashboard output stream shows less granular data (one message per turn vs. one per line). If this is intentional (PR description says it is), no code fix needed, but the behavior difference should be documented for users who relied on line-level streaming via `beat task logs`.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Regression Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+## Regression Assessment
+
+The migration from wrapper pipeline to unified Stop hook is well-executed with minimal regression risk:
+
+1. **Removed exports** (`WrapperConfig`, `WrapperManifest`, `CommunicationMode`, `generateWrapper`, `buildWrapperFlags`, `buildArgs`, `buildInteractiveArgs`): No remaining consumers found in `src/` or `tests/`. Clean removal.
+
+2. **SessionState enum migration** (boolean `exited` -> three-state `active|parked|exited`): All guards correctly check `session.state !== 'active'` instead of `session.exited`. Non-persistent tasks follow the same destroy path as before. Persistent tasks gain the new `parked` state for loop iteration reuse.
+
+3. **Non-persistent task path preserved**: `triggerExit()` correctly branches on `session.persistent` — non-persistent sessions still destroy the tmux session, clean up the directory, and fire onExit. No behavioral regression for standard (non-loop) tasks.
+
+4. **Port interface backward compatibility**: `TmuxConnectorPort` gains `prepareForReuse()` (additive). `TmuxHooksPort` replaces `generateWrapper()` with `generateSetupShim()` (already existed before this PR) and adds `initTaskDirectory()`. The mock in `tests/fixtures/mocks.ts` is correctly updated.
+
+5. **Agent adapter simplification**: `buildTmuxCommand()` always returns a non-empty prompt now (no wrapper baked-arg path). The `if (prompt)` guard in `launchAndRegister` is dead code for fresh spawns but harmless.
+
+6. **Stop hook script**: Correctly handles both Codex (`last_assistant_message`) and Claude (`transcript_path`) paths. Security validations (task ID regex, path traversal check) match the existing connector-level validation patterns.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/reliability.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/reliability.md
@@ -1,0 +1,116 @@
+# Reliability Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**configureAgentHook can throw instead of returning Result** - `src/cli/commands/init.ts:201-202`
+**Confidence**: 92%
+- Problem: `configureAgentHook` declares `Result<void, string>` return type but calls `deps.writeFile(tmpPath, content)` and `deps.renameFile(tmpPath, configPath)` without try/catch. The production implementations (`writeFileSync`, `renameSync`) can throw on disk errors (permissions, ENOSPC, EROFS). An uncaught throw propagates through `defaultConfigureHooks` and `runHookConfigure` (neither wraps in try/catch), crashing the entire `runInit` flow despite the JSDoc promise that "Hook config failures are non-fatal."
+- Fix: Wrap lines 201-202 in try/catch and return `err()` on failure:
+```typescript
+  try {
+    deps.writeFile(tmpPath, content);
+    deps.renameFile(tmpPath, configPath);
+  } catch (e) {
+    return err(`Failed to write ${agentType} config: ${e instanceof Error ? e.message : String(e)}`);
+  }
+```
+
+**Stop hook .seq read-increment-write is not atomic** - `scripts/autobeat-stop-hook.sh:56-58`
+**Confidence**: 82%
+- Problem: The sequence counter is read (`cat`), incremented in bash, and written back without any locking mechanism. If two Stop hook invocations fire concurrently for the same task (possible when the agent produces rapid successive outputs that each trigger a stop event), both read the same `.seq` value, produce the same sequence number, and one message file overwrites the other.
+- Impact: Message loss via filename collision. The `mv` on line 72 would overwrite an existing message with the same padded sequence.
+- Mitigating factor: In practice, Claude Code's Stop hook fires once per turn (synchronous hook invocation model), so concurrent invocations for the same task are unlikely under normal operation. However, this is an implicit assumption — not enforced.
+- Fix: Use `flock` with a fallback, or use a unique suffix (PID + timestamp) to prevent collision:
+```bash
+SEQ=$(cat "$SEQ_FILE" 2>/dev/null || echo 0)
+SEQ=$((SEQ + 1))
+echo "$SEQ" > "$SEQ_FILE"
+```
+Could become:
+```bash
+# Atomic increment via flock (if available) or fallback to racy path
+if command -v flock >/dev/null 2>&1; then
+  SEQ=$(flock "$SEQ_FILE.lock" bash -c "SEQ=\$(cat '$SEQ_FILE' 2>/dev/null || echo 0); SEQ=\$((SEQ + 1)); echo \$SEQ > '$SEQ_FILE'; echo \$SEQ")
+else
+  SEQ=$(cat "$SEQ_FILE" 2>/dev/null || echo 0)
+  SEQ=$((SEQ + 1))
+  echo "$SEQ" > "$SEQ_FILE"
+fi
+```
+Note: `flock` is not available on macOS without Homebrew. Given the mitigating factor (sequential hook invocation model), this may be acceptable risk. Document the assumption explicitly.
+
+### MEDIUM
+
+**Orphaned .tmp file on rename failure** - `src/cli/commands/init.ts:201-202`
+**Confidence**: 83%
+- Problem: If `deps.writeFile(tmpPath, content)` succeeds but `deps.renameFile(tmpPath, configPath)` throws (e.g., cross-device rename, permissions), the `.tmp` file is left on disk. The next `configureAgentHook` invocation does not clean up stale `.tmp` files, so it may be confusing to users who inspect their config directory.
+- Fix: In the try/catch block suggested above, attempt cleanup of tmpPath on rename failure:
+```typescript
+  try {
+    deps.writeFile(tmpPath, content);
+    deps.renameFile(tmpPath, configPath);
+  } catch (e) {
+    // Best-effort cleanup of orphaned .tmp
+    try { if (deps.fileExists(tmpPath)) deps.writeFile(tmpPath, ''); /* or unlink */ } catch { /* ignore */ }
+    return err(`Failed to write ${agentType} config: ${e instanceof Error ? e.message : String(e)}`);
+  }
+```
+
+**prepareForReuse does not clean up task directory on buildActiveSession failure** - `src/implementations/tmux/tmux-connector.ts:380-387`
+**Confidence**: 80%
+- Problem: `prepareForReuse` calls `initTaskDirectory` (Step 1) which creates the directory, then calls `buildActiveSession` (Step 2). If `buildActiveSession` returns err (invalid staleness config), the newly created task directory is orphaned — there is no cleanup path. The caller (`reuseSession`) calls `cleanupPersistentSession` which destroys the session entirely, but the orphaned directory for `newTaskId` is never removed because `loggedCleanup` is called with the _session handle's_ taskId, not `newTaskId`.
+- Impact: Directory leak on disk. Low frequency since staleness config validation failure is unlikely in practice (DEFAULT_STALENESS_CONFIG has valid values).
+- Fix: Add cleanup before returning on `buildActiveSession` error:
+```typescript
+    if (!sessionResult.ok) {
+      this.deps.hooks.cleanup(newTaskId, handle.sessionsDir);
+      return sessionResult;
+    }
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Stop hook transcript parsing uses unbounded `tail -n 50` without output size validation** - `scripts/autobeat-stop-hook.sh:15-20`
+**Confidence**: 80%
+- Problem: The transcript fallback path reads the last 50 lines of a JSONL transcript file into memory, then pipes to `jq -s` (slurp mode) which loads all 50 objects into memory. For normal transcripts this is fine, but if individual transcript lines are very large (multi-MB assistant messages), this could consume significant memory in the hook process. Additionally, there is no guard ensuring `$TRANSCRIPT` is a regular file (it could be a symlink to a large file or a pipe).
+- Impact: In degenerate cases, the hook could consume excessive memory or block on a non-file path. Low probability in normal operation.
+- Fix: Add a file size check and/or limit bytes read:
+```bash
+  if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] && [ "$(stat -f%z "$TRANSCRIPT" 2>/dev/null || stat -c%s "$TRANSCRIPT" 2>/dev/null || echo 0)" -lt 10485760 ]; then
+```
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**No assertion on `AUTOBEAT_SESSIONS_DIR` propagation to the Stop hook in reuse path** - `src/implementations/tmux/tmux-connector.ts:348`
+**Confidence**: 82%
+- Problem: `prepareForReuse` creates a new task directory under `handle.sessionsDir`, but does not verify or update the `AUTOBEAT_SESSIONS_DIR` environment variable in the tmux session. For the initial spawn, the setup shim exports `AUTOBEAT_SESSIONS_DIR` (tmux-hooks.ts:73). On reuse, `reuseSession` only updates `AUTOBEAT_TASK_ID` (event-driven-worker-pool.ts:408). If `sessionsDir` changes between iterations (unlikely but not asserted), the Stop hook would write to the wrong directory.
+- Impact: Correctness depends on `sessionsDir` being immutable across the session lifetime. This is true in practice (the field comes from WorkerPool constructor, which is singleton), but there is no runtime assertion or explicit comment establishing this invariant.
+
+## Suggestions (Lower Confidence)
+
+- **Stop hook silent exit on missing `jq`** - `scripts/autobeat-stop-hook.sh:6` (Confidence: 65%) — When `jq` is not found, the hook exits silently with code 0. No sentinel file is written, so the connector must rely solely on staleness detection (60s default) to detect task completion. Consider writing a `.exit` sentinel even when `jq` is unavailable so the connector can react promptly.
+
+- **`tail -n 50` magic number** - `scripts/autobeat-stop-hook.sh:15` (Confidence: 62%) — The 50-line limit for transcript parsing is undocumented. If the last assistant message spans more than 50 lines of JSONL, the output will be truncated or parsing may fail silently. Consider documenting this bound or making it configurable.
+
+- **No upper bound on `stopHooks` array length in idempotency scan** - `src/cli/commands/init.ts:161` (Confidence: 60%) — The `alreadyPresent` scan iterates the entire `stopHooks` array. If a user has a very large hooks config (hundreds of entries), this scan is O(N). Not a realistic concern today but violates bounded-iteration principles.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 2 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Reliability Score**: 7/10
+**Recommendation**: CHANGES_REQUESTED
+
+The overall lifecycle management (SessionState enum, park/reuse protocol, staleness skipping for parked sessions) is well-designed with clear state transitions and appropriate guards against re-entrancy. The bounded iteration patterns (MAX_PENDING_MESSAGES, MIN_CHECK_INTERVAL_MS, delivery loop cap) are solid. The two HIGH issues are the unguarded throws in `configureAgentHook` (which contradicts the non-fatal promise and can crash `runInit`) and the non-atomic sequence counter in the stop hook shell script (which has a mitigating factor but represents an unasserted assumption).

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/resolution-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/resolution-summary.md
@@ -1,0 +1,52 @@
+# Resolution Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31_1823
+**Review**: .devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823
+**Command**: /resolve
+
+## Decisions Citations
+
+- applies ADR-002 — batch-1, stop-hook:56-58:atomicity (documented intentional design choice explicitly)
+- avoids PF-001 — batch-3, tmux-connector:959-961:orphan-dirs (fixed inaccurate comment in-place rather than deferring)
+
+## Statistics
+| Metric | Value |
+|--------|-------|
+| Total Issues | 18 |
+| Fixed | 17 |
+| False Positive | 0 |
+| Deferred | 1 |
+| Blocked | 0 |
+
+## Fixed Issues
+| Issue | File:Line | Commit |
+|-------|-----------|--------|
+| Missing task ID validation on early-exit path | scripts/autobeat-stop-hook.sh:24-34 | 49fcc01 |
+| Duplicated tmux session/task ID resolution | scripts/autobeat-stop-hook.sh:25-41 | 49fcc01 |
+| .seq non-atomic assumption undocumented | scripts/autobeat-stop-hook.sh:56-58 | 49fcc01 |
+| Stdin read without size limit | scripts/autobeat-stop-hook.sh:8 | 49fcc01 |
+| Redundant jq subprocess call | scripts/autobeat-stop-hook.sh:10,63-64 | 49fcc01 |
+| configureAgentHook throws instead of Result | src/cli/commands/init.ts:201-202 | 99f661b |
+| Orphaned .tmp on rename failure | src/cli/commands/init.ts:201-202 | 99f661b |
+| 4-level nested idempotency predicate | src/cli/commands/init.ts:161-172 | 99f661b |
+| Synthetic config coupling comment | src/implementations/tmux/tmux-connector.ts:370-378 | eef29b0 |
+| prepareForReuse orphaned dir on failure | src/implementations/tmux/tmux-connector.ts:380-387 | eef29b0 |
+| Stale session.exited comment | src/implementations/tmux/tmux-connector.ts:526-530 | eef29b0 |
+| Unnecessary type assertion | src/implementations/tmux/tmux-connector.ts:491 | eef29b0 |
+| Inaccurate park cleanup comment | src/implementations/tmux/tmux-connector.ts:959-961 | eef29b0 |
+| Misleading persistent JSDoc | src/implementations/base-agent-adapter.ts:99-102 | 4cb51dc |
+| Dead `if (prompt)` guard | src/implementations/event-driven-worker-pool.ts:658 | 4cb51dc |
+| Mixed concerns: timer lifecycle extraction | src/implementations/event-driven-worker-pool.ts:555-624 | 4cb51dc |
+| Flaky setTimeout in test | tests/unit/implementations/tmux/tmux-connector.test.ts:2859 | d2de69b |
+
+## False Positives
+_(none)_
+
+## Deferred to Tech Debt
+| Issue | File:Line | Risk Factor |
+|-------|-----------|-------------|
+| reuseSession 111 lines / 9 steps | src/implementations/event-driven-worker-pool.ts:389-499 | Steps 2-4 each have distinct error paths calling cleanupPersistentSession — extraction adds indirection without net readability gain; step-numbered comments serve as guardrails |
+
+## Blocked
+_(none)_

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/review-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/review-summary.md
@@ -1,0 +1,277 @@
+# Code Review Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+**Review Cycle**: 1 (initial)
+
+## Merge Recommendation: CHANGES_REQUESTED
+
+Multiple HIGH-severity blocking issues across security, architecture, and reliability require fixes before merge. Once addressed, the architectural refactoring (wrapper pipeline removal) is sound and well-decomposed.
+
+---
+
+## Issue Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW | Total |
+|----------|----------|------|--------|-----|-------|
+| Blocking | 0 | 5 | 6 | 0 | 11 |
+| Should Fix | 0 | 0 | 4 | 0 | 4 |
+| Pre-existing | 0 | 0 | 1 | 0 | 1 |
+
+---
+
+## Blocking Issues
+
+### CRITICAL
+(none)
+
+### HIGH
+
+**1. Missing CURRENT_TASK_ID validation on early-exit path in stop hook** (Security + Architecture consensus)
+- **Files**: `scripts/autobeat-stop-hook.sh:24-35`
+- **Confidence**: 92% (3 reviewers flagged, consistent details)
+- **Severity**: HIGH
+- **Problem**: The early-exit path (when `RESPONSE` is empty) resolves `CURRENT_TASK_ID` from tmux/env without validating it against the regex `^[a-z0-9][a-z0-9_-]*$`, unlike the main path at line 43. A malicious task ID containing path traversal (e.g., `../../etc`) bypasses validation and writes `.exit` to an arbitrary directory.
+- **Proposed Fix**: Add validation guards before sentinel write in early-exit block:
+```bash
+if [ -z "$RESPONSE" ]; then
+  TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+  CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+  [ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
+  # ADD VALIDATION
+  [[ "$CURRENT_TASK_ID" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || exit 0
+  SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
+  [ -z "$SESSIONS_DIR" ] && exit 0
+  [[ "$SESSIONS_DIR" =~ \.\. ]] && exit 0
+  if [ -n "$CURRENT_TASK_ID" ] && [ -n "$SESSIONS_DIR" ]; then
+    TASK_DIR="$SESSIONS_DIR/$CURRENT_TASK_ID"
+    mkdir -p "$TASK_DIR"
+    echo "1" > "$TASK_DIR/.exit.tmp"
+    mv "$TASK_DIR/.exit.tmp" "$TASK_DIR/.exit"
+  fi
+  exit 0
+fi
+```
+
+**2. configureAgentHook can throw instead of returning Result** (Reliability consensus)
+- **Files**: `src/cli/commands/init.ts:201-202`
+- **Confidence**: 92%
+- **Severity**: HIGH
+- **Problem**: Function declares `Result<void, string>` return type but calls `deps.writeFile(tmpPath, content)` and `deps.renameFile(tmpPath, configPath)` without try/catch. Disk errors (permissions, ENOSPC) throw uncaught, crashing `runInit` despite JSDoc promise that "Hook config failures are non-fatal."
+- **Proposed Fix**: Wrap file operations in try/catch:
+```typescript
+try {
+  deps.writeFile(tmpPath, content);
+  deps.renameFile(tmpPath, configPath);
+} catch (e) {
+  return err(`Failed to write ${agentType} config: ${e instanceof Error ? e.message : String(e)}`);
+}
+```
+
+**3. Duplicate tmux session + task ID resolution in stop hook** (Performance + Complexity + Consistency consensus)
+- **Files**: `scripts/autobeat-stop-hook.sh:24-28` and `38-41`
+- **Confidence**: 90% (4 reviewers flagged as HIGH/MEDIUM with DRY concern)
+- **Severity**: HIGH (when combined with missing validation fix)
+- **Problem**: Both early-exit and main paths call `tmux display-message` and `tmux show-environment` separately. Each subprocess is ~5-20ms. More importantly, duplicated logic means validation fixes must be applied twice, increasing regression risk.
+- **Proposed Fix**: Extract resolution into a shell function or move above both branches:
+```bash
+TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+[ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
+SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
+
+if [ -z "$RESPONSE" ]; then
+  # Use already-resolved vars...
+  exit 0
+fi
+# Main path uses same vars...
+```
+
+**4. Synthetic TmuxSpawnConfig in prepareForReuse uses dummy fields that bypass type safety** (Architecture)
+- **Files**: `src/implementations/tmux/tmux-connector.ts:370-378`
+- **Confidence**: 82%
+- **Severity**: HIGH
+- **Problem**: `prepareForReuse()` constructs a synthetic `TmuxSpawnConfig` with `command: ''`, `agentArgs: []`, `agent: 'claude' as const` to satisfy `buildActiveSession()`. The comment documents these fields are unused, but this creates coupling risk: any future change to `buildActiveSession` that reads these fields would silently receive bogus values.
+- **Proposed Fix**: Extract narrower parameter type:
+```typescript
+interface BuildActiveSessionConfig {
+  readonly taskId: TaskId;
+  readonly sessionsDir: string;
+  readonly staleness?: Partial<StalenessConfig>;
+  readonly persistent?: boolean;
+}
+// Then: buildActiveSession(config: BuildActiveSessionConfig)
+```
+
+**5. Stop hook .seq read-increment-write is not atomic** (Reliability)
+- **Files**: `scripts/autobeat-stop-hook.sh:56-58`
+- **Confidence**: 82%
+- **Severity**: HIGH (message loss risk)
+- **Problem**: Sequence counter reads (`cat`), increments in bash, and writes without locking. Concurrent Stop hook invocations (possible if agent produces rapid outputs) would read the same seq value, producing identical sequence numbers and causing message file overwrites.
+- **Mitigating Factor**: Claude Code's Stop hook fires synchronously once per turn, so concurrent invocations are unlikely in practice. However, this is an implicit assumption not enforced at runtime.
+- **Proposed Fix**: Use flock with fallback or document the assumption explicitly:
+```bash
+if command -v flock >/dev/null 2>&1; then
+  SEQ=$(flock "$SEQ_FILE.lock" bash -c "SEQ=\$(cat '$SEQ_FILE' 2>/dev/null || echo 0); SEQ=\$((SEQ + 1)); echo \$SEQ > '$SEQ_FILE'; echo \$SEQ")
+else
+  # Document: Stop hook invocations are synchronous per turn; concurrent writes unlikely
+  SEQ=$(cat "$SEQ_FILE" 2>/dev/null || echo 0)
+  SEQ=$((SEQ + 1))
+  echo "$SEQ" > "$SEQ_FILE"
+fi
+```
+
+---
+
+## Should-Fix Issues (Can be addressed in follow-up if unblocking is urgent)
+
+### MEDIUM
+
+**1. `configureAgentHook` idempotency check has 4-level nesting** (Complexity)
+- **Files**: `src/cli/commands/init.ts:161-172`
+- **Confidence**: 85%
+- **Category**: Should Fix
+- **Problem**: Nested `.some()` with two layers of type narrowing reaches 4 levels of indentation, making logic harder to follow.
+- **Proposed Fix**: Extract into named predicate:
+```typescript
+function hasStopHookCommand(stopHooks: unknown[]): boolean {
+  return stopHooks.some((entry) => {
+    if (typeof entry !== 'object' || entry === null) return false;
+    const e = entry as Record<string, unknown>;
+    if (!Array.isArray(e.hooks)) return false;
+    return (e.hooks as unknown[]).some((h) => {
+      if (typeof h !== 'object' || h === null) return false;
+      const hookEntry = h as Record<string, unknown>;
+      return hookEntry.type === 'command' && hookEntry.command === STOP_HOOK_COMMAND;
+    });
+  });
+}
+```
+
+**2. Stale comments referencing removed `session.exited` boolean** (Consistency + TypeScript + Regression)
+- **Files**: `src/implementations/tmux/tmux-connector.ts:526-530` and `281`
+- **Confidence**: 95% (4 reviewers flagged)
+- **Category**: Should Fix
+- **Problem**: Comments still reference `session.exited` (old boolean) instead of `session.state` (new enum). The code is correct but documentation drift will confuse future readers about the actual guard logic.
+- **Proposed Fix**: Update comments to match new state model:
+```typescript
+// Line 526-530:
+// No debounce needed here: handleSentinel() checks session.state !== 'active'
+// synchronously at the top of the event-loop tick. Because
+// triggerExit() sets session.state to 'parked' or 'exited' before returning,
+// any platform double-fire of the same sentinel file is a no-op —
+// the second callback sees state !== 'active' and returns immediately.
+```
+
+**3. Misleading JSDoc: `persistent` "has no effect" contradicts actual usage** (Consistency + Architecture)
+- **Files**: `src/implementations/base-agent-adapter.ts:99-102`
+- **Confidence**: 82%
+- **Category**: Should Fix
+- **Problem**: JSDoc states `persistent` "has no effect" but the option is actively used by caller for session lifecycle (park vs. destroy). Comment implies option is vestigial; readers might remove it.
+- **Proposed Fix**: Clarify distinction between adapter-level and connector-level behavior:
+```typescript
+* DECISION: Wrapper pipeline mode (--print/--quiet based) has been removed.
+* All tmux sessions are interactive; output is captured via the Stop hook.
+* The `persistent` option no longer affects CLI arg generation (all sessions
+* use the interactive path), but it is still passed through to
+* TmuxSpawnCoreConfig by the caller for session lifecycle control
+* (park vs destroy on sentinel).
+```
+
+**4. `if (prompt)` guard in launchAndRegister is now dead code** (Architecture + Regression)
+- **Files**: `src/implementations/event-driven-worker-pool.ts:658`
+- **Confidence**: 85%
+- **Category**: Should Fix
+- **Problem**: Comment correctly states "prompt is never empty for fresh spawn" after removing wrapper pipeline. The `if (prompt)` guard is dead code that suggests an optional path still exists.
+- **Proposed Fix**: Remove conditional and always execute sendKeys:
+```typescript
+// All sessions use interactive mode — prompt is always present.
+const sendResult = this.tmuxConnector.sendKeys(handle, prompt + '\n');
+```
+
+---
+
+## Pre-existing Issues (Not Blocking)
+
+**1. No assertion on `AUTOBEAT_SESSIONS_DIR` propagation in reuse path** (Reliability)
+- **Files**: `src/implementations/tmux/tmux-connector.ts:348`
+- **Confidence**: 82%
+- **Problem**: `prepareForReuse` creates a new task directory but does not verify `AUTOBEAT_SESSIONS_DIR` is set correctly in the tmux session. Correctness depends on `sessionsDir` being immutable across the session lifetime (true in practice but not asserted).
+- **Status**: Noted for future work; does not block this PR.
+
+---
+
+## Convergence Status
+
+**Cycle 1 (Initial Review)**
+
+### Convergent Findings (Multiple reviewers agree)
+| Finding | Reviewers | Issue Count |
+|---------|-----------|-------------|
+| Stop hook early-exit path missing task ID validation | Security + Architecture | 1 HIGH |
+| Stop hook task ID/session resolution duplicated | Performance + Complexity + Consistency | 1 HIGH |
+| configureAgentHook missing try/catch for Result contract | Reliability | 1 HIGH |
+| Stop hook .seq counter non-atomic | Reliability | 1 HIGH |
+| Synthetic TmuxSpawnConfig type safety gap | Architecture | 1 HIGH |
+| Stale comments referencing session.exited | Consistency + TypeScript + Regression | 2 MEDIUM |
+| Misleading `persistent` JSDoc | Consistency + Architecture | 1 MEDIUM |
+| `configureAgentHook` nesting complexity | Complexity | 1 MEDIUM |
+| Dead code `if (prompt)` guard | Architecture + Regression | 1 MEDIUM |
+
+### Divergent Findings (Reviewers disagree on severity)
+| Finding | Source A | Source B | Resolution |
+|---------|----------|---------|------------|
+| Stop hook shell script duplication | Consistency (MEDIUM) | Performance (HIGH when combined with validation fix) | Treat as HIGH because fixing validation requires addressing duplication |
+| Orphaned .tmp file on rename failure | Reliability (MEDIUM) | Not flagged by others | Trust Reliability assessment; recommend fix in error path |
+| prepareForReuse directory cleanup on buildActiveSession failure | Reliability (MEDIUM) | Not flagged by others | Trust Reliability assessment; add cleanup guard |
+
+---
+
+## Quality Assessment
+
+**Strengths**:
+- Architectural refactoring is clean: removes 1,187 lines of wrapper pipeline code, replaces with cleaner Stop hook
+- New code follows project patterns: Result types throughout, proper DI, no mutations, bounded iterations
+- Test suite thoroughly covers behavioral changes (stop-hook integration with 29 tests, regression coverage B1-1 to B1-5)
+- SessionState enum (active|parked|exited) correctly models three-state lifecycle with proper state transitions
+- All guards for non-persistent task path preserved (SessionState correctly branches on persistent flag)
+- Port interface abstraction well-maintained (TmuxConnectorPort additions are additive, mock updated)
+
+**Weaknesses**:
+- Security validation gap in shell script (early-exit path different from main path)
+- Error handling contract broken (Result type promised, throws delivered)
+- Documentation drift (comments reference pre-refactor mechanisms)
+- Type safety bypass (synthetic config with dummy fields)
+- Atomicity assumptions not enforced (sequence counter)
+
+---
+
+## Action Plan
+
+**Before Merge (BLOCKING)**:
+1. Add task ID validation to stop hook early-exit path (line 24-35) — matches main path validation
+2. Fix `configureAgentHook` to return `err()` instead of throwing on disk write/rename failures
+3. Extract stop hook task ID/session resolution to avoid duplication and simplify validation fix
+4. Consolidate jq calls in stop hook hot path (recommended but can be follow-up if time-critical)
+5. Consider atomicity of .seq counter (flock with fallback or explicit assumption documentation)
+
+**Should-Fix (Can be follow-up PR if unblocking is urgent)**:
+1. Extract nested predicate in `configureAgentHook` idempotency check
+2. Update stale comments referencing removed `session.exited` boolean
+3. Clarify `persistent` JSDoc to distinguish adapter vs. connector behavior
+4. Remove dead `if (prompt)` guard in `launchAndRegister`
+5. Extract narrower `BuildActiveSessionConfig` parameter type for `buildActiveSession()`
+
+---
+
+## Recommendation Details
+
+**CHANGES_REQUESTED** because:
+1. HIGH-severity security gap (task ID validation) requires fix
+2. HIGH-severity reliability issue (uncaught throws in config hook) breaks contract
+3. HIGH-severity duplication (shell script) increases risk of incomplete fixes
+4. HIGH-severity atomicity gap (sequence counter) risks message loss
+5. HIGH-severity type safety gap (synthetic config) creates future coupling risk
+
+Once the five HIGH-severity blocking issues are addressed, the PR is ready for merge. The should-fix items strengthen the codebase but do not block approval.
+

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/security.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/security.md
@@ -1,0 +1,72 @@
+# Security Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Missing CURRENT_TASK_ID validation on early-exit path in stop hook** - `scripts/autobeat-stop-hook.sh:24-34`
+**Confidence**: 85%
+- Problem: When `RESPONSE` is empty (lines 24-35), the script reads `CURRENT_TASK_ID` from the tmux environment or the `AUTOBEAT_TASK_ID` env var and uses it directly in a path (`$SESSIONS_DIR/$CURRENT_TASK_ID`) without the regex validation (`^[a-z0-9][a-z0-9_-]*$`) that is applied on the main path at line 43. A malicious or malformed task ID containing path traversal sequences (e.g., `../../etc`) would bypass the validation and write `.exit` to an arbitrary directory.
+- Fix: Add the same validation check before using CURRENT_TASK_ID on the early-exit path:
+```bash
+if [ -z "$RESPONSE" ]; then
+  TMUX_SESSION=$(tmux display-message -p '#{session_name}' 2>/dev/null)
+  CURRENT_TASK_ID=$(tmux show-environment -t "$TMUX_SESSION" AUTOBEAT_TASK_ID 2>/dev/null | cut -d= -f2-)
+  [ -z "$CURRENT_TASK_ID" ] && CURRENT_TASK_ID="${AUTOBEAT_TASK_ID:-}"
++ [[ "$CURRENT_TASK_ID" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || exit 0
+  SESSIONS_DIR="${AUTOBEAT_SESSIONS_DIR:-}"
++ [ -z "$SESSIONS_DIR" ] && exit 0
++ [[ "$SESSIONS_DIR" =~ \.\. ]] && exit 0
+  if [ -n "$CURRENT_TASK_ID" ] && [ -n "$SESSIONS_DIR" ]; then
+    TASK_DIR="$SESSIONS_DIR/$CURRENT_TASK_ID"
+    mkdir -p "$TASK_DIR"
+    echo "1" > "$TASK_DIR/.exit.tmp"
+    mv "$TASK_DIR/.exit.tmp" "$TASK_DIR/.exit"
+  fi
+  exit 0
+fi
+```
+
+### MEDIUM
+
+**Stop hook reads from stdin without size limit** - `scripts/autobeat-stop-hook.sh:8`
+**Confidence**: 80%
+- Problem: `HOOK_DATA=$(cat)` reads the entire stdin into a shell variable with no upper-bound check. If the calling CLI delivers a very large payload (e.g., a large transcript embedded in `.last_assistant_message`), this can exhaust memory or cause the hook to hang. While the caller (Claude Code/Codex CLI) is trusted, a defense-in-depth approach would cap the input.
+- Fix: Consider limiting the read to a reasonable maximum (e.g., 10MB):
+```bash
+HOOK_DATA=$(head -c 10485760)
+```
+  Alternatively, if the CLIs guarantee bounded payloads, document this assumption with a comment.
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **SESSIONS_DIR path validation regex is minimal** - `scripts/autobeat-stop-hook.sh:48` (Confidence: 65%) — The `..` check rejects literal `..` anywhere in the path but does not handle URL-encoded or symlink-based traversal. In practice the env var comes from the trusted shim (line 73 of tmux-hooks.ts), so this is low-risk, but a stricter absolute-path assertion (`[[ "$SESSIONS_DIR" == /* ]]`) would be more robust.
+
+- **Hook config writes to user home directory without confirming ownership** - `src/cli/commands/init.ts:92-94` (Confidence: 62%) — `AGENT_HOOK_CONFIG_PATHS` resolves to `~/.claude/settings.json` and `~/.codex/hooks.json`. On shared systems or when HOME is overridden, this could write to unintended locations. The `mode: 0o600`/`0o700` mitigates exposure, but a HOME-is-expected-user check would add defense-in-depth.
+
+- **Backup file (.bak) not permission-restricted to 0o600** - `src/cli/commands/init.ts:183-185` (Confidence: 60%) — The backup write uses the same `deps.writeFile` (mode 0o600), which is correct. However if the original file had broader permissions, the backup atomically replaces the content without adjusting the original's perms. Not a real issue given the implementation always writes fresh with 0o600.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Security Score**: 8/10
+**Recommendation**: CHANGES_REQUESTED
+
+The overall security posture of this PR is strong. The existing patterns (SAFE_PATH_REGEX validation, singleQuoteToken escaping, TASK_ID_REGEX enforcement, FILE_MODE 0o700/0o600, atomic writes via tmp+rename) are well-maintained through the refactoring. The new `configureAgentHook` function uses proper file permissions and atomic writes. The removal of the wrapper pipeline eliminates an entire class of shell-injection surface area (the old `buildWrapperScript` with embedded agent output piping).
+
+The one HIGH finding (missing task ID validation on the early-exit path of the stop hook) is a straightforward fix that should be addressed before merge — it is an inconsistency where the main code path validates but the error/empty-response path does not.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/testing.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/testing.md
@@ -1,0 +1,72 @@
+# Testing Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Real `setTimeout` in async test assertion — potential flakiness** - `tests/unit/implementations/tmux/tmux-connector.test.ts:2859-2866`
+**Confidence**: 82%
+- Problem: The `prepareForReuse` test at line 2859 uses a real `setTimeout` inside a `new Promise()` wrapper to wait for async message delivery. Unlike other tests in this file that use `vi.waitFor()` or `sleep()` from fixtures, this test creates a raw setTimeout with 100ms. Since the file uses `vi.useFakeTimers()` in some describe blocks but not this one, the real timer will work — but the pattern is inconsistent with the rest of the file and could become flaky under CI load.
+- Fix: Replace with the `vi.waitFor()` pattern used elsewhere in this file:
+```typescript
+// Instead of:
+return new Promise<void>((resolve) => {
+  setTimeout(() => {
+    expect(newOnOutput).toHaveBeenCalledWith(...);
+    resolve();
+  }, 100);
+});
+
+// Use:
+await vi.waitFor(() => expect(newOnOutput).toHaveBeenCalledWith(
+  expect.objectContaining({ sequence: 1, type: 'result', content: 'hello' }),
+), { timeout: 300 });
+```
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Missing test for `prepareForReuse` on non-parked session** - `tests/unit/implementations/tmux/tmux-connector.test.ts:2690` (Confidence: 72%) — The test suite covers `prepareForReuse` after parking and after `initTaskDirectory` failure, but does not test calling `prepareForReuse` on a session that is still in `active` state (should it be rejected or silently succeed?). The implementation has a guard for duplicate taskId but not for non-parked state.
+
+- **Integration test `stop-hook.test.ts` relies on `process.env` spreading** - `tests/integration/tmux/stop-hook.test.ts:78` (Confidence: 65%) — The `runHook()` helper filters and spreads `process.env` which is fine, but the `PATH` from the test environment leaks into the hook execution. If a CI runner has a minimal PATH that excludes `jq` or `date`, some tests could fail with misleading errors. This is mitigated by the test not requiring `jq` (the hook uses only bash builtins and `date`).
+
+- **No negative test for `configureAgentHook` with missing parent directory** - `tests/unit/cli-init.test.ts:711` (Confidence: 64%) — The `configureAgentHook` test suite verifies creation, merge, idempotency, backup, and invalid JSON, but does not test the case where the config file's parent directory does not exist (e.g., `~/.claude/` not present). The `ensureDir` dep should handle this, but the behavior when it fails is untested.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Testing Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+## Assessment
+
+The test suite for this PR is thorough and well-structured. Key strengths:
+
+1. **Comprehensive behavioral coverage**: The stop-hook integration tests cover syntax validation, guard behavior, both agent paths (Codex/Claude), contract validation, special characters, sequence numbering, sentinel mapping, security (path traversal), atomicity, and fail-fast — 29 tests with real filesystem and bash execution.
+
+2. **Proper test architecture**: Tests use dependency injection throughout (no `vi.mock()` in the unit tests for `cli-init.test.ts`). The `HookConfigDeps` interface enables real filesystem testing with tmpdir isolation.
+
+3. **Regression coverage**: The worker pool tests include explicit regression tests for known bugs (B1-1 through B1-5, timer leaks, stale closures) — these are labeled and documented.
+
+4. **State machine testing**: The SessionState enum (active/parked/exited) is tested at both the connector level (persistent=true parks, persistent=false destroys, staleness skips parked) and the worker pool level (prepareForReuse ordering, fallback on failure).
+
+5. **Deleted wrapper tests replaced**: The 348-line `hook-script-generation.test.ts` (testing the removed wrapper pipeline) is properly deleted. Its behavioral coverage is replaced by the 651-line `stop-hook.test.ts` that tests the new unified hook script with real bash execution.
+
+6. **Mock fixture updated**: `createMockTmuxConnector` properly includes `prepareForReuse: vi.fn()` so all consumer tests compile and can exercise the new method.
+
+The single blocking item is minor (inconsistent async test pattern) and does not affect correctness today, but could cause flakiness under CI pressure.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/typescript.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1823/typescript.md
@@ -1,0 +1,60 @@
+# TypeScript Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Unnecessary type assertion `'active' as SessionState`** - `src/implementations/tmux/tmux-connector.ts:491`
+**Confidence**: 90%
+- Problem: The string literal `'active'` is directly assignable to the `SessionState` union type (`'active' | 'parked' | 'exited'`) without a cast. The `as SessionState` assertion is redundant and suppresses future type checking if the union is refactored.
+- Fix: Remove the assertion — TypeScript infers the correct type:
+```typescript
+state: 'active',
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Stale comments referencing removed `session.exited` boolean (2 occurrences)** - Confidence: 95%
+- `src/implementations/tmux/tmux-connector.ts:526-530` — Comment says "handleSentinel() reads session.exited" and "triggerExit() sets session.exited = true before returning"
+- `src/implementations/tmux/tmux-connector.ts:281` — Comment says "The exited flag (set above) prevents watchers..."
+- Problem: These comments reference `session.exited` which was replaced by `session.state` (`SessionState` enum) in this PR. All code paths were updated but two JSDoc/inline comments still reference the old boolean pattern. This creates cognitive dissonance for future readers.
+- Fix: Update comments to reference the new state model:
+  - Line 526-530: "handleSentinel() checks `session.state !== 'active'`" / "triggerExit() sets `session.state` to 'parked' or 'exited' before returning"
+  - Line 281: "The 'exited' state (set above) prevents watchers and staleness ticks from re-firing..."
+
+## Pre-existing Issues (Not Blocking)
+
+(None at CRITICAL severity in unchanged code.)
+
+## Suggestions (Lower Confidence)
+
+- **Synthetic config lacks explicit type annotation** - `src/implementations/tmux/tmux-connector.ts:370` (Confidence: 65%) — The `syntheticConfig` object passed to `buildActiveSession()` relies on structural typing without an explicit `TmuxSpawnConfig` annotation. Adding `const syntheticConfig: TmuxSpawnConfig = {...}` would surface compile-time errors if `TmuxSpawnConfig` gains new required fields. However, the project typechecks cleanly today and the inline comment documents intent.
+
+- **`configureAgentHook` uses `as Record<string, unknown>` casts for nested JSON** - `src/cli/commands/init.ts:145,156,163,167` (Confidence: 60%) — The JSON parsing code uses several `as Record<string, unknown>` casts after partial type guards. A Zod schema or a proper type guard function would provide runtime validation and type narrowing without casts. However, the guards preceding each cast are adequate for the limited JSON structure expected.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**TypeScript Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR demonstrates strong type safety practices overall:
+- Proper discriminated union (`SessionState`) replacing a boolean for tri-state lifecycle
+- Correct use of `Result<T, E>` throughout new code
+- No `any` types introduced
+- No non-null assertions
+- Type-only imports used correctly
+- Proper structural compatibility checked (typecheck passes clean)
+- Good use of `readonly` modifiers on interfaces and config objects
+
+The two conditions are minor: fix the stale comments and remove the unnecessary type assertion. Neither blocks merge but both should be addressed for consistency with the rest of the well-documented codebase.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/architecture.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/architecture.md
@@ -1,0 +1,72 @@
+# Architecture Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+**Prior Resolutions**: Cycle 1 resolved 17/18 issues; 1 deferred (reuseSession complexity).
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Synthetic config uses dummy `agent` field that could break future buildActiveSession callers** - `src/implementations/tmux/tmux-connector.ts:375-383`
+**Confidence**: 82%
+- Problem: `prepareForReuse()` constructs a synthetic `TmuxSpawnConfig` with `agent: 'claude' as const` as a placeholder. The comment explains that `buildActiveSession()` does not currently read `config.agent`, but this is a fragile coupling: any future change to `buildActiveSession()` that reads `agent` will silently receive the wrong value for Codex sessions. The type system provides no guard against this drift because the value satisfies the `TmuxAgentType` constraint.
+- Impact: If `buildActiveSession()` ever starts using `config.agent` (e.g., for agent-specific staleness tuning or per-agent logging), Codex sessions reused via `prepareForReuse()` would be silently misidentified as Claude sessions. This is a design-time coupling risk, not a runtime bug today.
+- Fix: Either (a) thread the real `agent` value through via the `PersistentSessionEntry` or the `TmuxHandle` (preferred — the data is available at spawn time), or (b) extract the four fields `buildActiveSession` actually reads into a narrower interface so the type system prevents accidental field reads. Option (a) is simpler:
+  ```typescript
+  // In PersistentSessionEntry, add: agent: TmuxAgentType
+  // In prepareForReuse, use: agent: entry.agent ?? 'claude'
+  ```
+  However, since the comment is explicit and accurate today, this is a should-fix rather than a hard block. Document it as a known coupling point at minimum.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`reuseSession` creates new callbacks BEFORE taskIdRef.current is updated** - `src/implementations/event-driven-worker-pool.ts:443`
+**Confidence**: 83%
+- Problem: At line 443, `this.createCallbacks(entry.taskIdRef)` is called and the resulting callbacks are passed to `prepareForReuse()`. At this point, `entry.taskIdRef.current` still holds the OLD task ID (the update to `task.id` happens later in the remap step at line 520 for the re-registration path or line 575 for the in-place remap path). The callbacks close over `taskIdRef` (a ref object, not a value copy), so once `taskIdRef.current` is updated, the callbacks will route to the correct task ID. However, there is a window between `prepareForReuse()` returning and the remap step where the callbacks embedded in the new `ActiveSession` read the stale old task ID from `taskIdRef.current`.
+- Impact: If the agent produces output in the ~0ms between `prepareForReuse()` returning and `taskIdRef.current` being updated (unlikely given the /clear settle delay already passed, but not impossible if the agent has buffered output), that output would be attributed to the old task ID. In practice the risk is very low because the agent has not received the new prompt yet (sendKeys happens after the remap), but the ordering assumption is subtle and fragile.
+- Fix: Move the `taskIdRef.current = task.id` update to immediately after the settle delay (line 434) and before `createCallbacks()`, so the ref is already correct when the callbacks are embedded in the new ActiveSession. The remap step already handles the ref update defensively, so doing it earlier is safe:
+  ```typescript
+  // After the settle delay (line 433):
+  entry.taskIdRef.current = task.id;
+  const reuseCallbacks = this.createCallbacks(entry.taskIdRef);
+  ```
+
+## Pre-existing Issues (Not Blocking)
+
+No CRITICAL pre-existing issues found.
+
+## Suggestions (Lower Confidence)
+
+- **`void agent` parameter in `defaultConfigureHooks`** - `src/cli/commands/init.ts:674` (Confidence: 65%) -- The `agent` parameter is accepted but explicitly voided. This suggests the function signature was designed for future extensibility, but a parameter that is always ignored is a code smell. If agent-specific hook configuration is expected soon, a TODO comment would clarify intent. If not, removing the parameter avoids confusion.
+
+- **Old `ActiveSession` for the previous iteration is never cleaned up from `activeSessions` during the `parked` -> `prepareForReuse` transition** - `src/implementations/tmux/tmux-connector.ts:959-966` (Confidence: 72%) -- When `triggerExit()` parks a persistent session, it calls `this.activeSessions.delete(taskId)` (line 966), which removes the old entry. `prepareForReuse()` then adds a new entry under `newTaskId`. This is correct for the activeSessions map. However, the old session's `sessionDir` is intentionally preserved (line 973 comment). Over many loop iterations, these directories accumulate until `cleanupPersistentSession()` is called at loop end. If a loop runs 100+ iterations, this could accumulate significant disk usage. The existing architecture handles this correctly -- just noting the accumulation pattern.
+
+- **`configureAgentHook` backup-before-modify does not catch exceptions from `ensureDir`** - `src/cli/commands/init.ts:135` (Confidence: 60%) -- `deps.ensureDir(configDir)` can throw but is not wrapped in try/catch with an `err()` return. All other disk operations in this function are wrapped. If `ensureDir` fails (e.g., permission denied on `~/.claude/`), it will throw an uncaught exception. However, `configureHooks` is called from `runHookConfigure` which does handle the Result, so the calling chain may absorb this. The `createDefaultHookConfigDeps` implementation uses `mkdirSync` with `recursive: true` which is quite resilient.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 0 | - |
+| Should Fix | - | 0 | 1 | - |
+| Pre-existing | - | - | 0 | 0 |
+
+**Architecture Score**: 8/10
+
+The architecture changes are well-considered and represent a significant simplification. The removal of the wrapper pipeline (~1,187 lines net reduction) eliminates an entire code path that was redundant with the interactive (Stop hook) approach. Key architectural strengths:
+
+1. **Clean unification**: All sessions now follow a single interactive mode path, eliminating the persistent/non-persistent branching in adapter, connector, and worker pool.
+2. **Proper separation of concerns**: The Stop hook is an external script (`autobeat-stop-hook.sh`) registered as an npm bin entry, cleanly separating output capture from the Node.js process. This is a better boundary than the in-process wrapper pipeline.
+3. **Port interface evolution**: `TmuxConnectorPort` gains `prepareForReuse()` which keeps the reuse protocol behind the port boundary (applies ADR-003 spirit -- pre-existing design gaps tracked separately). The WorkerPool does not need to know about task directories, sequence counters, or watcher lifecycle.
+4. **SessionState enum**: Replacing the boolean `exited` field with a three-state enum (`active` | `parked` | `exited`) correctly models the lifecycle and makes guard conditions self-documenting.
+5. **`TmuxHooksPort.initTaskDirectory()`**: New method correctly separates "create iteration directory" from "generate setup shim," avoiding shim regeneration on reuse.
+6. **Hook configuration in init**: `configureAgentHook()` follows dependency injection (injectable `HookConfigDeps`), uses atomic writes (`.tmp` + rename), creates backups, and is idempotent.
+
+The deferred issue from Cycle 1 (reuseSession complexity at 111 lines / 9 steps) is acknowledged. The new `prepareForReuse()` step increases the step count but the extracted `restartTimersForWorker()` helper partially offsets the complexity.
+
+**Recommendation**: APPROVED_WITH_CONDITIONS
+- Fix the synthetic config coupling in `prepareForReuse()` (HIGH) before merge
+- Consider fixing the taskIdRef ordering in `reuseSession` (MEDIUM) before merge

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/complexity.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/complexity.md
@@ -1,0 +1,86 @@
+# Complexity Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31T19:07:00Z
+**Prior Resolutions**: Cycle 1 deferred reuseSession (111 lines / 9 steps) — assessed as acceptable due to distinct error paths per step.
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**configureAgentHook is 96 lines with mixed concerns** - `src/cli/commands/init.ts:128-223`
+**Confidence**: 85%
+- Problem: This function handles five distinct responsibilities in a single body: (1) read and parse existing config, (2) idempotency check via `hasStopHookCommand`, (3) backup creation, (4) config deep-merge, and (5) atomic write with rollback. At 96 lines this exceeds the 50-line warning threshold for function length. The nesting within `hasStopHookCommand` (nested `.some()` inside `.some()`) reaches 4 levels of callback depth.
+- Fix: Extract the five phases into named helpers. `hasStopHookCommand` is already a local function (good), but the remaining four phases could be extracted:
+  ```typescript
+  function readExistingConfig(configPath: string, agentType: string, deps: HookConfigDeps): Result<Record<string, unknown>, string> { ... }
+  function backupIfNeeded(configPath: string, deps: HookConfigDeps): void { ... }
+  function atomicWriteConfig(configPath: string, content: string, agentType: string, deps: HookConfigDeps): Result<void, string> { ... }
+  ```
+  This would bring `configureAgentHook` under 30 lines and make each phase independently testable.
+
+### MEDIUM
+
+**remapExistingWorkerForReuse has 8 side-effects in a single method** - `src/implementations/event-driven-worker-pool.ts:555-608`
+**Confidence**: 82%
+- Problem: This 54-line method performs 8 sequential mutation steps: (1) delete flushingInProgress, (2) delete taskToWorker, (3) set taskToWorker, (4) update taskIdRef, (5) update worker.task, (6) update worker.taskId, (7) DB updateTaskId, (8) restartTimersForWorker. While each step is simple, the combined cognitive load makes it hard to verify correctness at a glance. The risk is not in any single step but in step ordering — reordering any two of these could introduce subtle bugs.
+- Fix: Consider grouping the mutations into two named sub-operations with a comment fence that makes the ordering invariant explicit:
+  ```typescript
+  // Phase 1: Remap identity (must complete before Phase 2 reads new taskId)
+  this.remapWorkerIdentity(worker, task, workerId, entry);
+  // Phase 2: Restart timers under new identity
+  this.restartTimersForWorker(worker);
+  ```
+  This is a readability improvement, not a structural refactor — the method is doing the right thing, it just takes effort to verify.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**runInit is 79 lines with branching paths for interactive vs non-interactive** - `src/cli/commands/init.ts:381-459`
+**Confidence**: 80%
+- Problem: `runInit` handles three major paths: non-interactive (`--agent` flag), non-TTY guard, and interactive (prompt-based). The function length (79 lines) is at the upper end of the warning range, and the branching between paths makes it moderately difficult to follow the flow. The skill install sub-flow call appears in two branches with slightly different follow-up logic (lines 400-410 and 448-455), creating near-duplication.
+- Fix: The two skill-install + hook-configure + return sequences (lines 400-410 and 448-458) could be extracted into a shared `finalizeInit(agent, status, options, deps)` helper. This would reduce `runInit` by ~15 lines and eliminate the near-duplication.
+
+**runSkillInstall has 5 exit paths across 67 lines** - `src/cli/commands/init.ts:465-531`
+**Confidence**: 80%
+- Problem: The function has 5 early returns across interactive, non-interactive, and error paths. While each path is simple, the function requires reading all 67 lines to understand the complete set of outcomes. The conditional chain for determining `agents` (lines 475-503) uses four `if/else if` branches with different combinations of flags and TTY state.
+- Fix: Extract the agent-resolution logic into a dedicated `resolveTargetAgents()` helper that returns the agent list or a skip/cancel reason. This would simplify `runSkillInstall` to: resolve agents -> check existing -> copy.
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**event-driven-worker-pool.ts is 1,240 lines** - `src/implementations/event-driven-worker-pool.ts`
+**Confidence**: 85%
+- Problem: The file exceeds the 500-line critical threshold by 2.5x. While methods are individually well-extracted (spawn, kill, reuseSession, etc.), the file contains the full lifecycle for workers, persistent sessions, flushing, heartbeats, timeouts, and completion handling. This concentrates a large number of responsibilities into a single file.
+- Fix: Consider extracting timer management (heartbeat, timeout, flushing) into a `WorkerTimerManager` class, or persistent session lifecycle into a `PersistentSessionManager`. This is a significant refactor best done in a dedicated PR. The PR description notes a net -1,187 line reduction from removing the wrapper pipeline, so the overall direction is toward simplification.
+
+**tmux-connector.ts is 1,066 lines** - `src/implementations/tmux/tmux-connector.ts`
+**Confidence**: 85%
+- Problem: The file exceeds the 500-line critical threshold by 2x. It manages session lifecycle, staleness detection, message ordering/delivery, sentinel watching, and flush orchestration. The class has well-decomposed private methods but the sheer volume makes navigation difficult.
+- Fix: The staleness timer subsystem (restartSharedStalenessTimer, runSharedStalenessCheck, checkSessionStaleness, stopSharedStalenessTimer — ~90 lines) and message delivery subsystem (handleMessageFile, deliverPendingMessages, deliverSingle, forceDeliverRemaining, flushPendingFiles, parseMessageFile — ~150 lines) are both self-contained and could be extracted into collaborator classes injected via the constructor.
+
+## Suggestions (Lower Confidence)
+
+- **triggerExit dual-path complexity** - `src/implementations/tmux/tmux-connector.ts:946-1008` (Confidence: 70%) — The persistent vs non-persistent branches share flush/close/delete/timer/onExit steps in different orders. A shared "common teardown" helper that takes a mode parameter could reduce the near-duplication, though the ordering differences may make this impractical.
+
+- **hasStopHookCommand nested callbacks** - `src/cli/commands/init.ts:161-172` (Confidence: 65%) — The nested `.some()` inside `.some()` with type narrowing at each level reaches 4 indentation levels. Could be flattened with `Array.prototype.flatMap()` to reduce to a single `.some()` call.
+
+- **ActiveSession has 15 fields** - `src/implementations/tmux/tmux-connector.ts:107-143` (Confidence: 60%) — The interface carries session identity, watcher state, staleness config, message ordering state, and lifecycle flags. A sub-grouping (e.g., `MessageDeliveryState { lastDeliveredSeq, pendingMessages, nextExpectedSeq }`) could improve readability, though the current flat structure avoids an extra level of indirection on the hot path.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 0 | 0 |
+| Should Fix | 0 | 0 | 2 | 0 |
+| Pre-existing | 0 | 0 | 2 | 0 |
+
+**Complexity Score**: 6/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR achieves a net -1,187 line reduction by removing the wrapper pipeline, which is a meaningful complexity win. The new code (stop hook, init hook configuration, connector SessionState, prepareForReuse) is well-structured with clear extraction patterns already applied (buildActiveSession, startWatchers, createAndRegisterSession, etc.). The `reuseSession` 111-line deferral from Cycle 1 is acknowledged and the justification (distinct error paths per step) is reasonable.
+
+The one blocking HIGH is `configureAgentHook` at 96 lines with mixed concerns — this is new code that can be decomposed without risk. The two should-fix items in `init.ts` (`runInit` and `runSkillInstall`) are moderate improvements that would reduce near-duplication and simplify the agent-resolution branching.
+
+The file-length pre-existing issues (worker pool 1,240 lines, connector 1,066 lines) are informational — they predate this PR and extracting subsystems is best done in a dedicated refactor PR (applies ADR-003).

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/consistency.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/consistency.md
@@ -1,0 +1,89 @@
+# Consistency Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31T19:07:00Z
+**Prior Resolutions**: Cycle 1 resolved 17/18 issues (1 deferred). This is Cycle 2.
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Stale "wrapper" terminology in error code JSDoc** - `src/core/errors.ts:105`
+**Confidence**: 95%
+- Problem: The `TMUX_HOOK_FAILED` error code JSDoc still reads `"Failed to generate wrapper script or create session directory"`. This PR renamed the wrapper pipeline to setup shim and removed all wrapper-related code, but the error code description was not updated.
+- Fix: Update the JSDoc to match the new terminology:
+  ```typescript
+  /** Failed to generate setup shim or create session directory */
+  TMUX_HOOK_FAILED = 'TMUX_HOOK_FAILED',
+  ```
+
+**Stale "wrapper" comments in orchestrate-interactive.ts (4 occurrences)** - `src/cli/commands/orchestrate-interactive.ts:103,246,247,250`
+**Confidence**: 90%
+- Problem: Four comments in the interactive orchestrator still reference "wrapper scripts" and "wrapper":
+  - Line 103: `"which the wrapper scripts require"`
+  - Line 246: `"creates the tmux window + wrapper"`
+  - Line 247: `"output and exit signals from the wrapper"`
+  - Line 250: `"Output captured by wrapper"`
+  These are stale now that the wrapper pipeline has been replaced by the Stop hook + setup shim.
+- Fix: Update the comments to reference "setup shim" and "Stop hook" respectively:
+  ```
+  Line 103: "which the Stop hook requires"
+  Line 246: "creates the tmux window + setup shim"
+  Line 247: "output and exit signals from the Stop hook"
+  Line 250: "Output captured by Stop hook"
+  ```
+
+**Stale "wrapper" comment in tmux-hooks test** - `tests/unit/implementations/tmux/tmux-hooks.test.ts:54`
+**Confidence**: 85%
+- Problem: Comment reads `"independent of generateWrapper() tests"` but `generateWrapper()` has been removed and replaced by `generateSetupShim()`.
+- Fix: Update to `"independent of generateSetupShim() tests"`.
+
+**Stale "--output-format json" reference in usage-parser.ts** - `src/services/usage-parser.ts:7`
+**Confidence**: 85%
+- Problem: The usage-parser JSDoc states `"Claude spawns with --output-format json which appends a final result message"`. This PR removed `--output-format json` from the Claude adapter in favor of the Stop hook capturing output. The parser still works (it parses task output regardless of how it was captured), but the rationale comment is now misleading about how output is produced.
+- Fix: Update the comment:
+  ```
+  * Rationale: The Stop hook writes result messages as JSON files. When Claude
+  * emits a {"type":"result", ..., "usage": {...}, "total_cost_usd": ...} message,
+  * the parser extracts usage data from the captured output.
+  ```
+
+## Issues in Code You Touched (Should Fix)
+
+_No issues found._
+
+## Pre-existing Issues (Not Blocking)
+
+_No CRITICAL pre-existing issues found._
+
+## Suggestions (Lower Confidence)
+
+- **Section header comment in interactive-orchestrator test** - `tests/unit/interactive-orchestrator.test.ts:181` (Confidence: 65%) -- Comment `"Agent Adapter -- buildInteractiveArgs"` references the removed `buildInteractiveArgs` method. The section is empty (just a heading), so this is purely cosmetic.
+
+- **`void agent` pattern in `defaultConfigureHooks`** - `src/cli/commands/init.ts:674` (Confidence: 60%) -- `void agent` is used to suppress unused-parameter warnings. The codebase elsewhere uses `_agent` prefix convention for intentionally-unused parameters (e.g., `_path` in `getSystemPromptConfig`). However, the function does reference `agent` in its JSDoc as "for future extensibility" so this may be an intentional style choice to keep the parameter name readable.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 4 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Consistency Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+### Rationale
+
+This PR is an impressively consistent refactoring that removes the entire wrapper pipeline (-1,187 lines) and replaces it with a unified Stop hook + setup shim approach. The pattern changes are applied thoroughly:
+
+1. **Type renames**: `WrapperConfig` -> `SetupShimConfig`, `WrapperManifest` -> `SetupShimManifest`, `wrapperPath` -> `shimPath` are consistent across all production types, interfaces, and barrel exports.
+
+2. **State enum migration**: The `exited: boolean` -> `state: SessionState` transition is applied uniformly across all 8 guard sites in tmux-connector.ts (`handleMessageFile`, `onMessageFileChange`, `triggerExit`, `handleSentinel`, `runSharedStalenessCheck`, `destroy`, `dispose`, and the `flushPendingFiles` path).
+
+3. **Method removal**: `buildWrapperFlags()`, `buildInteractiveArgs()`, `buildArgs()`, and `generateWrapper()` are removed from both implementations and all tests. Replacement `buildTmuxArgs()` is used consistently.
+
+4. **Port extension**: `prepareForReuse()` is added to both `TmuxConnectorPort` (core interface) and `TmuxConnector` (implementation), with mock coverage in `createMockTmuxConnector`.
+
+5. **Test coverage**: Tests are comprehensively updated -- wrapper-mode tests are either removed or rewritten as interactive-mode tests with assertion polarity flipped (e.g., `toContain('--print')` -> `not.toContain('--print')`).
+
+The only consistency gap is stale "wrapper" terminology in comments and JSDoc across 4 files that were not part of the direct diff but reference concepts removed by this PR. These are non-blocking documentation-level issues (applies ADR-003 -- pre-existing doc gaps tracked separately).

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/performance.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/performance.md
@@ -1,0 +1,51 @@
+# Performance Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+**Prior Resolutions**: Cycle 1 (18 issues, 17 fixed, 1 deferred). This cycle focuses on new/remaining issues only.
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Multiple jq subprocess spawns per Stop hook invocation** - `scripts/autobeat-stop-hook.sh:10,17,68,73`
+**Confidence**: 85%
+- Problem: The Stop hook runs on every agent turn (hot path). In the Codex path, HOOK_DATA is piped to jq 3 times (lines 10, 68, 73) spawning 3 separate jq subprocesses. In the Claude transcript fallback path, up to 5 jq invocations occur (lines 10, 17, 20, 68, 73). Each `printf '%s' "$HOOK_DATA" | jq ...` forks a subshell, copies up to 10MB of data through a pipe, and execs jq. On macOS, fork+exec is ~1-2ms each; with 3-5 invocations this adds 3-10ms of latency per agent turn.
+- Impact: Per-turn overhead adds up in loops and rapid-fire task sequences. The cost is small in absolute terms but avoidable. For a 100-iteration loop, this is 300-1000ms of cumulative subprocess overhead.
+- Fix: Consolidate the Codex path into a single jq invocation that extracts all needed fields at once:
+  ```bash
+  # Single jq call for Codex path (most common):
+  eval "$(printf '%s' "$HOOK_DATA" | jq -r '
+    "RESPONSE=\(.last_assistant_message // "" | @sh)",
+    "STOP_REASON=\(.stop_reason // "end_turn" | @sh)"
+  ' 2>/dev/null)"
+  ```
+  This reduces 3 jq invocations to 1 for the Codex path. The Claude transcript path would still need its separate jq -s call (line 20), but the STOP_REASON extraction (line 73) would already be handled. Net reduction: 2 fewer jq spawns in Codex path, 1 fewer in Claude path.
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Double file read in configureAgentHook backup path** - `src/cli/commands/init.ts:140,184` (Confidence: 65%) -- The config file is read once at line 140 for parsing and again at line 184 for backup creation. The already-read `raw` string from line 140 could be reused for the backup write. However, this is a cold CLI init path (one-shot, not hot), so the impact is negligible.
+
+- **HOOK_DATA stored as bash variable up to 10MB** - `scripts/autobeat-stop-hook.sh:8` (Confidence: 60%) -- `HOOK_DATA=$(head -c 10485760)` stores up to 10MB in a bash variable. Each `printf '%s' "$HOOK_DATA" | jq` copies this through a pipe. In practice, hook payloads are typically small (a few KB), but the 10MB cap means the worst case involves copying 10MB * 3-5 times. This is defense-in-depth (the cap exists for security), and typical payloads are well under this limit.
+
+- **prepareForReuse creates a synthetic TmuxSpawnConfig with unused fields** - `src/implementations/tmux/tmux-connector.ts:375-383` (Confidence: 62%) -- The synthetic config object passes empty/dummy values for `command`, `agentArgs`, and `agent` to satisfy the type constraint. These fields are never read by `buildActiveSession` in this path, but they are allocated. This is a single object allocation on a cold path (once per loop iteration) with no measurable impact.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Performance Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The architecture change itself is a net performance improvement: removing the wrapper pipeline eliminates an entire bash process that ran for the lifetime of each agent invocation, piping all stdout through a while-read loop with per-line jq calls. The new Stop hook approach processes output once at the end of each turn rather than on every line. The single MEDIUM finding (consolidating jq invocations) is a straightforward optimization that would reduce per-turn subprocess overhead by ~60% on the common Codex path. The PR removes 1,187 net lines of wrapper pipeline code, which is itself a maintenance and runtime win.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/regression.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/regression.md
@@ -1,0 +1,77 @@
+# Regression Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+**Prior Resolution Cycles**: 1 (18 total issues, 17 fixed, 0 FP, 1 deferred)
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Usage/cost data capture regression -- UsageParser depends on `--output-format json` fields no longer emitted** - `src/services/usage-parser.ts:7`
+**Confidence**: 85%
+- Problem: The `usage-parser.ts` module's doc comment and implementation expect Claude's `--output-format json` output containing `{"type":"result", "usage": {...}, "total_cost_usd": ...}`. The PR removes `--print` and `--output-format` flags from `ClaudeAdapter.buildTmuxArgs()` (line 22-24 of `claude-adapter.ts`). The new Stop hook (`autobeat-stop-hook.sh` line 76-78) writes `{"type":"result","content":...}` messages that contain only the response text -- no `usage` or `total_cost_usd` fields. The parser will find the `{"type":"result"` marker but then fail field validation (lines 84-105 of `usage-parser.ts`) and return `null`. The `UsageCaptureHandler` handles this gracefully (logs a warning), so there is no crash, but cost/token tracking for ALL tasks will silently stop producing data. The `task_usage` table will stop receiving new rows.
+- Impact: Loss of token/cost observability for all tasks. Dashboard metrics depending on `task_usage` data will show no new entries. This is not a crash but a functional regression in the usage tracking feature introduced in v1.4.0.
+- Fix: The Stop hook should extract and forward the `usage` and `total_cost_usd` fields from the hook stdin payload (`HOOK_DATA`) into the result message JSON. Claude Code's Stop hook data includes these fields. Alternatively, update `usage-parser.ts` to parse usage data from the hook payload separately from the response content. The stale doc comment at line 7 should also be updated.
+
+### MEDIUM
+
+**Stale doc comment in usage-parser.ts references removed `--output-format json` flag** - `src/services/usage-parser.ts:7`
+**Confidence**: 92%
+- Problem: Line 7 states "Claude spawns with --output-format json" but this PR removes that flag. The comment is now incorrect documentation that will mislead future developers.
+- Fix: Update the Rationale comment to reflect the new architecture: output is captured via the Stop hook, and the parser searches for usage data in the captured output messages. (Note: this fix should be combined with the functional fix above.)
+
+## Issues in Code You Touched (Should Fix)
+
+_No issues found._
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**Stale comment in orchestration-manager.ts references `claude --print`** - `src/services/orchestration-manager.ts:172`
+**Confidence**: 90%
+- Problem: Line 172 says "workers run as `claude --print`" but this PR removes `--print` from all spawn paths. The comment is in an unchanged file but is now inaccurate.
+- Fix: Update to: "workers run as interactive REPL sessions (output captured via Stop hook)" or similar.
+
+## Suggestions (Lower Confidence)
+
+- **Deleted test file not fully replaced** - `tests/integration/tmux/hook-script-generation.test.ts` (Confidence: 65%) -- The deleted file had 348 lines of integration tests for the wrapper script including jq-missing detection (exit 127), multi-line sequence numbering, and special character escaping. The new `stop-hook.test.ts` (651 lines) covers most of these scenarios for the stop hook instead, but the jq-missing test specifically tests the setup shim / wrapper behavior, not the stop hook. The stop hook silently exits 0 when jq is missing (line 6 of the script), which is correct behavior for a hook, but may differ from the old wrapper's explicit 127 exit. This may be intentional but is worth confirming.
+
+- **`CommunicationMode` type reference in tmux/types.ts comment** - `src/implementations/tmux/types.ts:9` (Confidence: 60%) -- The comment on line 9 still lists `CommunicationMode` among "internal or self-documenting types" but this type was removed from this file. The comment is only a naming convention note and has no functional impact.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Regression Score**: 7/10
+**Recommendation**: CHANGES_REQUESTED
+
+### Regression Checklist
+
+- [x] No exports removed without deprecation -- removed exports (`WrapperConfig`, `WrapperManifest`, `CommunicationMode`, `generateWrapper`, `buildWrapperFlags`, `buildInteractiveArgs`, `buildArgs`) are internal implementation types with no external consumers. The `tmux/index.ts` barrel export was updated. No callers remain in the codebase.
+- [x] Return types backward compatible -- `buildTmuxCommand()` return shape unchanged; `prompt` field now always contains the prompt text (was empty in wrapper mode). Consumers (WorkerPool) already handled non-empty prompts correctly.
+- [x] Default values unchanged or documented -- `persistent` flag semantics documented: controls session lifecycle (park vs destroy), no longer affects CLI arg generation.
+- [x] Side effects preserved -- `onOutput`, `onExit` callbacks preserved. Sentinel files (`.done`, `.exit`) still written (now by Stop hook instead of wrapper). Staleness detection updated to skip parked sessions.
+- [x] All consumers of changed code updated -- `EventDrivenWorkerPool`, `TmuxConnector`, adapters all updated consistently.
+- [x] Migration complete across codebase -- grep confirms no remaining references to removed APIs in source code.
+- [x] CLI options preserved -- no CLI option changes.
+- [x] API endpoints preserved -- MCP tools unchanged.
+- [x] Commit message matches implementation -- PR description accurately describes the wrapper-to-stop-hook migration.
+- [ ] **Breaking changes documented** -- Usage/cost data regression not documented. The `usage-parser.ts` is functionally broken by this change (returns null for all tasks) though it degrades gracefully without crashes.
+
+### Key Regression Observations
+
+1. **Wrapper pipeline removal is clean**: The removal of `generateWrapper`, `buildWrapperScript`, `WrapperConfig`, `WrapperManifest`, `buildCommunicationBlock`, `NEXT_SEQ_FN`, and related code is thorough. No orphaned references remain. The `--print` and `--quiet` flags are correctly removed from both `ClaudeAdapter` and `CodexAdapter`.
+
+2. **SessionState enum is a safe replacement for boolean `exited`**: The `'active' | 'parked' | 'exited'` enum correctly captures the three-state lifecycle. All guards that previously checked `session.exited` now check `session.state !== 'active'`, which is semantically equivalent for both the old `exited=true` and the new `'parked'` state.
+
+3. **`prepareForReuse()` integration is correctly sequenced**: The method is called AFTER `setEnvironment` and the 300ms settle delay, and BEFORE `sendKeys(prompt)`, ensuring watchers are ready before output arrives. The method is properly guarded against duplicate taskIds and cleans up on failure.
+
+4. **Test coverage is comprehensive**: 651 lines of new stop-hook integration tests plus expanded unit tests for `configureAgentHook`, `prepareForReuse`, and updated `buildTmuxCommand` assertions. The deleted wrapper test file (348 lines) is fully replaced by stop-hook tests covering equivalent scenarios.
+
+5. **Mock fixture updated**: `createMockTmuxConnector` in `tests/fixtures/mocks.ts` includes `prepareForReuse` mock, preventing test failures from the new port method.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/reliability.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/reliability.md
@@ -1,0 +1,137 @@
+# Reliability Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Parked persistent session orphaned on loop cleanup** - `src/implementations/event-driven-worker-pool.ts:699` / `src/implementations/tmux/tmux-connector.ts:266-268`
+**Confidence**: 92%
+- Problem: When a persistent session is parked by `triggerExit()` (line 966 of tmux-connector.ts), it is removed from `activeSessions` under the current taskId. The `PersistentSessionEntry.handle` retains the ORIGINAL first-iteration taskId (declared `readonly` at line 123 of worker pool). When `cleanupPersistentSession()` later calls `destroy(entry.handle)`, `destroy()` looks up `activeSessions.get(handle.taskId)` at line 267 -- this returns `undefined` because the first iteration's taskId was deleted from `activeSessions` during parking. `destroy()` early-returns with `ok(undefined)` at line 268 without ever calling `destroySession(handle.sessionName)`. The tmux session process remains alive, orphaned.
+  - This affects every loop that runs 2+ iterations with persistent sessions: the tmux session is never killed on loop completion.
+  - `dispose()` on the connector also cannot catch it -- parked sessions are not in `activeSessions`.
+- Fix: In `cleanupPersistentSession`, bypass the `destroy()` method (which requires activeSessions lookup) and call `destroySession` directly by session name:
+
+```typescript
+cleanupPersistentSession(key: string): void {
+  const entry = this.persistentSessions.get(key);
+  if (!entry) return;
+  this.persistentSessions.delete(key);
+
+  // Destroy by session name — the session may be parked (not in
+  // connector's activeSessions) but the tmux process is still alive.
+  // Use the connector's destroy() first (handles flush/cleanup if tracked),
+  // then fall through to direct sessionManager.destroySession() as a
+  // safety net for the parked-session case.
+  const destroyResult = this.tmuxConnector.destroy(entry.handle);
+  if (!destroyResult.ok) {
+    this.logger.warn('Failed to destroy persistent session during cleanup', {
+      persistentSessionKey: key,
+      sessionName: entry.handle.sessionName,
+      error: destroyResult.error.message,
+    });
+  }
+
+  // Alternatively, add a destroyByName() method on TmuxConnectorPort that
+  // calls destroySession(sessionName) directly, or have destroy() fall
+  // through to destroySession even when the session is not in activeSessions.
+}
+```
+
+  A cleaner fix would be to update `TmuxConnector.destroy()` to call `destroySession` even when the session is not tracked in activeSessions (since the session name on the handle is still valid):
+
+```typescript
+destroy(handle: TmuxHandle): Result<void, AutobeatError> {
+  const session = this.activeSessions.get(handle.taskId);
+  if (!session) {
+    // Session not tracked (may be parked) — still try to kill the tmux process
+    const result = this.deps.sessionManager.destroySession(handle.sessionName);
+    this.loggedCleanup('destroy', handle.taskId, handle.sessionsDir);
+    return result.ok ? ok(undefined) : result;
+  }
+  // ... existing tracked-session cleanup path ...
+}
+```
+
+**Stop hook: no sentinel written when jq fails on main path** - `scripts/autobeat-stop-hook.sh:68-78`
+**Confidence**: 82%
+- Problem: If `jq -Rs .` fails at line 68 (e.g., jq OOM on a very large `$RESPONSE`), `ESCAPED` is empty and the `printf` at line 76 writes malformed JSON to the message file. The `mv` at line 78 succeeds, so the message file exists but is corrupt. The sentinel (.done/.exit) is still written at lines 82-88, so the session exits. However, the corrupt message file will cause `parseMessageFile` in the connector to log a warning and skip delivery -- the last assistant message is silently lost with no indication in the sentinel exit code.
+  - The old wrapper script had a `_sentinel_guard` trap that wrote `.exit` on any unexpected failure. The new Stop hook has no equivalent trap.
+- Fix: Add an ERR trap that writes `.exit` on unexpected failures, and validate `ESCAPED` before writing:
+
+```bash
+# After line 38 (SESSIONS_DIR validation):
+_emergency_exit() {
+  local _ec=$?
+  if [ -n "${TASK_DIR:-}" ]; then
+    echo "$_ec" > "$TASK_DIR/.exit.tmp" 2>/dev/null
+    mv "$TASK_DIR/.exit.tmp" "$TASK_DIR/.exit" 2>/dev/null || true
+  fi
+}
+trap _emergency_exit ERR
+
+# At line 68, validate ESCAPED:
+if [ "$RESPONSE_FROM_DIRECT" = "true" ]; then
+  ESCAPED=$(printf '%s' "$RESPONSE" | jq -Rs .)
+  if [ -z "$ESCAPED" ]; then
+    ESCAPED='""'
+  fi
+else
+  ...
+```
+
+### MEDIUM
+
+**Stop hook: `ensureDir` failure in `configureAgentHook` is unguarded** - `src/cli/commands/init.ts:135`
+**Confidence**: 84%
+- Problem: `deps.ensureDir(configDir)` at line 135 can throw (permission denied, disk full), but it is not wrapped in a try/catch. The error propagates as an unhandled exception. All other disk operations in `configureAgentHook` are properly guarded with try/catch and return `err()`.
+- Fix: Wrap in try/catch like the other disk operations:
+
+```typescript
+try {
+  deps.ensureDir(configDir);
+} catch (e) {
+  return err(`Failed to create ${agentType} config directory: ${e instanceof Error ? e.message : String(e)}`);
+}
+```
+
+**Stop hook: `configureAgentHook` orphaned `.tmp` cleanup writes empty file instead of deleting** - `src/cli/commands/init.ts:214-215`
+**Confidence**: 80%
+- Problem: On rename failure, the cleanup at line 214 writes an empty string to the `.tmp` file rather than deleting it. The `HookConfigDeps` interface has no `deleteFile` method. While this is noted in a comment, an empty `.tmp` file left on disk could confuse subsequent runs or cause confusion during debugging.
+- Fix: Add a `deleteFile` method to `HookConfigDeps` (using `unlinkSync`) and use it for cleanup. Alternatively, accept the minor cosmetic issue since the `.tmp` file is harmless.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`prepareForReuse` synthetic config uses hardcoded `'claude'` agent type** - `src/implementations/tmux/tmux-connector.ts:381`
+**Confidence**: 85%
+- Problem: The synthetic config at line 381 hardcodes `agent: 'claude' as const`. While the comment at lines 367-374 explains that `agent` is not read by `buildActiveSession`, this is fragile -- if `buildActiveSession` ever starts reading `agent` (e.g., for agent-specific staleness thresholds), the hardcoded value would produce incorrect behavior for Codex sessions. The original session's agent type is available on the handle's associated state but not passed through.
+- Fix: Store the original `agent` type on the `ActiveSession` interface (or pass it through the `TmuxHandle`) so `prepareForReuse` can use the correct value. If that is too invasive, add a defensive assertion comment documenting that `agent` is intentionally unused and must remain so.
+
+## Pre-existing Issues (Not Blocking)
+
+No pre-existing reliability issues detected in the reviewed files.
+
+## Suggestions (Lower Confidence)
+
+- **Stop hook: `tail -n 50` transcript lines could be individually large** - `scripts/autobeat-stop-hook.sh:19` (Confidence: 65%) -- Each JSONL transcript line is a complete JSON object (potentially megabytes for long assistant messages). While 50 lines is bounded, `jq -s` loads all of them into memory at once. Consider adding `head -c` after `tail` to cap total bytes read from the transcript.
+
+- **`prepareForReuse` does not inherit staleness config from original session** - `src/implementations/tmux/tmux-connector.ts:375-383` (Confidence: 70%) -- The synthetic config has no `staleness` field, so `buildActiveSession` falls back to `DEFAULT_STALENESS_CONFIG`. If the original session was spawned with custom staleness thresholds, the reused session reverts to defaults. This may not matter in practice since persistent sessions all use default config, but it is a silent behavior change if custom configs are ever used.
+
+- **No bounded retry on `tmux show-environment` failure in Stop hook** - `scripts/autobeat-stop-hook.sh:30` (Confidence: 62%) -- If `tmux show-environment` fails (tmux server unresponsive), the hook falls back to `AUTOBEAT_TASK_ID` env var, which is the correct behavior. However, there is no logging of the fallback -- diagnosing output attribution issues in production would be difficult without it. (Shell hooks cannot easily log, so this may be acceptable.)
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 2 | 2 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Reliability Score**: 6/10
+**Recommendation**: CHANGES_REQUESTED
+
+The persistent session orphan leak (HIGH) is the primary concern -- every loop with 2+ iterations will leave a tmux process alive after loop completion. The `destroy()` early-return when a session is not in `activeSessions` is the root cause; the fix is straightforward (fall through to `destroySession` by session name). The Stop hook's missing ERR trap (HIGH) removes a safety net that the old wrapper script had; adding it back is a small change with high defensive value. The two MEDIUM issues (unguarded `ensureDir` throw, hardcoded agent type) are lower risk but should be addressed for consistency with the project's error handling standards.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/resolution-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/resolution-summary.md
@@ -1,0 +1,51 @@
+# Resolution Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31_1907
+**Review**: .devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907
+**Command**: /resolve
+
+## Statistics
+| Metric | Value |
+|--------|-------|
+| Total Issues | 22 |
+| Fixed | 21 |
+| False Positive | 1 |
+| Deferred | 0 |
+| Blocked | 0 |
+
+## Fixed Issues
+| Issue | File:Line | Commit |
+|-------|-----------|--------|
+| Usage/cost data capture regression — stop hook now emits usage message | scripts/autobeat-stop-hook.sh:73-78 | a800840 |
+| ESCAPED guard — validates jq output before writing message file | scripts/autobeat-stop-hook.sh:83-86 | a800840 |
+| jq subprocess consolidation — single eval call for Codex path | scripts/autobeat-stop-hook.sh:17-22 | a800840 |
+| Parked session orphan leak — destroy() falls through to destroySession | src/implementations/tmux/tmux-connector.ts:266 | 30fe9fb |
+| Synthetic config agent:'claude' — agent type threaded via parkedSessionAgents | src/implementations/tmux/tmux-connector.ts:375-383 | 30fe9fb |
+| taskIdRef stale window — ref updated before createCallbacks | src/implementations/event-driven-worker-pool.ts:443 | 30fe9fb |
+| remapExistingWorkerForReuse phase comments — ordering invariant explicit | src/implementations/event-driven-worker-pool.ts:555-608 | 30fe9fb |
+| configureAgentHook decomposition — extracted 4 helpers | src/cli/commands/init.ts:128-223 | a800840 |
+| ensureDir unguarded throw — wrapped in try/catch with err() | src/cli/commands/init.ts:135 | a800840 |
+| Orphaned .tmp cleanup — added unlinkFile to HookConfigDeps | src/cli/commands/init.ts:214-215 | a800840 |
+| runInit near-duplication — extracted finalizeInit helper | src/cli/commands/init.ts:381-459 | a800840 |
+| runSkillInstall branches — extracted resolveTargetAgents helper | src/cli/commands/init.ts:465-531 | a800840 |
+| Stale "wrapper" in TMUX_HOOK_FAILED JSDoc | src/core/errors.ts:105 | a68a4f2 |
+| Stale "wrapper" comments (4 occurrences) | src/cli/commands/orchestrate-interactive.ts:103,246,247,250 | a68a4f2 |
+| Stale "generateWrapper()" in test comment | tests/unit/implementations/tmux/tmux-hooks.test.ts:54 | a68a4f2 |
+| Stale "--output-format json" rationale | src/services/usage-parser.ts:7 | a68a4f2 |
+| Stale "claude --print" DECISION comment | src/services/orchestration-manager.ts:172 | a68a4f2 |
+| Missing jq-unavailable guard test | tests/integration/tmux/stop-hook.test.ts | b45f21d |
+| Missing transcript string-content test (2 tests) | tests/integration/tmux/stop-hook.test.ts | b45f21d |
+| Missing transcript special-chars tests (3 tests) | tests/integration/tmux/stop-hook.test.ts | b45f21d |
+| Usage regression tests (6 tests) | tests/integration/tmux/stop-hook.test.ts | a800840 |
+
+## False Positives
+| Issue | File:Line | Reasoning |
+|-------|-----------|-----------|
+| Communication target filter tests deleted | tests/unit/implementations/tmux/tmux-hooks.test.ts | Grep of entire production codebase (src/) found zero references to communicationTarget, CommunicationTarget, or COMMUNICATION_TARGET. The communication target logic is fully removed — no orphaned code remains, no tests needed. |
+
+## Deferred to Tech Debt
+_(none)_
+
+## Blocked
+_(none)_

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/review-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/review-summary.md
@@ -1,0 +1,329 @@
+# Code Review Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31_1907
+**Review Cycle**: 2 (incremental after cycle 1)
+**Prior Status**: 18 issues in cycle 1; 17 fixed, 1 deferred
+
+---
+
+## Merge Recommendation: CHANGES_REQUESTED
+
+Two HIGH severity regressions block merge:
+1. **Usage/cost data capture broken** (Regression) — UsageParser receives empty hook data; task_usage table stops populating
+2. **Persistent session orphan leak** (Reliability) — Parked sessions never killed on loop cleanup; tmux processes accumulate
+
+Additionally, one HIGH blocking issue in architecture requires resolution:
+3. **Synthetic config coupling** — Hardcoded agent type could silently break future buildActiveSession changes
+
+---
+
+## Issue Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW | Total |
+|----------|----------|------|--------|-----|-------|
+| Blocking | 0 | 3 | 6 | 0 | 9 |
+| Should Fix | 0 | 0 | 3 | 0 | 3 |
+| Pre-existing | 0 | 0 | 1 | 0 | 1 |
+
+**Overall Issues**: 13 total (9 blocking, 3 should-fix, 1 informational)
+
+---
+
+## Blocking Issues (MUST FIX BEFORE MERGE)
+
+### Architecture — Synthetic config uses dummy `agent` field that could break future buildActiveSession callers
+**File**: `src/implementations/tmux/tmux-connector.ts:375-383`
+**Severity**: HIGH
+**Confidence**: 82%
+
+The `prepareForReuse()` method constructs a synthetic `TmuxSpawnConfig` with `agent: 'claude' as const` as a placeholder. The design doc (lines 367-374) explains that `buildActiveSession()` does not currently read this field, but this coupling is fragile. If `buildActiveSession()` ever adds logic that reads `agent` (e.g., for agent-specific staleness tuning), Codex sessions would silently be misidentified as Claude.
+
+**Fix**: Thread the real `agent` type through either:
+- (a) Add `agent: TmuxAgentType` to `PersistentSessionEntry` and use `entry.agent ?? 'claude'` in prepareForReuse
+- (b) Extract `buildActiveSession`'s actual consumed fields into a narrower interface so the type system prevents accidental reads
+
+**Impact**: Medium — coupling point is documented but needs structural fix
+
+---
+
+### Regression — Usage/cost data capture broken
+**File**: `src/services/usage-parser.ts:7` + `scripts/autobeat-stop-hook.sh:76-78`
+**Severity**: HIGH
+**Confidence**: 85%
+
+The `UsageParser` module expects Claude's `--output-format json` output with `{"type":"result", "usage": {...}, "total_cost_usd": ...}` fields. This PR removes those flags from `ClaudeAdapter`. The new Stop hook writes `{"type":"result","content":...}` messages without `usage`/`total_cost_usd` fields. The parser will match the result marker but fail field validation (lines 84-105) and return `null`. The `UsageCaptureHandler` handles the `null` gracefully, so there's no crash — but all task cost/token tracking silently stops. The `task_usage` table will no longer receive new rows for any task.
+
+**Fix**: Stop hook must extract and forward `usage` and `total_cost_usd` fields from the hook stdin payload into the result message JSON. These fields are available in Claude Code's Stop hook data.
+
+**Impact**: High — Feature regression; complete loss of task usage observability (introduced in v1.4.0)
+
+---
+
+### Reliability — Parked persistent session orphaned on loop cleanup
+**File**: `src/implementations/event-driven-worker-pool.ts:699` / `src/implementations/tmux/tmux-connector.ts:266-268`
+**Severity**: HIGH
+**Confidence**: 92%
+
+When a persistent session is parked by `triggerExit()`, it is removed from `activeSessions` using the current taskId. The `PersistentSessionEntry.handle` retains the ORIGINAL first-iteration taskId (declared `readonly`). When `cleanupPersistentSession()` later calls `destroy(entry.handle)`, the `destroy()` method looks up `activeSessions.get(handle.taskId)` — this returns `undefined` because the first iteration's taskId was deleted during parking. The method early-returns with `ok(undefined)` without calling `destroySession(handle.sessionName)`. The tmux session process remains alive, orphaned.
+
+Impact: Every loop with 2+ iterations will leak a tmux process after loop completion.
+
+**Fix**: In `TmuxConnector.destroy()`, fall through to `destroySession(sessionName)` even when the session is not in `activeSessions`:
+
+```typescript
+destroy(handle: TmuxHandle): Result<void, AutobeatError> {
+  const session = this.activeSessions.get(handle.taskId);
+  if (!session) {
+    // Session not tracked (may be parked) — still try to kill the tmux process
+    const result = this.deps.sessionManager.destroySession(handle.sessionName);
+    this.loggedCleanup('destroy', handle.taskId, handle.sessionsDir);
+    return result.ok ? ok(undefined) : result;
+  }
+  // ... existing tracked-session cleanup path ...
+}
+```
+
+**Impact**: Critical — Resource leak in every multi-iteration loop
+
+---
+
+## Should-Fix Issues (Recommended Before Merge)
+
+### Performance — Multiple jq subprocess spawns per Stop hook invocation
+**File**: `scripts/autobeat-stop-hook.sh:10,17,68,73`
+**Severity**: MEDIUM
+**Confidence**: 85%
+
+The Stop hook runs on every agent turn (hot path). The Codex path spawns 3 separate jq subprocesses; the Claude transcript path spawns up to 5. Each fork+exec is ~1-2ms on macOS; over a 100-iteration loop this adds 300-1000ms of cumulative overhead.
+
+**Fix**: Consolidate the Codex path into a single jq invocation that extracts all needed fields at once. This reduces 3 jq invocations to 1 on the common path.
+
+**Impact**: Medium — Optimization; improves loop iteration latency
+
+---
+
+### Complexity — configureAgentHook is 96 lines with mixed concerns
+**File**: `src/cli/commands/init.ts:128-223`
+**Severity**: MEDIUM
+**Confidence**: 85%
+
+This function handles five distinct responsibilities: (1) read and parse existing config, (2) idempotency check, (3) backup creation, (4) config merge, (5) atomic write with rollback. Reaches 4 levels of callback nesting in `hasStopHookCommand`.
+
+**Fix**: Extract the five phases into named helpers:
+- `readExistingConfig()`
+- `backupIfNeeded()`
+- `atomicWriteConfig()`
+
+Brings function under 30 lines and makes each phase independently testable.
+
+**Impact**: Low-Medium — Code clarity; reduces cyclomatic complexity
+
+---
+
+### Reliability — Stop hook: no sentinel written when jq fails on main path
+**File**: `scripts/autobeat-stop-hook.sh:68-78`
+**Severity**: MEDIUM
+**Confidence**: 82%
+
+If `jq -Rs .` fails at line 68 (e.g., OOM on large response), `ESCAPED` is empty and the message file becomes corrupt. The `.done`/`.exit` sentinel is still written so the session exits, but the corrupt message file causes `parseMessageFile` to skip delivery — the last assistant message is lost with no indication.
+
+**Fix**: Add an ERR trap that writes `.exit` on any unexpected failures, and validate `ESCAPED` before writing:
+
+```bash
+_emergency_exit() {
+  local _ec=$?
+  if [ -n "${TASK_DIR:-}" ]; then
+    echo "$_ec" > "$TASK_DIR/.exit.tmp" 2>/dev/null
+    mv "$TASK_DIR/.exit.tmp" "$TASK_DIR/.exit" 2>/dev/null || true
+  fi
+}
+trap _emergency_exit ERR
+```
+
+**Impact**: Medium — Defensive error handling; prevents silent data loss
+
+---
+
+### Testing — Missing test coverage for behavioral regressions
+**File**: `tests/integration/tmux/stop-hook.test.ts`
+**Severity**: MEDIUM / HIGH
+**Confidence**: 85% / 82%
+
+Two test gaps where coverage from the deleted wrapper test suite was not carried forward:
+
+1. **jq-unavailable guard** — Old suite tested "wrapper exits 127 when jq not in PATH". New hook exits 0 (correct), but behavioral coverage is missing.
+2. **Transcript string-content format** — Transcript path handles both array and plain-string content. Only array format is tested; string fallback is untested.
+
+**Fix**: Add two tests (see Complexity report for examples).
+
+**Impact**: Medium — Behavioral gaps in test suite; potential silent failures if transcript format changes
+
+---
+
+## Convergence Status
+
+**Cycle 1 vs Cycle 2 Progress**:
+- Cycle 1 identified 18 issues; **17 fixed** (94% resolution rate), 1 deferred
+- Cycle 2 identified **13 new issues** across different focus areas:
+  - Regression reviewers uncovered functional break in usage parsing (not detected in cycle 1)
+  - Reliability reviewers uncovered session orphan leak (new code path not in cycle 1 scope)
+  - Architecture/Complexity reviewers identified NEW coupling risks from cycle 1's fixes
+
+**Pattern**: Cycle 1 fixes were safe but introduced two regressions (usage data + session cleanup) that only became visible when testing the complete integration. Indicates need for additional integration testing before merge.
+
+**Convergence**: 3 HIGH blocking issues (1 architecture + 2 regressions) + 3 MEDIUM should-fixes. Not converged; requires fixes to blocking issues.
+
+---
+
+## By Reviewer Focus
+
+### Architecture (Cycle 2)
+- 1 HIGH: Synthetic config coupling
+- Score: 8/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: Architecture changes are well-considered; net -1,187 line reduction eliminates entire wrapper code path. Removal of pipeline is clean. Only issue is the fragile coupling in prepareForReuse.
+
+---
+
+### Reliability (Cycle 2)
+- 2 HIGH: Session orphan leak, missing jq error trap
+- 2 MEDIUM: ensureDir throw, hardcoded agent type
+- Score: 6/10
+- Status: CHANGES_REQUESTED
+
+**Key Assessment**: Session orphan leak is the critical concern — every loop with 2+ iterations leaks a tmux process. Missing ERR trap removes a safety net from the old wrapper script.
+
+---
+
+### Regression (Cycle 2)
+- 1 HIGH: Usage/cost data capture broken
+- 1 MEDIUM: Stale comment in orchestration-manager.ts (pre-existing)
+- Score: 7/10
+- Status: CHANGES_REQUESTED
+
+**Key Assessment**: Functional regression in usage tracking; complete loss of task cost/token observability. Not a crash, but feature stops working silently.
+
+---
+
+### Testing (Cycle 2)
+- 2 HIGH: Missing jq-unavailable test, missing transcript string-content test
+- 2 MEDIUM: Implicit RESPONSE_FROM_DIRECT path difference, deleted wrapper communication tests
+- Score: 8/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: Strong testing discipline overall; 651-line stop-hook test suite is comprehensive. Two HIGH gaps are behavioral coverage that should have been carried forward.
+
+---
+
+### Complexity (Cycle 2)
+- 1 HIGH: configureAgentHook 96 lines with mixed concerns
+- 2 MEDIUM: runInit 79 lines, runSkillInstall 67 lines with 5 exit paths
+- 2 Pre-existing MEDIUM: worker-pool 1,240 lines, tmux-connector 1,066 lines
+- Score: 6/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: PR achieves net -1,187 line reduction from wrapper removal. New code is well-structured; extracting phases from configureAgentHook would improve clarity.
+
+---
+
+### Consistency (Cycle 2)
+- 4 MEDIUM: Stale "wrapper" terminology in comments/JSDoc across 4 files
+- 0 Blocking
+- Score: 8/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: Impressively consistent refactoring; wrapper pipeline removal is thorough. Only gaps are documentation-level stale comments in files not directly modified.
+
+---
+
+### Security (Cycle 2)
+- 0 HIGH/CRITICAL
+- 0 Should-Fix
+- Score: 9/10
+- Status: APPROVED
+
+**Key Assessment**: Strong security posture. All cycle 1 fixes verified in place (task ID validation, SESSIONS_DIR path traversal check, stdin cap, atomic writes). Stop hook has proper guards; hook configuration uses dependency injection.
+
+---
+
+### TypeScript (Cycle 2)
+- 1 MEDIUM: Unhandled throw in configureAgentHook breaks Result contract
+- Score: 9/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: No `any` types; SessionState enum is well-designed. Only issue is inconsistent error handling in one function (ensureDir not wrapped in try/catch while writeFile/renameFile are).
+
+---
+
+### Performance (Cycle 2)
+- 1 MEDIUM: Multiple jq subprocess spawns
+- Score: 8/10
+- Status: APPROVED_WITH_CONDITIONS
+
+**Key Assessment**: Architecture change is a net performance win (eliminates wrapper pipeline). Single jq consolidation optimization would reduce per-turn overhead by ~60%.
+
+---
+
+## Action Plan
+
+### Critical Path (Block Merge)
+1. **Fix session orphan leak** (reliability HIGH) — Modify `destroy()` to call `destroySession()` by session name even when not in activeSessions
+2. **Fix usage/cost data regression** (regression HIGH) — Stop hook must extract `usage` and `total_cost_usd` fields and include in result message JSON
+3. **Fix synthetic config coupling** (architecture HIGH) — Add `agent` field to `PersistentSessionEntry` or add defensive assertion
+
+### High-Impact Before Merge
+4. **Add missing test coverage** (testing HIGH) — jq-unavailable test + transcript string-content test
+5. **Consolidate jq spawns** (performance MEDIUM) — Single jq call for Codex path
+
+### Recommended Before Merge
+6. **Extract configureAgentHook phases** (complexity MEDIUM) — Break into named helpers to reduce from 96 to ~30 lines
+7. **Wrap ensureDir in try/catch** (typescript/reliability MEDIUM) — Consistent error handling
+
+### Documentation (Non-blocking)
+8. **Update stale "wrapper" comments** (consistency MEDIUM) — 4 files with outdated terminology
+9. **Update usage-parser doc comment** (regression MEDIUM) — Reflect new Stop hook architecture
+
+---
+
+## Quality Metrics
+
+| Metric | Value |
+|--------|-------|
+| Net Lines Changed | -1,187 |
+| Files Modified | 42 |
+| New Tests | 23 |
+| Blocking Issues | 3 |
+| Should-Fix Issues | 3 |
+| False Positives | 0 |
+| Convergence | Not Yet — requires fixes to blocking issues |
+
+---
+
+## Cycle Comparison
+
+| Aspect | Cycle 1 | Cycle 2 |
+|--------|---------|---------|
+| Total Issues | 18 | 13 |
+| Fixed | 17 (94%) | 0 (staged for fixing) |
+| Deferred | 1 | 0 |
+| HIGH Issues | ~6 | 3 |
+| Test Gaps | Not detected | 2 HIGH |
+| Regressions | 0 | 2 HIGH |
+
+Cycle 1 fixes were high-quality (17/18) but introduced regressions only visible in end-to-end testing. Cycle 2 reviewers detected these regressions, indicating the multi-focus review process is working as designed.
+
+---
+
+## Closure Criteria for Merge
+
+- [ ] Session orphan leak fixed (destroy() fallthrough to destroySession)
+- [ ] Usage/cost data capture restored (Stop hook exports usage fields)
+- [ ] Synthetic config coupling resolved (agent type threaded through)
+- [ ] Missing tests added (jq-unavailable, transcript string-content)
+- [ ] Stale comments updated (wrapper → setup shim, 4 files)
+- [ ] `configureAgentHook` decomposed (optional but recommended)
+- [ ] `ensureDir` wrapped in try/catch (optional but recommended)
+
+Once these are addressed, **recommend APPROVED** status.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/security.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/security.md
@@ -1,0 +1,86 @@
+# Security Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+**Cycle**: 2 (incremental after cycle 1 resolved 17/18 issues)
+
+## Cross-Cycle Awareness
+
+Cycle 1 fixed 17 security-relevant issues including:
+- Missing task ID regex validation on early-exit path (now fixed at line 33 of stop hook)
+- Stdin read without size limit (now capped at 10MB via `head -c 10485760`)
+- `configureAgentHook` throwing instead of returning Result (now returns `err()`)
+- Orphaned `.tmp` on rename failure (now best-effort truncated)
+- Path traversal prevention on `SESSIONS_DIR` (now checks `..`)
+
+This cycle reviews the current state of the branch after those fixes.
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Transcript path not validated against SAFE_PATH_REGEX** - `scripts/autobeat-stop-hook.sh:18` (Confidence: 65%) -- `TRANSCRIPT` is extracted from `jq -r '.transcript_path // empty'` and used with `tail -n 50 "$TRANSCRIPT"` without path validation (no `..` check, no regex). However, `transcript_path` is supplied by the agent CLI itself (trusted caller), not by the user, and the file is read-only via `tail`. The blast radius is limited to reading (not writing) an arbitrary file readable by the current user. Still, defense-in-depth would suggest validating or rejecting paths containing `..`.
+
+- **STOP_REASON whitelist is permissive in the default case** - `scripts/autobeat-stop-hook.sh:85-88` (Confidence: 62%) -- The `case` statement allows any `STOP_REASON` value from jq in the default `*` branch, writing a `.exit` sentinel. The value itself is not embedded in any file or shell command (only the literal string `"1"` is written), so this is not an injection vector. However, validating `STOP_REASON` against a known set before the `case` would be stricter defense-in-depth.
+
+- **ensureDir called before fileExists check** - `src/cli/commands/init.ts:134-135` (Confidence: 60%) -- `configureAgentHook` calls `deps.ensureDir(configDir)` unconditionally before checking if the config file exists. If the config directory does not exist (e.g., CLI not installed), the function creates it as a side effect. The caller `defaultConfigureHooks` already guards with `deps.fileExists(configDir)` and skips if absent, so this is unreachable in production. But `configureAgentHook` is exported and could be called directly by future callers without the guard.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Security Score**: 9/10
+**Recommendation**: APPROVED
+
+## Rationale
+
+This PR demonstrates strong security posture across all changed files:
+
+**Shell script (autobeat-stop-hook.sh)**:
+- Task ID validated via regex (`^[a-z0-9][a-z0-9_-]*$`) -- line 33
+- SESSIONS_DIR validated against path traversal (`..`) -- line 38
+- Stdin capped at 10MB (`head -c 10485760`) -- line 8
+- All file writes use atomic `.tmp` + `mv` pattern -- lines 43-44, 77-78, 82-84, 87-88
+- No shell expansion risks: variables are double-quoted throughout; `jq` handles JSON parsing
+- AUTOBEAT_WORKER env-var gate prevents execution outside managed sessions -- line 4
+
+**Hook configuration (init.ts)**:
+- Config paths hardcoded via `AGENT_HOOK_CONFIG_PATHS` -- no user-controlled paths
+- Atomic writes with `.tmp` + rename -- lines 204-210
+- Restrictive file permissions: `0o600` for config files, `0o700` for directories
+- Idempotent: checks for existing hook before modification -- lines 161-174
+- Backup created before first modification -- lines 181-189
+- Disk errors return `err()` instead of throwing -- lines 206-219
+
+**TmuxConnector (prepareForReuse)**:
+- `initTaskDirectory` validates taskId via `TASK_ID_REGEX` and sessionsDir via `SAFE_PATH_REGEX`
+- Duplicate taskId guard prevents orphaning existing watchers -- line 350
+- Orphan cleanup on buildActiveSession failure -- line 396
+- Session directories use `0o700` permissions
+
+**Adapter changes (base-agent-adapter.ts, claude-adapter.ts, codex-adapter.ts)**:
+- Removal of wrapper pipeline (`buildWrapperFlags`, `buildArgs`) reduces attack surface (fewer CLI args assembled)
+- `--dangerously-skip-permissions` retained for Claude -- required for unattended operation, documented as intentional
+- No new external inputs introduced; all removed code paths were strictly additive in surface area
+
+**Prior cycle fixes verified in place**: All 17 fixes from cycle 1 are confirmed present in the current diff. The deferred item (reuseSession complexity) is architectural, not security.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/testing.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/testing.md
@@ -1,0 +1,128 @@
+# Testing Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Missing jq-unavailable guard test in stop-hook integration tests** - `tests/integration/tmux/stop-hook.test.ts`
+**Confidence**: 85%
+- Problem: The stop hook script at line 6 has a `command -v jq >/dev/null 2>&1 || exit 0` guard. The old deleted test suite (`hook-script-generation.test.ts`) had a test "wrapper exits 127 when jq is not in PATH" that validated the jq-absent defense-in-depth guard. The new `stop-hook.test.ts` has no equivalent test. The script exits 0 (not 127) without jq, so the old test's exact assertion does not apply, but the behavioral coverage of "no jq = silent no-op" is missing.
+- Fix: Add a test to `stop-hook.test.ts` that runs the hook with `PATH=/nonexistent` (or similar) to confirm the hook exits 0 and creates no files when jq is absent:
+```typescript
+it('exits 0 without creating files when jq is not available', () => {
+  const sessionsDir = path.join(tmpDir, 'guard-no-jq');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+
+  const result = spawnSync('/bin/bash', [HOOK_SCRIPT], {
+    input: codexPayload('hello'),
+    encoding: 'utf8',
+    env: {
+      PATH: '/nonexistent',
+      HOME: os.homedir(),
+      AUTOBEAT_WORKER: 'true',
+      AUTOBEAT_TASK_ID: 'task-jq',
+      AUTOBEAT_SESSIONS_DIR: sessionsDir,
+    },
+  });
+
+  expect(result.status).toBe(0);
+  expect(fs.readdirSync(sessionsDir)).toHaveLength(0);
+});
+```
+
+**Missing test for transcript-path content array type handling** - `tests/integration/tmux/stop-hook.test.ts`
+**Confidence**: 82%
+- Problem: The stop hook script lines 19-25 handle two content formats: when `message.content` is an array of `{type: "text", text: ...}` objects (concatenated via `join("")`), and when it is a plain string (`.message.content // ""`). The existing Claude path tests only exercise the array format. The string-content fallback (the `else` branch in the jq expression) is untested. If this jq path breaks, Claude transcripts with non-array content would silently produce empty responses.
+- Fix: Add a test with a transcript where assistant message content is a plain string:
+```typescript
+it('handles transcript with plain string content (non-array format)', () => {
+  const sessionsDir = path.join(tmpDir, 'claude-string-content');
+  const taskId = 'task-str-content';
+  const transcriptPath = path.join(tmpDir, 'transcript-string.jsonl');
+
+  const lines = [
+    JSON.stringify({
+      role: 'assistant',
+      message: { content: 'plain string response' },
+    }),
+  ];
+  fs.writeFileSync(transcriptPath, lines.join('\n') + '\n');
+
+  const payload = JSON.stringify({
+    transcript_path: transcriptPath,
+    stop_reason: 'end_turn',
+  });
+  const { taskDir } = runHook(payload, taskId, sessionsDir);
+  const msg = readFirstMessage(taskDir);
+  expect(msg.content).toBe('plain string response');
+});
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Test for `RESPONSE_FROM_DIRECT` escaping difference is implicit** - `tests/integration/tmux/stop-hook.test.ts`
+**Confidence**: 80%
+- Problem: The stop hook has a critical branching path at lines 67-71 where `RESPONSE_FROM_DIRECT=true` means the response gets `jq -Rs .` escaping, while the transcript path does not. The special character tests (quotes, newlines, backslashes, etc.) all exercise the Codex/direct path via `codexPayload()`. None of the special character tests exercise the Claude/transcript path, which uses a different escaping strategy. If the transcript path's jq `join("")` output incorrectly escapes content in a way that differs from direct responses, this would not be caught.
+- Fix: Add at least one special-character test via the Claude transcript path:
+```typescript
+it('handles special characters via transcript path', () => {
+  const sessionsDir = path.join(tmpDir, 'special-transcript');
+  const taskId = 'task-special-transcript';
+  const transcriptPath = path.join(tmpDir, 'transcript-special.jsonl');
+
+  const payload = claudePayload(transcriptPath, 'say "hello" with \\backslash');
+  runHook(payload, taskId, sessionsDir);
+
+  const msg = readFirstMessage(path.join(sessionsDir, taskId));
+  expect(msg.content).toBe('say "hello" with \\backslash');
+});
+```
+
+**Deleted wrapper pipeline tests have no replacement for communication target filtering** - `tests/unit/implementations/tmux/tmux-hooks.test.ts`
+**Confidence**: 80%
+- Problem: The old `generateWrapper()` tests included 7 tests for communication target embedding and security filtering (SESSION_NAME_REGEX validation, load-buffer/paste-buffer vs send-keys, broadcast mode). These tests were deleted with the wrapper pipeline. If any communication target logic remains in `tmux-hooks.ts` or was moved elsewhere, it has lost test coverage. If the logic was fully removed (per the PR description removing the wrapper pipeline), this is acceptable, but should be verified.
+- Fix: Verify that no communication target logic remains in the production code. If it does, the tests need to be re-added for the new implementation.
+
+## Pre-existing Issues (Not Blocking)
+
+_No pre-existing CRITICAL issues found._
+
+## Suggestions (Lower Confidence)
+
+- **Missing edge case: empty `last_assistant_message` string** - `tests/integration/tmux/stop-hook.test.ts` (Confidence: 70%) -- The script checks `[ -n "$RESPONSE" ]` but an empty string `""` from `jq -r '.last_assistant_message // empty'` would be treated as empty. A test with `codexPayload('')` would clarify whether an empty string message falls through to the transcript path or writes an empty-content message.
+
+- **No negative test for `configureAgentHook` with non-object JSON** - `tests/unit/cli-init.test.ts` (Confidence: 65%) -- `configureAgentHook` handles invalid JSON but does not test valid JSON that is not an object (e.g., a JSON array `[]` or a literal `"string"`). The function's behavior with `JSON.parse('[]')` is unclear.
+
+- **Deleted integration test had stronger `bash -n` + execution coverage** - `tests/integration/tmux/stop-hook.test.ts` (Confidence: 68%) -- The old `hook-script-generation.test.ts` tested the generated wrapper end-to-end (write to disk, execute, check sentinels). The new stop-hook tests test the static script, which is better for the new architecture, but the setup shim (`generateSetupShim`) has no integration test that writes the shim and executes it with `bash`. The unit tests for `generateSetupShim` only check in-memory mock calls, not that the generated script actually runs.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 2 | 0 | - |
+| Should Fix | - | 0 | 2 | - |
+| Pre-existing | - | - | 0 | 0 |
+
+**Testing Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+### Assessment
+
+This PR demonstrates strong testing discipline. The test changes are architecturally sound:
+
+1. **Test replacement strategy is excellent**: The deleted `hook-script-generation.test.ts` (348 lines of wrapper pipeline tests) is replaced by `stop-hook.test.ts` (651 lines) which tests the actual stop hook script against real filesystem operations. This is behavior-focused testing -- testing the contract rather than the implementation.
+
+2. **New `configureAgentHook` tests are thorough**: 11 tests covering creation, merging, idempotency, backup, atomicity, error handling (invalid JSON, write failure, rename failure), and codex agent type. Error paths properly test `Result` types. `avoids PF-004` -- the rename failure test verifies `.tmp` cleanup, preventing orphaned state.
+
+3. **`prepareForReuse` integration at worker-pool level is well-tested**: 3 new tests verify call ordering (setEnvironment -> /clear -> prepareForReuse -> sendKeys), failure fallthrough to fresh spawn, and correct task ID passing.
+
+4. **`prepareForReuse` at connector level is well-tested**: 5 new tests cover registration, hooks.initTaskDirectory delegation, watcher restart, error propagation, and sequence number reset with `vi.waitFor` (replacing the flaky `setTimeout` pattern flagged in cycle 1 -- `avoids PF-005` by following up on prior resolution).
+
+5. **Persistent session state machine tests are thorough**: 6 new tests for the `SessionState` enum covering parking behavior, destroy/cleanup suppression for persistent sessions, activeSessions removal on park, and staleness timer ignoring parked sessions.
+
+The two HIGH findings are about test gaps where behavioral coverage from deleted tests was not carried forward to the new test suite.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/typescript.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-05-31_1907/typescript.md
@@ -1,0 +1,66 @@
+# TypeScript Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-05-31
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Unhandled throw in `configureAgentHook` breaks Result contract** - `src/cli/commands/init.ts:135`
+**Confidence**: 85%
+- Problem: `deps.ensureDir(configDir)` on line 135 can throw (e.g., permission denied), but it is not wrapped in try/catch. The function signature is `Result<void, string>`, which promises callers that all errors are captured as `err(...)` values. A throw here violates that contract. The later `deps.writeFile` and `deps.renameFile` calls (lines 205-218) are correctly wrapped in try/catch, making this an inconsistency within the same function.
+- Fix: Wrap the `ensureDir` call in try/catch like the other filesystem operations:
+```typescript
+try {
+  deps.ensureDir(configDir);
+} catch (e) {
+  return err(`Failed to create ${agentType} config directory: ${e instanceof Error ? e.message : String(e)}`);
+}
+```
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Synthetic config dummy fields in `prepareForReuse`** - `src/implementations/tmux/tmux-connector.ts:375-383` (Confidence: 65%) — The `syntheticConfig` uses dummy values (`command: ''`, `agentArgs: []`, `agent: 'claude' as const`) to satisfy the `TmuxSpawnConfig` type. The JSDoc comment explains these are not read by `buildActiveSession`, but this couples `prepareForReuse` to an implementation detail of `buildActiveSession`. A future change to `buildActiveSession` that reads `command` or `agent` would silently get wrong values. Consider extracting a narrower type (e.g., `BuildActiveSessionConfig`) that only requires the fields actually consumed, or adding an assertion that documents the coupling.
+
+- **Orphaned `.tmp` cleanup uses truncation instead of deletion** - `src/cli/commands/init.ts:214-216` (Confidence: 70%) — On rename failure, the orphaned `.tmp` file is truncated via `deps.writeFile(tmpPath, '')` rather than deleted, because `HookConfigDeps` has no `deleteFile` method. The truncated empty file is harmless but will persist on disk. Consider adding an `unlinkFile` method to `HookConfigDeps` for clean removal, or documenting why truncation is sufficient.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**TypeScript Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+## Analysis Notes
+
+**Type Safety**: No `any` types anywhere in the diff. All new types use `readonly` properties consistently. The `SessionState` discriminated union type (`'active' | 'parked' | 'exited'`) is well-designed and consistently used across all guard checks. The `HookConfigResult` discriminated union on `ok` is properly narrowed at all usage sites.
+
+**Removed Code**: The wrapper pipeline removal is clean. All references to `WrapperConfig`, `WrapperManifest`, `generateWrapper`, `buildWrapperFlags`, `buildInteractiveArgs`, `buildArgs`, and `CommunicationMode` have been completely removed from the source tree. No orphaned references remain (verified via grep).
+
+**Import Organization**: `SpawnCallbacks` was correctly moved from `./types.ts` to `../../core/tmux-types.ts` (where it is canonically defined), and remains re-exported from `./types.ts` for backward compatibility. All new imports use `import type` where appropriate.
+
+**Generic Patterns**: The `Result<T, E>` pattern is consistently applied. `configureAgentHook` uses `Result<void, string>` which matches the existing CLI convention (e.g., `parseSkillsAgents`, `copySkills`). The core infrastructure code correctly uses `Result<T, AutobeatError>`.
+
+**Port Interface Extension**: `TmuxConnectorPort.prepareForReuse()` is cleanly added to the port interface in `core/tmux-types.ts` with proper JSDoc and the mock fixture in `tests/fixtures/mocks.ts` is updated to include the new method.
+
+**Prior Resolution Cross-Check**: The two TypeScript issues from cycle 1 (unnecessary type assertion in tmux-connector.ts:491, dead `if (prompt)` guard) are confirmed fixed in the current code. The type assertion was removed and the `if (prompt)` guard was replaced with unconditional sendKeys (lines 662-671 in worker pool).

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/architecture.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/architecture.md
@@ -1,0 +1,74 @@
+# Architecture Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**parkedSessionAgents secondary map introduces subtle coupling between triggerExit and prepareForReuse** - `src/implementations/tmux/tmux-connector.ts:176`
+**Confidence**: 82%
+- Problem: The `parkedSessionAgents` map is a side-channel between `triggerExit()` (producer, line 1018) and `prepareForReuse()` (consumer, line 411). This introduces temporal coupling — `prepareForReuse()` silently falls back to `'claude'` (line 411) if the session was never parked via `triggerExit()`, or if the map entry is missing due to a code path change. The defensive fallback masks a programming error rather than surfacing it. Additionally, `dispose()` clears this map (line 476) but `destroy()` only deletes single entries (line 302) — the asymmetry is correct but non-obvious.
+- Fix: Consider either:
+  1. Storing the agent type on the `TmuxHandle` itself (which already carries taskId/sessionName/sessionsDir) so no secondary map is needed, OR
+  2. Replace the `?? 'claude'` fallback with an explicit error (`return err(...)`) since reaching that state indicates a bug rather than a recoverable condition.
+
+  Option 2 is the smaller change:
+  ```typescript
+  const parkedAgent = this.parkedSessionAgents.get(handle.sessionName);
+  if (!parkedAgent) {
+    return err(tmuxSessionFailed('prepareForReuse', `no parked agent type for session '${handle.sessionName}' — this is a bug`));
+  }
+  this.parkedSessionAgents.delete(handle.sessionName);
+  ```
+
+### MEDIUM
+
+**syntheticConfig in prepareForReuse uses empty command/agentArgs to satisfy type** - `src/implementations/tmux/tmux-connector.ts:422-430`
+**Confidence**: 83%
+- Problem: `prepareForReuse()` constructs a `syntheticConfig` with `command: ''` and `agentArgs: [] as string[]` solely to satisfy the `TmuxSpawnConfig` type shape for `buildActiveSession()`. This violates the Liskov Substitution Principle — the type contract implies these fields carry meaningful values, but here they are garbage placeholders. If `buildActiveSession()` (or any future code) ever reads `config.command` or `config.agentArgs`, it will silently consume empty values rather than failing fast.
+- Fix: Either:
+  1. Extract a narrower type (`ActiveSessionConfig`) that `buildActiveSession()` actually uses (taskId, sessionsDir, staleness, persistent, agent) without requiring command/agentArgs, OR
+  2. Add a `@internal` JSDoc annotation to `buildActiveSession` documenting which fields it actually reads, with an assertion guard:
+  ```typescript
+  // In buildActiveSession:
+  // Assertion: only these fields are consumed. If you add usage of config.command
+  // or config.agentArgs, update prepareForReuse()'s syntheticConfig.
+  ```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**SpawnCallbacks moved to core/tmux-types.ts but still re-exported from implementations/tmux/types.ts** - `src/implementations/tmux/types.ts`, `src/core/tmux-types.ts:53`
+**Confidence**: 85%
+- Problem: `SpawnCallbacks` is now defined in `src/core/tmux-types.ts` (the port layer) and imported from there in `tmux-connector.ts`. However, the barrel file `src/implementations/tmux/index.ts` still re-exports `SpawnCallbacks` from `./types.js`. The `types.ts` file no longer defines `SpawnCallbacks` (it was removed in this PR). This means the re-export from the barrel is now re-exporting a type that `types.ts` itself re-imports from core. While this works in TypeScript (the type resolves correctly), it creates a circular re-export path: core defines it, implementations/tmux/types.ts re-exports it, and implementations/tmux/index.ts re-exports it again. External consumers importing from the barrel get the right type, but the layering is muddied — the canonical source is now core, not implementations.
+- Fix: Remove `SpawnCallbacks` from the `implementations/tmux/index.ts` barrel re-export list and ensure all consumers import it from `core/tmux-types.ts` directly (which is already the case for `tmux-connector.ts` and `event-driven-worker-pool.ts`). This clarifies the dependency direction: core defines, implementations consume.
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**TmuxConnector class exceeds 1000 lines (1118 lines)** - `src/implementations/tmux/tmux-connector.ts`
+**Confidence**: 90%
+- Problem: At 1118 lines, TmuxConnector is approaching god-class territory. It manages session lifecycle, staleness detection, message ordering/delivery, sentinel watching, flushing, and now the parking/reuse state machine. The `prepareForReuse()` addition is well-encapsulated, but the class now has 5 distinct responsibilities: (1) session spawn/destroy, (2) watcher management, (3) message delivery pipeline, (4) staleness detection, (5) persistent session reuse. This is a pre-existing concern that this PR incrementally worsens by adding ~100 lines.
+- Observation: The message ordering/delivery pipeline (handleMessageFile, deliverPendingMessages, flushPendingFiles, forceDeliverRemaining, deliverSingle, parseMessageFile) is ~200 lines that could be extracted into a `MessageDeliveryPipeline` collaborator injected via the constructor. This would reduce TmuxConnector to ~900 lines and give the delivery pipeline its own unit tests.
+
+## Suggestions (Lower Confidence)
+
+- **Defensive fallback in destroy for parked sessions** - `src/implementations/tmux/tmux-connector.ts:297-306` (Confidence: 70%) — The parked-session fallback path in `destroy()` calls `loggedCleanup('destroy', handle.taskId, handle.sessionsDir)` which removes the session directory for `handle.taskId`. However, if this destroy is called after `prepareForReuse()` already created a new task directory for the next iteration, the wrong directory may be cleaned. Verify that the handle passed to `cleanupPersistentSession()` always carries the original (parked) taskId, not the new iteration's taskId.
+
+- **buildTmuxCommand assertion on non-empty prompt** - `src/implementations/base-agent-adapter.ts:158` (Confidence: 65%) — With wrapper mode removed, `prompt` is always the return value of `transformedPrompt`. If a task has an empty prompt string, `sendKeys(handle, '\n')` will be sent (just a newline). Consider adding a precondition assertion: `if (!transformedPrompt) return err(...)`.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Architecture Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The architectural transformation is sound. Removing the wrapper pipeline in favor of a unified Stop hook model simplifies the system significantly (-1187 lines net). The SessionState enum is a correct state-machine pattern replacing a boolean. The port boundary (`TmuxConnectorPort`) is properly extended with `prepareForReuse()`. The `configureAgentHook` function in init.ts is well-decomposed with injectable deps. The one HIGH finding (parkedSessionAgents fallback masking bugs) should be addressed before merge.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/complexity.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/complexity.md
@@ -1,0 +1,69 @@
+# Complexity Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**`reuseSession()` exceeds 50-line function length (114 lines)** - `src/implementations/event-driven-worker-pool.ts:381`
+**Confidence**: 90%
+- Problem: The `reuseSession()` method is 114 lines long (380–494), containing 9 sequential steps with error handling for each. While the orchestration is inherently sequential, the function handles too many concerns: environment update, agent context clear, async settling, prepareForReuse coordination, worker state branching (re-register vs remap), prompt delivery, and cleanup-on-failure. This makes the function hard to understand in under 5 minutes and expensive to modify safely.
+- Fix: Extract the first 4 steps (setEnvironment, sendClear, settle delay, prepareForReuse) into a private helper like `prepareSessionForIteration(task, key, handle, entry)` that returns `Result<SpawnCallbacks | null>` (null = fall through). The remaining steps (worker remap + sendKeys) are already well-decomposed into helper calls. This would bring `reuseSession()` to ~60 lines — still high but under the critical threshold — and give the preparation phase a testable boundary.
+
+### MEDIUM
+
+**`EventDrivenWorkerPool.spawn()` at 104 lines with 4 nesting levels** - `src/implementations/event-driven-worker-pool.ts:200`
+**Confidence**: 82%
+- Problem: The `spawn()` method has grown to 104 lines despite having `launchAndRegister()` and `tryReuseSession()` extracted. The method still handles resource checks, adapter resolution, config construction, reuse logic, and post-spawn registration in a single flow. The deepest nesting (the `if (psk)` block at line 266 + the `if (result.ok && psk)` block at line 290) makes the persistent session path mentally taxing to trace.
+- Fix: Consider extracting the "post-spawn persistent registration" block (lines 290–300) into a named helper like `registerPersistentEntry(psk, result)`. This small extraction would reduce `spawn()` by 10 lines and name the intent clearly.
+
+**`prepareForReuse()` has verbose synthetic config boilerplate (79 lines)** - `src/implementations/tmux/tmux-connector.ts:386`
+**Confidence**: 80%
+- Problem: The `prepareForReuse()` method dedicates 18 lines (414–430) to a comment explaining a synthetic config object and constructing it with dummy values (`command: ''`, `agentArgs: []`). This boilerplate exists because `buildActiveSession()` accepts a full `TmuxSpawnConfig` but only reads a few fields. The construction is not complex per se, but the explanatory comments signal the code is working around a type that is too broad for this usage.
+- Fix: Introduce a narrower parameter type (e.g. `BuildSessionConfig` with only the fields `buildActiveSession` actually reads: `taskId`, `sessionsDir`, `name`, `staleness?`, `persistent?`, `agent`) and use it as the parameter type. This eliminates the synthetic config with dummy fields and the 5-line comment explaining why they are unused. Not blocking, but reduces cognitive overhead for future maintainers.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`runInit()` at 56 lines — just over the warning threshold** - `src/cli/commands/init.ts:417`
+**Confidence**: 80%
+- Problem: After this PR's refactoring (extracting `finalizeInit` and `resolveTargetAgents`), `runInit()` is 56 lines. This is an improvement from the pre-existing state (previously 65+), and the function is now linear and flat (max nesting depth 2). It is on the boundary of "warning" rather than genuinely complex.
+- Fix: No action needed for this PR — the refactoring already reduced it. If a future change adds another branch, consider extracting the non-interactive path (lines 423–435) into a named helper.
+
+## Pre-existing Issues (Not Blocking)
+
+### HIGH
+
+**`TmuxConnector` class at 964 lines** - `src/implementations/tmux/tmux-connector.ts`
+**Confidence**: 85%
+- Problem: The class is at 964 lines with 26+ methods. This exceeds the 500-line file-length warning threshold significantly. While individual methods are mostly well-decomposed (spawn: 39 lines, createAndRegisterSession: 41 lines, prepareForReuse: 79 lines), the class as a whole has a large surface area encompassing session lifecycle, staleness detection, message ordering/delivery, and flush management.
+- Fix: Consider extracting the message delivery pipeline (handleMessageFile, deliverPendingMessages, deliverSingle, forceDeliverRemaining, parseMessageFile, flushPendingFiles — ~150 lines) into a separate `MessageDeliveryPipeline` class. This would bring TmuxConnector closer to 800 lines and give message ordering its own testable boundary. Track as tech debt — not actionable in this PR.
+
+**`EventDrivenWorkerPool` class at 1082 lines** - `src/implementations/event-driven-worker-pool.ts`
+**Confidence**: 85%
+- Problem: At 1082 lines, this is the largest class in the system. It handles spawning, persistent session reuse, worker state management, timer lifecycle, output flushing, and heartbeating. The persistent-session reuse protocol added in this branch (reuseSession, tryReuseSession, reRegisterWorkerForReuse, remapExistingWorkerForReuse, restartTimersForWorker, cleanupPersistentSession) is necessary complexity, but the class is approaching the point where a new contributor cannot hold the full state machine in mind.
+- Fix: Consider extracting the persistent-session reuse protocol (~200 lines: tryReuseSession, reuseSession, reRegisterWorkerForReuse, remapExistingWorkerForReuse, restartTimersForWorker, cleanupPersistentSession) into a `PersistentSessionCoordinator` class that receives the tmuxConnector and workerRepository as deps. Track as tech debt.
+
+## Suggestions (Lower Confidence)
+
+- **Eval + jq one-pass extraction pattern** - `scripts/autobeat-stop-hook.sh:17` (Confidence: 65%) — The `eval "$(... | jq ...)"` pattern (lines 17-22) is powerful but dense; a reader unfamiliar with jq's `@sh` escaping needs several minutes to verify correctness. The nested single-quote escaping (`"'\''" + "'\''"``) adds visual noise. Consider adding a one-line structural comment above each field showing the expected output shape.
+
+- **`triggerExit()` dual-path branching** - `src/implementations/tmux/tmux-connector.ts:995` (Confidence: 70%) — The method now has two completely separate exit paths (persistent parking vs non-persistent destruction) with shared preamble. At 66 lines with the two paths, it is within bounds but approaching the point where splitting into `parkSession()` and `destroyExitedSession()` private helpers would improve scanability.
+
+- **`hasStopHookCommand()` nested some-within-some** - `src/cli/commands/init.ts:175` (Confidence: 62%) — Two nested `.some()` calls make it subtly hard to verify what shape of object matches. Functionally correct but a brief comment above the outer `.some()` explaining the expected array shape would help.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 2 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 2 | 0 | 0 |
+
+**Complexity Score**: 7/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR demonstrates good decomposition discipline overall — `configureAgentHook` was brought down to 33 lines, `finalizeInit` and `resolveTargetAgents` cleanly extracted, the wrapper pipeline removed (-1,187 lines is a net simplification). The one blocking HIGH issue (`reuseSession` at 114 lines) is the only function that meaningfully exceeds the 50-line threshold and has enough sequential concern mixing to warrant extraction. The MEDIUM items are advisory. The pre-existing class-size issues are structural debt that predates this PR.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/consistency.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/consistency.md
@@ -1,0 +1,80 @@
+# Consistency Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Stale "wrapper" reference in orchestrate-interactive.ts:264** - `src/cli/commands/orchestrate-interactive.ts:264`
+**Confidence**: 95%
+- Problem: Comment says "the wrapper is now alive and ready" but 4 other wrapper references in the same file were updated to "setup shim" / "Stop hook" terminology in this PR. This one was missed.
+- Fix:
+```typescript
+// Deliver the initial prompt via send-keys (the session is now alive and ready).
+```
+
+**Stale "wrapper" reference in event-driven-worker-pool.ts:657** - `src/implementations/event-driven-worker-pool.ts:657`
+**Confidence**: 92%
+- Problem: Comment says "baked-arg wrapper path has been removed" — while technically accurate as historical context, other comments in the same file were updated (e.g. lines 235-236) to remove wrapper references entirely. This comment references a removed concept without context.
+- Fix:
+```typescript
+// Step 10: Send prompt via sendKeys. All sessions use interactive mode;
+// prompt is always present (delivered via send-keys, not baked into args).
+```
+
+**Stale "wrapper" reference in test comment** - `tests/unit/implementations/tmux/tmux-connector.test.ts:2832`
+**Confidence**: 90%
+- Problem: Test comment says "Need a hooks that generates wrapper ok but initTaskDirectory fails" — the wrapper concept was removed in this PR and all other test labels were updated. This is a leftover from the prior naming.
+- Fix:
+```typescript
+// Need a hooks where generateSetupShim succeeds but initTaskDirectory fails
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**SetupShimConfig JSDoc says "persistent" but all sessions now use it** - `src/implementations/tmux/types.ts:221-222`
+**Confidence**: 88%
+- Problem: JSDoc says "Configuration for generating a setup shim for a persistent interactive session. Used when persistent=true — the agent runs as an interactive REPL." After this PR, ALL sessions use the setup shim (wrapper pipeline removed). The "Used when persistent=true" qualifier is now incorrect — every session spawns via `generateSetupShim()`.
+- Fix:
+```typescript
+/**
+ * Configuration for generating a setup shim for an interactive session.
+ * All sessions use this path — the agent runs as an interactive REPL.
+ */
+```
+
+**TmuxHooksPort.generateSetupShim JSDoc says "persistent interactive session"** - `src/implementations/tmux/types.ts:253`
+**Confidence**: 88%
+- Problem: Same issue — JSDoc says "Generates the session directory and setup shim for a persistent interactive session" but this is now called for ALL sessions regardless of the `persistent` flag.
+- Fix:
+```typescript
+/**
+ * Generates the session directory and setup shim for an interactive session.
+ * The shim initialises the messages directory and seq file, then execs the agent
+ * interactively (no --print). Output is captured via the Stop hook mechanism.
+ */
+```
+
+## Pre-existing Issues (Not Blocking)
+
+_None at CRITICAL severity._
+
+## Suggestions (Lower Confidence)
+
+- **Inconsistent Phase naming scheme** - Multiple source files (Confidence: 65%) — Some comments reference "Phase B" (alphabetical), others "Phase 5", "Phase 7", etc. (numeric). The new code in this PR uses "Phase B" while existing code uses sequential numbers. This is an organic style difference; no functional impact but could confuse future readers about the ordering relationship between phases.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 3 | 0 |
+| Should Fix | 0 | 0 | 2 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Consistency Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The PR demonstrates strong consistency overall. The wrapper-to-stop-hook terminology migration is thorough across 20+ files with only 3 stray references remaining (2 in source, 1 in tests). The new `SessionState` enum, `prepareForReuse()` protocol, and `initTaskDirectory()` method all follow existing patterns (Result types, dependency injection, error-first guards). The `SpawnCallbacks` import relocation from `types.ts` to `core/tmux-types.ts` is clean and the barrel re-export maintains backward compatibility. Type exports via `index.ts` correctly include all new types. The mock fixture (`createMockTmuxConnector`) adds `prepareForReuse` consistent with the existing method stub pattern. Conditions: fix the 3 stale comment references and update the 2 JSDoc inaccuracies in `types.ts`.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/dependencies.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/dependencies.md
@@ -1,0 +1,46 @@
+# Dependencies Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+(none)
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **`files` whitelist does not explicitly include `scripts/`** - `package.json:9-13` (Confidence: 65%) — The `files` array (`["dist", "skills", "README.md", "LICENSE"]`) does not list `scripts/`, and `.npmignore` explicitly excludes `scripts/`. The `bin` entry overrides both (confirmed via `npm pack --dry-run`), but this implicit inclusion relies on npm-specific behavior. Adding `"scripts/autobeat-stop-hook.sh"` to the `files` array would make intent explicit and prevent confusion if someone later refactors `bin` entries. Not a functional issue today.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Dependencies Score**: 9/10
+**Recommendation**: APPROVED
+
+## Analysis Notes
+
+The only change to `package.json` is adding a new `bin` entry:
+```json
+"autobeat-stop-hook": "scripts/autobeat-stop-hook.sh"
+```
+
+Verified:
+- No new runtime or dev dependencies added or removed
+- No version bumps to existing dependencies
+- Lockfile (`package-lock.json`) unchanged — consistent with no dependency changes
+- Script file exists, has executable permissions (755) tracked in git, and correct `#!/bin/bash` shebang
+- `npm pack --dry-run` confirms the script (4.8kB) is included in the published tarball despite `files` whitelist and `.npmignore` exclusion (npm always includes `bin` targets)
+- The bin name `autobeat-stop-hook` is clear, namespaced to the project, and not a typosquat risk
+- No supply chain concerns — the script is first-party code, not a third-party dependency

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/performance.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/performance.md
@@ -1,0 +1,70 @@
+# Performance Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Stop hook: multiple jq process spawns per invocation** - `scripts/autobeat-stop-hook.sh:17,27,30,80,105`
+**Confidence**: 82%
+- Problem: The stop hook spawns jq up to 5 times per invocation (lines 17, 27, 30, 80, 105). In the worst-case (transcript fallback + direct response + usage), this is 4-5 separate process forks for a hook that fires on every single agent turn. While individual jq invocations are fast (~5-10ms), the cumulative overhead across a long-running loop with hundreds of iterations adds up (500+ process forks just for the hook).
+- Impact: For high-iteration loops, the hook contributes measurable latency per turn. The line-17 extraction jq handles 4 fields in one pass (good), but lines 27, 30, 80, and 105 are additional invocations that could be consolidated.
+- Fix: The current architecture already consolidates the main extraction into one jq call (line 17). Lines 27+30 (transcript fallback) only fire when `RESPONSE` is empty, and line 80 only fires for direct responses. This is acceptable given the conditional branching. The real concern is line 105 which always fires when usage data exists -- consider inlining the `jq -Rs .` into the main extraction pass. However, given that this is shell code on the hot path and each invocation is only processing small payloads, this is a should-fix rather than a blocker.
+
+### MEDIUM
+
+**Regex recompilation on every orchestration request** - `src/implementations/base-agent-adapter.ts:415`
+**Confidence**: 85%
+- Problem: `ORCHESTRATOR_ID_RE` is constructed inside `buildSpawnEnv()` which is called on every `spawn()`. The regex is constant and should be module-level.
+- Impact: Regex compilation is cheap (~microseconds) but this is a pattern violation -- constants should not be re-created per call. On a system spawning 50+ tasks in rapid succession (pipeline launch), this is 50 unnecessary compilations.
+- Fix: Move to module scope:
+```typescript
+const ORCHESTRATOR_ID_RE = /^orchestrator-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+```
+Note: This is pre-existing code (not introduced by this PR) but it is in the direct execution path of the changed `buildTmuxCommand` flow.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**process.env iteration on every spawn (unchanged but performance-relevant)** - `src/implementations/base-agent-adapter.ts:408-412`
+**Confidence**: 80%
+- Problem: `Object.entries(process.env).filter(...)` iterates the entire process environment (~50-200 entries) on every spawn. With interactive mode now being the sole path for all tasks (not just persistent ones), every single task spawn goes through this. Previously wrapper-mode tasks also went through it, so the frequency hasn't increased, but it's worth noting as a candidate for caching since the env stripping list is static per adapter.
+- Impact: Negligible for most workloads (one spawn per task), but in pipeline burst scenarios (10 tasks at once), it's 10 full env scans. The filter uses `.some()` with prefix matching which is O(prefixes * entries).
+- Fix: Could cache `cleanEnv` at adapter construction time and invalidate only if `process.env` is known to change. However, process.env can be mutated between spawns (e.g., by runtime config resolution), so caching requires careful invalidation. Not a blocker -- the current cost is bounded and small.
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**300ms fixed settle delay on every loop iteration reuse** - `src/implementations/event-driven-worker-pool.ts:425`
+**Confidence**: 85%
+- Problem: `CLEAR_SETTLE_MS = 300` is an unconditional sleep on every persistent session reuse. This adds 300ms of latency to every loop iteration transition regardless of whether the `/clear` command actually needs that long.
+- Impact: For a 100-iteration loop, that is 30 seconds of pure idle wait. The comment says "Wait for /clear to settle" but there is no mechanism to detect when `/clear` has actually completed.
+- Fix: Consider a shorter delay (100ms may suffice for tmux command propagation) or implement a sentinel-based detection where the agent acknowledges the clear. This is pre-existing design and outside the scope of this PR.
+
+## Suggestions (Lower Confidence)
+
+- **head -c 10485760 buffering** - `scripts/autobeat-stop-hook.sh:8` (Confidence: 65%) -- Reading up to 10MB into a shell variable on every stop hook invocation. If the hook data is typically small (a few KB), this is fine since `head` will return immediately when stdin closes. But if stdin is slow to close (e.g., pipe buffer draining), this could add latency. The 10MB cap is a safety guard, not a performance concern in practice.
+
+- **Synchronous mkdirSync in prepareForReuse hot path** - `src/implementations/tmux/tmux-hooks.ts:161-163` (Confidence: 68%) -- `initTaskDirectory()` uses sync filesystem calls on the loop-iteration reuse path. This blocks the Node.js event loop for the duration of the mkdir+write. For local filesystems this is typically < 1ms, but on networked/slow storage it could be problematic. The sync approach is intentional (Result type return, matching existing patterns).
+
+- **parkedSessionAgents map growth** - `src/implementations/tmux/tmux-connector.ts:176` (Confidence: 62%) -- The `parkedSessionAgents` map grows with each park and is cleaned on reuse/destroy, but if reuse repeatedly fails and sessions are destroyed externally (not via the connector), entries could leak. However, the destroy() method at line 302 does clean up the entry, so this is bounded in practice.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Performance Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The architectural change from wrapper pipeline to unified Stop hook is a net performance improvement: it eliminates the per-line jq processing that the old wrapper performed (one `jq -Rs .` per stdout line), replacing it with per-turn hook processing (one jq call per complete agent response). For a typical agent turn that produces hundreds of stdout lines, this is a significant reduction in process forks.
+
+The `prepareForReuse()` path is well-designed with O(1) session lookups via the `parkedSessionAgents` map and the `persistentSessions` map. The staleness timer skip-if-same-interval optimization prevents O(N) timer churn during batch spawns.
+
+Conditions: The regex recompilation (line 415, base-agent-adapter.ts) is trivial to fix and should be moved to module scope. The stop hook jq invocation count is acceptable given the conditional branching.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/regression.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/regression.md
@@ -1,0 +1,79 @@
+# Regression Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+(none)
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Stale comment reference to "wrapper"** - `src/cli/commands/orchestrate-interactive.ts:264` (Confidence: 65%) — Line 264 comment says "the wrapper is now alive and ready" but should say "the setup shim is now alive and ready" or "the agent is now alive and ready". This is a documentation-level inconsistency, not a functional issue.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | - |
+| Should Fix | - | 0 | 0 | - |
+| Pre-existing | - | - | 0 | 0 |
+
+**Regression Score**: 9/10
+**Recommendation**: APPROVED
+
+## Analysis Notes
+
+### Migration Completeness
+
+The removal of the wrapper pipeline is complete:
+
+1. **Removed types**: `WrapperConfig`, `WrapperManifest`, `CommunicationMode` — zero remaining references in src/ or tests/.
+2. **Removed methods**: `buildWrapperFlags()` (abstract + overrides in Claude/Codex adapters), `buildWrapperScript()`, `buildArgs()`, `buildInteractiveArgs()`, `generateWrapper()` — all removed with no dangling consumers.
+3. **Removed CLI flags**: `--print`, `--output-format json`, `--output-format stream-json`, `--quiet` — no remaining references in source code.
+4. **Barrel exports**: `WrapperConfig`, `WrapperManifest`, `CommunicationMode` removed from `tmux/index.ts`; `SetupShimConfig` and `SetupShimManifest` added.
+5. **All consumers updated**: `TmuxConnector.spawn()` no longer branches between wrapper and setup shim paths. All sessions now follow the unified interactive (setup shim) path.
+
+### Behavioral Equivalence
+
+1. **Non-persistent (one-shot) tasks**: Previously used wrapper pipeline (`--print` mode). Now use interactive mode with Stop hook. Output capture is equivalent — the Stop hook writes the same `OutputMessage` JSON format that the wrapper script produced. Sentinel files (`.done`/`.exit`) are written by the Stop hook instead of the wrapper, using the same file format and atomic write pattern (`.tmp` + `mv`).
+
+2. **Persistent (loop iteration) tasks**: Previously used setup shim with `--output-format stream-json`. Now use setup shim without `--output-format` — the Stop hook captures output per-turn instead of relying on stream-json format. The session lifecycle (park/reuse/destroy) is preserved and enhanced with `prepareForReuse()`.
+
+3. **Usage/cost capture**: The Stop hook explicitly writes a synthetic `stdout` type message containing `{"type":"result","usage":...,"total_cost_usd":...}` (lines 97-112 of stop hook script). This matches the marker pattern that `UsageParser.parseClaudeUsage()` searches for via `combined.lastIndexOf('{"type":"result"')`. Prior resolution (cycle 2) verified.
+
+4. **Interactive orchestrator**: Strips `AUTOBEAT_WORKER=true` from env, causing the Stop hook to exit immediately (line 4 guard). This is NOT a regression — the interactive orchestrator previously also did not use the wrapper pipeline for output capture. Exit detection relies on the staleness timer and tmux attach process exit, which is unchanged behavior.
+
+5. **taskIdRef ordering**: Prior resolution (cycle 2) fixed ordering. In this PR, `taskIdRef.current` is set at Step 5 (line 437 in reuseSession) before `prepareForReuse()`, ensuring callbacks route correctly before any output can arrive. The redundant set in `reRegisterWorkerForReuse` (line 515) is harmless/idempotent.
+
+### New Port Method: `prepareForReuse()`
+
+Added to `TmuxConnectorPort` interface with proper JSDoc. The mock in `tests/fixtures/mocks.ts` is updated. All callers are covered by tests (`tmux-connector.test.ts` has a dedicated `prepareForReuse()` describe block).
+
+### Deleted Test File
+
+`tests/integration/tmux/hook-script-generation.test.ts` — 348 lines deleted. This tested the wrapper pipeline script generation (the `buildWrapperScript` function output). Since the wrapper pipeline is removed, this deletion is appropriate. The equivalent functionality (Stop hook script) has its own comprehensive test file: `tests/integration/tmux/stop-hook.test.ts` (927 lines).
+
+### Cross-Cycle Awareness
+
+Prior cycle 2 resolutions verified as maintained:
+- Usage/cost capture regression: Fixed and verified — Stop hook preserves the `{"type":"result"}` marker pattern.
+- taskIdRef ordering: Fixed and verified — ordering is explicit (set before prepareForReuse, before sendKeys).

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/reliability.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/reliability.md
@@ -1,0 +1,107 @@
+# Reliability Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01T00:59Z
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Stop hook `head -c 10485760` blocks indefinitely on non-pipe stdin** - `scripts/autobeat-stop-hook.sh:8`
+**Confidence**: 82%
+- Problem: `head -c 10485760` reads from stdin with a 10MB cap — this bounds data size, but there is no timeout on the read itself. If the calling agent fails to close its stdin pipe (e.g., crashes mid-write, or the hook is accidentally invoked outside an agent context where AUTOBEAT_WORKER=true but stdin is a terminal), the script will hang forever waiting for EOF or 10MB of data. The early-exit guard on line 4 (`[[ "${AUTOBEAT_WORKER:-}" = "true" ]] || exit 0`) prevents accidental terminal invocations, but does not prevent the hang when the agent process itself is stuck.
+- Impact: A hung stop hook blocks the agent's turn-completion event loop (hooks are synchronous in Claude Code), stalling the entire task indefinitely.
+- Fix: Add a read timeout using `timeout` or shell `read -t`:
+```bash
+# Replace line 8:
+HOOK_DATA=$(timeout 30 head -c 10485760) || { exit 0; }
+```
+Note: `timeout` is coreutils (available on Linux CI, may need `gtimeout` on macOS). An alternative is to accept the risk since Claude Code guarantees stdin pipe closure, but document the assumption explicitly.
+
+**Stop hook `eval` of jq output with no validation of eval input shape** - `scripts/autobeat-stop-hook.sh:17-22`
+**Confidence**: 80%
+- Problem: The `eval` command executes whatever jq produces. While the jq filter uses `@sh` escaping and the outer `|| true` suppresses errors, if jq produces malformed output (e.g., partial write due to OOM or signal), `eval` could execute truncated shell fragments. The `2>/dev/null || true` after `eval` means failures are silent, leaving variables potentially unset or set to garbage.
+- Impact: In the degraded case, RESPONSE, STOP_REASON, USAGE_JSON, and TOTAL_COST_USD may be uninitialized (empty strings in bash), which is handled downstream. However, a pathologically truncated eval could assign partial values. Risk is LOW in practice because jq's `@sh` output is atomic per field.
+- Fix: Add a defensive check that the four variables are set (even if empty) after eval, or switch to individual `jq -r` calls with variable assignment:
+```bash
+# Defensive: verify eval succeeded by checking STOP_REASON has a value
+if [ -z "${STOP_REASON+x}" ]; then
+  STOP_REASON="end_turn"
+  RESPONSE=""
+  USAGE_JSON=""
+  TOTAL_COST_USD=""
+fi
+```
+
+### MEDIUM
+
+**`prepareForReuse` does not validate session liveness before re-registering** - `src/implementations/tmux/tmux-connector.ts:386`
+**Confidence**: 83%
+- Problem: `prepareForReuse()` creates a new task directory and registers a new ActiveSession without first verifying that the tmux session (`handle.sessionName`) is still alive. If the tmux session died between `triggerExit` (park) and `prepareForReuse` (reuse), the new watchers will watch directories that will never receive output, and the staleness timer is the only detection mechanism (up to `maxSilenceMs` delay, default 60s).
+- Impact: A dead-but-parked session causes the next loop iteration to wait up to 60s before staleness detection fires, degrading loop throughput. The WorkerPool's `tryReuseSession` does check `isAlive()` before calling `reuseSession()`, so this is defense-in-depth rather than a primary path gap.
+- Fix: Add an `isAlive` check at the top of `prepareForReuse`:
+```typescript
+// After the duplicate-taskId guard:
+const aliveResult = this.deps.sessionManager.isAlive(handle.sessionName);
+if (!aliveResult.ok || !aliveResult.value) {
+  return err(tmuxSessionFailed('prepareForReuse', `parked session '${handle.sessionName}' is no longer alive`));
+}
+```
+
+**Sequence counter race between Stop hook writes and `initTaskDirectory` reset** - `src/implementations/tmux/tmux-hooks.ts:163` + `scripts/autobeat-stop-hook.sh:68-70`
+**Confidence**: 80%
+- Problem: `initTaskDirectory()` writes `'0'` to `.seq`, and the Stop hook reads `.seq`, increments, and writes back. The reuse protocol is: park (hook wrote last message) -> `setEnvironment(AUTOBEAT_TASK_ID)` -> `/clear` -> settle delay -> `initTaskDirectory(newTaskId)` -> `sendKeys(prompt)`. Since the NEW task directory is created under `newTaskId`, and the hook reads `AUTOBEAT_TASK_ID` from the tmux environment (updated in step 2), the hook and init write to different directories. However, if a late Stop hook fires for the `/clear` command itself (between env update and initTaskDirectory), it would write to `newTaskId`'s directory before init resets `.seq` to 0, potentially losing a message.
+- Impact: In normal operation, `/clear` does not trigger a Stop hook (it is a client-side command, not an agent turn). Risk is theoretical unless a future agent CLI change fires hooks on internal commands.
+- Fix: Document the ordering invariant explicitly, or have `initTaskDirectory` use `'0'` only if `.seq` does not already exist (idempotent init):
+```typescript
+// Only reset seq if file doesn't exist (avoids clobbering in-flight writes)
+if (!existsSync(seqFilePath)) {
+  this.deps.writeFile(seqFilePath, '0', { mode: FILE_MODE });
+}
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`dispose()` clears `parkedSessionAgents` but does not destroy parked tmux processes directly** - `src/implementations/tmux/tmux-connector.ts:476`
+**Confidence**: 82%
+- Problem: `dispose()` iterates `activeSessions` to destroy tmux processes and clear state, then clears `parkedSessionAgents`. But parked sessions have been removed from `activeSessions` by `triggerExit()`, so they are NOT iterated by `dispose()`. Their tmux processes would leak if `dispose()` were called without `killAll()` having run first.
+- Impact: Currently the only caller of `dispose()` is `killAll()` in the WorkerPool, which calls `cleanupPersistentSession()` first (destroying parked sessions), so in practice this is safe. However, if `dispose()` is ever called directly (e.g., emergency shutdown, test teardown), parked tmux sessions will be orphaned. The `parkedSessionAgents` map holds the session names needed to destroy them.
+- Fix: Before the `activeSessions` iteration in `dispose()`, iterate `parkedSessionAgents` and destroy those sessions too:
+```typescript
+dispose(): void {
+  // Destroy any parked sessions first (not in activeSessions)
+  for (const [sessionName] of this.parkedSessionAgents) {
+    try {
+      this.deps.sessionManager.destroySession(sessionName);
+    } catch { /* best-effort */ }
+  }
+  this.parkedSessionAgents.clear();
+  // ... existing activeSessions cleanup ...
+}
+```
+
+## Pre-existing Issues (Not Blocking)
+
+(None at CRITICAL severity in unchanged code.)
+
+## Suggestions (Lower Confidence)
+
+- **`CLEAR_SETTLE_MS = 300` is a fixed magic delay without retry/confirmation** - `src/implementations/event-driven-worker-pool.ts:153` (Confidence: 65%) — The 300ms settle delay assumes /clear completes in that window. On slow systems or under load, this may not hold. A confirmation signal (e.g., detecting the prompt reappearing) would be more reliable but adds complexity.
+
+- **Stop hook transcript fallback reads only last 50 lines** - `scripts/autobeat-stop-hook.sh:29` (Confidence: 62%) — `tail -n 50` bounds reads (good for reliability), but very long assistant messages (e.g., large code generation) may be truncated. This is an intentional trade-off documented in the comment, but worth noting for awareness.
+
+- **No explicit upper bound on `parkedSessionAgents` map growth** - `src/implementations/tmux/tmux-connector.ts:176` (Confidence: 60%) — If sessions are parked but never reused or cleaned up due to a bug in the loop handler, the map grows unboundedly. The practical bound is `MAX_CONCURRENT_SESSIONS` (20), since you cannot park more sessions than you spawned. Implicit bound via spawn cap is sufficient.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 2 | 2 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Reliability Score**: 7/10
+**Recommendation**: CHANGES_REQUESTED
+
+The core design is well-bounded: session caps (MAX_CONCURRENT_SESSIONS=20), message buffer caps (MAX_PENDING_MESSAGES=100), staleness timers with explicit intervals (MIN_CHECK_INTERVAL_MS=1000), atomic file writes via tmp+mv, bounded loop iteration in `deliverPendingMessages`, and defense-in-depth state guards (`session.state !== 'active'`) throughout. The stop hook bounds its stdin read (10MB cap) and transcript read (50 lines). The primary reliability gaps are: (1) the stdin read has no timeout bound, and (2) the `eval` path lacks post-validation of assigned variables. Both are shell-layer concerns with mitigations in the calling agent's pipe management, but explicit bounds would eliminate the residual risk.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/resolution-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/resolution-summary.md
@@ -1,0 +1,48 @@
+# Resolution Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01_0059
+**Review**: .devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059
+**Command**: /resolve
+
+## Statistics
+| Metric | Value |
+|--------|-------|
+| Total Issues | 20 |
+| Fixed | 20 |
+| False Positive | 0 |
+| Deferred | 0 |
+| Blocked | 0 |
+
+## Fixed Issues
+| Issue | File:Line | Commit |
+|-------|-----------|--------|
+| Transcript path traversal — prefix allowlist validation | scripts/autobeat-stop-hook.sh:28 | b90a699 |
+| eval post-validation guard + @sh trust boundary comment | scripts/autobeat-stop-hook.sh:17 | b90a699 |
+| stdin timeout — documented trust assumption (Claude Code pipe closure contract) | scripts/autobeat-stop-hook.sh:8 | b90a699 |
+| parkedSessionAgents fallback masks bugs — replaced with explicit err() | src/implementations/tmux/tmux-connector.ts:411 | d5d89e1 |
+| syntheticConfig satisfies TmuxSpawnConfig annotation | src/implementations/tmux/tmux-connector.ts:422 | d5d89e1 |
+| prepareForReuse isAlive defense-in-depth guard | src/implementations/tmux/tmux-connector.ts:386 | d5d89e1 |
+| dispose() destroys parked tmux sessions before clearing map | src/implementations/tmux/tmux-connector.ts:476 | d5d89e1 |
+| reuseSession() decomposed — extracted prepareSessionForIteration helper | src/implementations/event-driven-worker-pool.ts:381 | 1fb8d13 |
+| spawn() decomposed — extracted registerPersistentEntry helper | src/implementations/event-driven-worker-pool.ts:200 | 1fb8d13 |
+| Stale "wrapper" comment in worker pool step 10 | src/implementations/event-driven-worker-pool.ts:657 | 1fb8d13 |
+| SetupShimConfig JSDoc — removed "persistent" qualifier | src/implementations/tmux/types.ts:221 | 6047352 |
+| TmuxHooksPort.generateSetupShim JSDoc — removed "persistent" qualifier | src/implementations/tmux/types.ts:253 | 6047352 |
+| Stale "wrapper" in orchestrate-interactive comment | src/cli/commands/orchestrate-interactive.ts:264 | 6047352 |
+| Stale "wrapper" in test comment | tests/unit/implementations/tmux/tmux-connector.test.ts:2832 | 6047352 |
+| SpawnCallbacks removed from barrel re-export (canonical source is core) | src/implementations/tmux/index.ts | 6047352 |
+| Real setTimeout replaced with fake timers in test | tests/unit/implementations/tmux/tmux-connector.test.ts:614 | 129690d |
+| Shared tmpDir sequential-execution comment | tests/integration/tmux/stop-hook.test.ts:49 | 129690d |
+| initTaskDirectory ordering invariant documented | src/implementations/tmux/tmux-hooks.ts:163 | 129690d |
+| ORCHESTRATOR_ID_RE hoisted to module scope | src/implementations/base-agent-adapter.ts:415 | 129690d |
+| hasStopHookCommand type guards extracted | src/cli/commands/init.ts:178 | 129690d |
+
+## False Positives
+_(none)_
+
+## Deferred to Tech Debt
+_(none)_
+
+## Blocked
+_(none)_

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/review-summary.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/review-summary.md
@@ -1,0 +1,196 @@
+# Code Review Summary
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01_0059
+**Reviewers**: 10 (security, architecture, performance, complexity, consistency, regression, testing, reliability, typescript, dependencies)
+
+## Merge Recommendation: CHANGES_REQUESTED
+
+The PR implements a significant architectural transformation (wrapper pipeline removal → unified Stop hook model) with comprehensive test coverage and clean decomposition. However, 3 issues from the Reliability review (stdin hang, eval validation, parked session liveness check) are blocking; 7 issues from Architecture, Complexity, and Security should be fixed before merge per review methodology standards. The Regression review confirms zero functional regressions from prior cycle 2 resolutions.
+
+---
+
+## Issue Summary by Category
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW | Total |
+|----------|----------|------|--------|-----|-------|
+| **Blocking** (in your changes) | 0 | 5 | 7 | 0 | **12** |
+| **Should Fix** (touched code) | 0 | 0 | 6 | 0 | **6** |
+| **Pre-existing** (not blocking) | 0 | 2 | 5 | 0 | **7** |
+
+**Total Issues**: 25 across all reviewers
+**Confidence Aggregation**: Issues appearing in 2+ reviews boosted by 10% per additional reviewer (cap 100%)
+
+---
+
+## Blocking Issues (Must Fix Before Merge)
+
+### HIGH Severity (5 issues)
+
+| Issue | File:Line | Confidence | Category | Fix Effort |
+|-------|-----------|------------|----------|-----------|
+| **parkedSessionAgents secondary map introduces subtle coupling** | `src/implementations/tmux/tmux-connector.ts:176` | 82% | Architecture | Small — Replace `?? 'claude'` fallback with explicit error |
+| **Stop hook stdin read blocks indefinitely on non-pipe stdin** | `scripts/autobeat-stop-hook.sh:8` | 82% | Reliability | Small — Add `timeout 30` wrapper |
+| **Transcript path traversal in stop hook** | `scripts/autobeat-stop-hook.sh:28` | 82% | Security | Small — Add prefix validation (`case "$TRANSCRIPT"`) |
+| **reuseSession() exceeds 50-line function length (114 lines)** | `src/implementations/event-driven-worker-pool.ts:381` | 90% | Complexity | Medium — Extract prepareSessionForIteration helper |
+| **EventDrivenWorkerPool.spawn() at 104 lines with 4 nesting levels** | `src/implementations/event-driven-worker-pool.ts:200` | 82% | Complexity | Small — Extract registerPersistentEntry helper |
+
+### MEDIUM Severity (7 issues)
+
+| Issue | File:Line | Confidence | Category | Fix Effort |
+|-------|-----------|------------|----------|-----------|
+| **syntheticConfig in prepareForReuse uses empty command/agentArgs** | `src/implementations/tmux/tmux-connector.ts:422-430` | 83% | Architecture | Small — Extract narrower ActiveSessionConfig type or add assertion guard |
+| **SpawnCallbacks re-export creates circular barrel path** | `src/implementations/tmux/types.ts` | 85% | Architecture | Trivial — Remove from barrel re-export list |
+| **Stop hook eval lacks validation of assigned variable shape** | `scripts/autobeat-stop-hook.sh:17-22` | 80% | Reliability | Small — Add post-eval validation or use separate jq invocations |
+| **prepareForReuse does not validate session liveness** | `src/implementations/tmux/tmux-connector.ts:386` | 83% | Reliability | Small — Add `isAlive()` check at method start |
+| **SetupShimConfig JSDoc says "persistent" but all sessions now use it** | `src/implementations/tmux/types.ts:221-222` | 95% | TypeScript | Trivial — Update JSDoc to remove "persistent" qualifier |
+| **TmuxHooksPort.generateSetupShim JSDoc says "persistent interactive session"** | `src/implementations/tmux/types.ts:253` | 88% | TypeScript | Trivial — Update JSDoc to remove "persistent" qualifier |
+| **Stale "wrapper" reference in orchestrate-interactive.ts** | `src/cli/commands/orchestrate-interactive.ts:264` | 95% | Consistency | Trivial — Update comment |
+
+---
+
+## Should-Fix Issues (Touched Code)
+
+| Issue | File:Line | Confidence | Category | Fix Effort |
+|-------|-----------|------------|----------|-----------|
+| **Stale "wrapper" reference in event-driven-worker-pool.ts:657** | `src/implementations/event-driven-worker-pool.ts:657` | 92% | Consistency | Trivial — Update comment |
+| **Stale "wrapper" reference in test comment** | `tests/unit/implementations/tmux/tmux-connector.test.ts:2832` | 90% | Consistency | Trivial — Update test comment |
+| **SetupShimConfig JSDoc persistence qualifier incorrect** | `src/implementations/tmux/types.ts:221-222` | 88% | Consistency | Trivial — Remove "Used when persistent=true" |
+| **dispose() clears parkedSessionAgents but doesn't destroy parked tmux processes** | `src/implementations/tmux/tmux-connector.ts:476` | 82% | Reliability | Medium — Iterate and destroy parked sessions before clearing map |
+| **Real setTimeout in async test (line 614)** | `tests/unit/implementations/tmux/tmux-connector.test.ts:614` | 82% | Testing | Small — Replace with fake timers + `vi.advanceTimersByTimeAsync` |
+| **syntheticConfig lacks type annotation — use satisfies** | `src/implementations/tmux/tmux-connector.ts:422-430` | 82% | TypeScript | Trivial — Add `satisfies TmuxSpawnConfig` |
+
+---
+
+## Pre-existing Issues (Not Blocking)
+
+| Issue | File | Confidence | Category | Status |
+|-------|------|------------|----------|--------|
+| **TmuxConnector class at 1118 lines** | `src/implementations/tmux/tmux-connector.ts` | 90% | Architecture | Track as tech debt — extract MessageDeliveryPipeline |
+| **EventDrivenWorkerPool class at 1082 lines** | `src/implementations/event-driven-worker-pool.ts` | 85% | Complexity | Track as tech debt — extract PersistentSessionCoordinator |
+| **300ms fixed settle delay on every loop reuse** | `src/implementations/event-driven-worker-pool.ts:425` | 85% | Performance | Separate issue — consider sentinel-based detection |
+| **Regex recompilation on every spawn** | `src/implementations/base-agent-adapter.ts:415` | 85% | Performance | Separate issue — move ORCHESTRATOR_ID_RE to module scope |
+| **process.env iteration on every spawn** | `src/implementations/base-agent-adapter.ts:408-412` | 80% | Performance | Separate issue — consider caching with invalidation |
+| **Eval on jq output safe by construction but fragile** | `scripts/autobeat-stop-hook.sh:17` | 80% | Security | Separate issue — document trust assumption or use alternative pattern |
+| **SESSIONS_DIR path traversal check is regex-only** | `scripts/autobeat-stop-hook.sh:48` | 65% | Security | Separate issue — consider `realpath` check |
+
+---
+
+## Convergence Status
+
+### Issues Appearing in Multiple Reviews (High Confidence)
+
+| Finding | Reviewers | Boosted Confidence |
+|---------|-----------|-------------------|
+| Stale "wrapper" comments in source code (3 locations) | consistency, regression | 95% → 98% |
+| SetupShimConfig JSDoc persistence qualifier | typescript, consistency | 88% → 98% |
+| parkedSessionAgents coupling (fallback masking bugs) | architecture | 82% → 82% |
+| Stop hook stdin timeout missing | reliability, security | 82% → 92% |
+| reuseSession() complexity | complexity | 90% → 90% |
+| Regex recompilation in spawn path | performance | 85% → 85% |
+| Session liveness check missing in prepareForReuse | reliability | 83% → 83% |
+
+### Issues With Full Reviewer Agreement
+
+- **parkedSessionAgents secondary map fallback** — flagged by Architecture
+- **reuseSession() function length** — flagged by Complexity (blocking), noted by others
+- **SpawnCallbacks barrel re-export** — flagged by Architecture
+- **Transcript path traversal** — flagged by Security (high impact)
+
+### Divergent Findings
+
+- **dispose() parked session destruction**: Reliability flagged as MEDIUM should-fix; others did not mention. This is defense-in-depth; rated as should-fix per Reliability's depth analysis.
+- **Eval validation**: Reliability rates as HIGH (explicit validation needed), Security rates as MEDIUM (safe by construction but fragile). Taking Reliability's more conservative stance.
+
+---
+
+## Action Plan
+
+### Phase 1: Blocking Issues (5 HIGH + 7 MEDIUM) — 15 minutes
+
+#### Architecture Fixes (2 issues)
+1. **parkedSessionAgents fallback**: Replace `?? 'claude'` with explicit error return at `src/implementations/tmux/tmux-connector.ts:411`
+2. **SpawnCallbacks barrel**: Remove from `src/implementations/tmux/index.ts` re-exports
+
+#### Complexity Fixes (2 issues)
+3. **reuseSession() extraction**: Extract `prepareSessionForIteration()` helper covering lines 397-427 (setEnvironment → prepareForReuse)
+4. **spawn() nesting**: Extract `registerPersistentEntry()` covering lines 290-300
+
+#### Reliability Fixes (3 issues)
+5. **Stop hook stdin timeout**: Add `timeout 30` at `scripts/autobeat-stop-hook.sh:8`
+6. **Stop hook eval validation**: Add post-eval variable existence check after line 22
+7. **prepareForReuse liveness**: Add `isAlive()` check at start of `src/implementations/tmux/tmux-connector.ts:386`
+
+#### TypeScript Fixes (2 issues)
+8. **SetupShimConfig JSDoc** (2 locations): Update at `src/implementations/tmux/types.ts:221` and `:253`
+
+#### Consistency Fixes (1 issue)
+9. **Stale comment in orchestrate-interactive**: Update `src/cli/commands/orchestrate-interactive.ts:264`
+
+#### Security Fixes (1 issue)
+10. **Transcript path traversal**: Add `case` statement validation at `scripts/autobeat-stop-hook.sh:28`
+
+### Phase 2: Should-Fix Issues (6 issues) — 10 minutes
+11. Stale comments in event-driven-worker-pool.ts:657 and test
+12. dispose() parked session destruction
+13. Test real timer replacement
+14. syntheticConfig `satisfies` annotation
+
+### Phase 3: Document Pre-existing Issues
+- Create separate GitHub issues for tech debt (class sizes, performance optimizations)
+
+---
+
+## Quality Assessment Summary
+
+### Strengths
+- **Test coverage exceptional**: 927-line stop-hook.test.ts with end-to-end bash script testing + 421 new lines in tmux-connector.test.ts
+- **Decomposition solid**: configureAgentHook brought to 33 lines, finalizeInit/resolveTargetAgents extracted
+- **Regression-free**: Cycle 2 resolutions verified (usage capture, taskIdRef ordering, session orphan cleanup)
+- **Architectural simplification**: -1,187 net lines with wrapper pipeline removal
+- **Protocol ordering verified**: Phase B tests confirm setEnvironment → /clear → prepareForReuse → sendKeys ordering
+
+### Areas for Improvement
+- **Function complexity boundaries**: reuseSession (114 lines) and spawn (104 lines) need extraction to stay under 50-line warning threshold
+- **Type safety at construction**: syntheticConfig and hasStopHookCommand use `as` casts; consider `satisfies` and type guards
+- **Documentation stale after refactor**: 5 comment references to "wrapper" concept need updates; JSDoc persistence qualifiers misleading
+- **Shell script robustness**: Stop hook has 2 reliability gaps (stdin timeout, eval validation) that should have explicit bounds
+- **Path security**: Transcript fallback should validate path prefix before reading
+
+### Architecture Transformation Quality
+The removal of the wrapper pipeline is well-executed:
+- **State machine clean**: SessionState enum correctly replaces persist boolean (active → parked → reuse)
+- **Port boundary extended properly**: TmuxConnectorPort gains prepareForReuse method
+- **Initialization decomposed**: configureAgentHook dependencies injected cleanly
+- **One legitimate coupling**: parkedSessionAgents secondary map should use explicit error instead of fallback
+- **Behavioral equivalence maintained**: Non-persistent and persistent task workflows preserved; usage capture verified
+
+---
+
+## Reviewer Scores
+
+| Reviewer | Score | Recommendation |
+|----------|-------|-----------------|
+| Architecture | 8/10 | APPROVED_WITH_CONDITIONS |
+| Complexity | 7/10 | APPROVED_WITH_CONDITIONS |
+| Consistency | 8/10 | APPROVED_WITH_CONDITIONS |
+| Dependencies | 9/10 | APPROVED |
+| Performance | 8/10 | APPROVED_WITH_CONDITIONS |
+| Regression | 9/10 | APPROVED |
+| Reliability | 7/10 | CHANGES_REQUESTED |
+| Security | 7/10 | APPROVED_WITH_CONDITIONS |
+| Testing | 9/10 | APPROVED_WITH_CONDITIONS |
+| TypeScript | 8/10 | APPROVED_WITH_CONDITIONS |
+| **Overall** | **8/10** | **CHANGES_REQUESTED** |
+
+**Rationale**: Reliability review's 2 HIGH + 2 MEDIUM blocking issues (stdin timeout, eval validation, session liveness, parked session destruction) combined with Architecture's HIGH (parkedSessionAgents fallback) and Complexity's HIGH (reuseSession length) trigger CHANGES_REQUESTED per review methodology. All issues are fixable in <30 minutes. Post-fix, all 10 reviewers' conditions will be satisfied, enabling APPROVED recommendation.
+
+---
+
+## Next Steps for Developer
+
+1. **Address all 15 blocking/should-fix issues** above in order (Phase 1 → Phase 2)
+2. **Run test suite** after fixes: `npm run test:all` (or grouped suites in Claude Code)
+3. **Re-request review** with summary of fixes applied
+4. **No need to re-assign to reviewers** — synthesis-driven process
+5. **Track pre-existing issues separately** as GitHub issues for future sprints

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/security.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/security.md
@@ -1,0 +1,80 @@
+# Security Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Transcript path traversal in stop hook** - `scripts/autobeat-stop-hook.sh:28`
+**Confidence**: 82%
+- Problem: The `TRANSCRIPT` variable is read from untrusted JSON input (`$HOOK_DATA`) via `jq -r '.transcript_path // empty'`. The subsequent check is `[ -f "$TRANSCRIPT" ]` followed by `tail -n 50 "$TRANSCRIPT"`, which reads content from any readable file path the hook data can dictate. While the hook only runs when `AUTOBEAT_WORKER=true` (which limits the attack surface to processes controlled by autobeat), a malicious or corrupted hook payload could point `transcript_path` at an arbitrary file (e.g. `/etc/shadow`, SSH keys) and expose its last 50 lines as the task "response" which is then written to the sessions directory where the orchestrator reads it.
+- Impact: Potential information disclosure if an attacker can influence the JSON payload delivered to the hook's stdin. In practice the attack surface is narrow because the hook is invoked by Claude Code/Codex CLIs in a controlled tmux session, but the defense-in-depth principle is violated.
+- Fix: Validate that the transcript path is within an expected prefix before reading it. For example:
+  ```bash
+  if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+    # Only read transcripts from expected directories
+    case "$TRANSCRIPT" in
+      /tmp/claude-*|"$HOME"/.claude/*|"$HOME"/.codex/*)
+        RESPONSE=$(tail -n 50 "$TRANSCRIPT" | jq -s '...' 2>/dev/null)
+        ;;
+      *)
+        # Unexpected path — skip transcript fallback
+        ;;
+    esac
+  fi
+  ```
+
+### MEDIUM
+
+**`eval` on jq output — safe by construction but fragile** - `scripts/autobeat-stop-hook.sh:17`
+**Confidence**: 80%
+- Problem: `eval "$(printf '%s' "$HOOK_DATA" | jq -r '...' 2>/dev/null)" 2>/dev/null || true` uses `eval` to assign variables from jq output. The `@sh` filter in jq is the correct mechanism for this pattern and produces properly shell-quoted strings. However, if `jq` is replaced by a malicious binary on PATH (supply chain), or if jq has a bug in `@sh` escaping, the `eval` becomes an arbitrary code execution vector. The `|| true` means parse failures are silently swallowed rather than causing the hook to abort.
+- Impact: Under normal conditions this is safe (jq `@sh` is well-tested). The concern is defense-in-depth: if jq ever emits unquoted output for a crafted input, `eval` would execute it. The `2>/dev/null || true` suppresses all diagnostics, making debugging difficult.
+- Fix: Consider validating that the eval'd output only contains variable assignments before executing, or use an alternative extraction pattern that avoids eval entirely (e.g., separate jq invocations per field). At minimum, document this trust assumption explicitly:
+  ```bash
+  # SECURITY: @sh output from jq is shell-safe by design. If jq is compromised,
+  # this eval is an arbitrary code execution vector. Acceptable because the hook
+  # only runs inside autobeat-managed tmux sessions where PATH is controlled.
+  ```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Stop hook runs with world-readable+executable permissions** - `scripts/autobeat-stop-hook.sh`
+**Confidence**: 83%
+- Problem: The script is committed with 755 permissions (`-rwxr-xr-x`). As an npm bin entry, npm will install it with whatever permissions the package has. The script itself does not contain secrets, but it processes sensitive data (agent output, usage costs) and writes to a controlled directory. While the generated setup shim and session directories use restrictive mode 0o700, the stop hook script installed globally via npm has no such restriction.
+- Impact: Any local user can read the script (low concern — it is open source) and can technically invoke it, although the `AUTOBEAT_WORKER=true` guard and the need for a valid `AUTOBEAT_SESSIONS_DIR` prevent meaningful exploitation.
+- Fix: This is acceptable for an npm bin entry since npm manages permissions per platform. No code change needed, but document in the script header that the security boundary is the environment variables, not file permissions.
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**Config file written at 0o600 but backup at default umask** - `src/cli/commands/init.ts:143`
+**Confidence**: 81%
+- Problem: `createDefaultHookConfigDeps()` writes config files with mode `0o600` (owner-only read/write) and creates directories with mode `0o700` (owner-only). However, the `backupIfNeeded()` function at line 143 calls `deps.writeFile(backupPath, original)` which uses the same 0o600 mode (correct). This is actually fine — the implementation does pass the right mode. No issue here upon closer inspection.
+
+## Suggestions (Lower Confidence)
+
+- **SESSIONS_DIR path traversal check is regex-only** - `scripts/autobeat-stop-hook.sh:48` (Confidence: 65%) — The `[[ "$SESSIONS_DIR" =~ \.\. ]] && exit 0` check rejects literal `..` anywhere in the string, which is a good basic guard. However, it does not canonicalize the path (no `realpath` check). A symlink-based traversal would bypass this. Low practical risk because SESSIONS_DIR is set by the setup shim from a validated `sessionsDir` value.
+
+- **10MB stdin read without timeout** - `scripts/autobeat-stop-hook.sh:8` (Confidence: 62%) — `head -c 10485760` reads up to 10MB from stdin with no timeout. If the calling process hangs or sends data very slowly, the hook will block indefinitely. Claude Code and Codex fire hooks synchronously, so a blocked hook could stall the entire agent session. The bounded read size (10MB) prevents memory exhaustion but not indefinite blocking.
+
+- **No integrity check on hook command name** - `src/cli/commands/init.ts:104` (Confidence: 60%) — The hook command `'autobeat-stop-hook'` is registered by name only. After installation, if an attacker places a malicious `autobeat-stop-hook` earlier in PATH, it would execute instead. This is a general PATH-injection concern that applies to all CLI tools and is not specific to this implementation.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 1 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Security Score**: 7/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The stop hook introduces a sound security model: environment-variable-gated execution, task ID regex validation, path traversal rejection for SESSIONS_DIR, proper single-quote escaping in the setup shim, atomic file writes, and restrictive directory permissions. The main concern is the transcript path read (line 28) which trusts the hook payload's `transcript_path` field without validating it is within an expected prefix. This should be addressed before merge to uphold the defense-in-depth principle documented in the codebase.
+
+The `eval` usage with jq `@sh` is technically safe under normal operation but represents a fragility point worth documenting explicitly. The removal of the wrapper pipeline (-1,187 lines) reduces attack surface significantly by eliminating the stdout-piping architecture that previously processed untrusted agent output through shell pipelines.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/testing.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/testing.md
@@ -1,0 +1,72 @@
+# Testing Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01T00:59
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Real `setTimeout` in async test (potential flakiness)** - `tests/unit/implementations/tmux/tmux-connector.test.ts:614`
+**Confidence**: 82%
+- Problem: The test "messages watcher ignores null filename" uses `await new Promise((r) => setTimeout(r, 100))` with real timers to wait for async settlement. This introduces a timing-dependent assertion that can be flaky under load or CI resource contention.
+- Fix: Use `vi.useFakeTimers()` with `vi.advanceTimersByTimeAsync(100)`, or use `vi.waitFor()` with a negative assertion pattern. The rest of the connector tests already demonstrate the fake-timers pattern.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Shared mutable `tmpDir` + `afterEach` cleanup in stop-hook test may race on parallel execution** - `tests/integration/tmux/stop-hook.test.ts:49-65`
+**Confidence**: 80%
+- Problem: The `afterEach` hook iterates `tmpDir` entries and deletes them. Each test creates uniquely-named subdirectories, so concurrent tests (if pool mode changes in the future) could interfere. Currently safe because vitest config uses `maxWorkers: 1`, but the test does not document this dependency.
+- Fix: Add a brief comment noting the sequential execution dependency, or use per-test temp directories via `fs.mkdtempSync` instead of cleaning a shared root. Given the project's documented sequential vitest config, a comment is sufficient:
+```typescript
+// NOTE: Safe because vitest runs with maxWorkers: 1 (see vitest.config.ts)
+```
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Missing coverage: `destroy()` on a session where `destroySession` fails returns err and keeps session tracked for retry** - `src/implementations/tmux/tmux-connector.ts:317-326` (Confidence: 70%) -- The destroy failure path logs and keeps the session; no unit test exercises this recovery-retry scenario for the new code paths.
+
+- **Integration test does not verify hook stderr output on path-traversal rejection** - `tests/integration/tmux/stop-hook.test.ts:536-598` (Confidence: 65%) -- The security tests assert no files are created but do not check stderr for diagnostic messages that operators might rely on for audit logging.
+
+- **Worker pool reuse tests use dynamic imports for error construction** - `tests/unit/implementations/event-driven-worker-pool.test.ts:1341-1346` (Confidence: 62%) -- The `await import(...)` inside a `mockReturnValueOnce` call is unusual and harder to read than importing at the top of the file. Not incorrect but deviates from the test file's established pattern of using the already-imported `AutobeatError` and `ErrorCode`.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Testing Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+## Assessment
+
+This PR delivers an exceptionally well-structured test suite. Key strengths:
+
+1. **Comprehensive behavior coverage**: The new `stop-hook.test.ts` (927 lines) exercises the bash script end-to-end with real filesystem operations and real bash execution. It covers guard behavior, both Codex and Claude extraction paths, the isOutputMessage contract, special characters, sequence numbering, sentinel mapping, security (path traversal), atomic writes, fail-fast on empty response, usage capture, jq unavailability, and transcript string-content branches.
+
+2. **State machine testing**: The `tmux-connector.test.ts` additions (421 new lines) thoroughly cover the new `SessionState` enum transitions (`active` -> `parked` -> reuse), `prepareForReuse()` contract, staleness timer skip for parked sessions, and the parked-session destroy path (session-orphan regression test).
+
+3. **Protocol ordering tests**: The Phase B worker pool tests verify the critical ordering invariant (setEnvironment -> /clear -> prepareForReuse -> sendKeys) using call-order tracking, plus failure fallback paths.
+
+4. **Removed dead tests correctly**: The deleted `hook-script-generation.test.ts` (348 lines) was for the old wrapper pipeline; the new `stop-hook.test.ts` replaces it with direct integration tests against the actual bash script. The `tmux-hooks.test.ts` removed ~250 lines of `generateWrapper()` tests and added targeted `initTaskDirectory()` tests plus retained `generateSetupShim()` and `cleanup()` coverage.
+
+5. **Mock fixture updated**: `prepareForReuse` added to `MockTmuxConnector`, maintaining interface parity.
+
+The only blocking issue is a minor flakiness risk from a real timer in one test. The prior cycle's resolution (22 issues resolved, including 6 usage regression tests) is reflected in the usage capture test section of stop-hook.test.ts. No regressions from resolved issues detected.

--- a/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/typescript.md
+++ b/.devflow/docs/reviews/feat-stop-hook--full-interactive-mode-for-all/2026-06-01_0059/typescript.md
@@ -1,0 +1,94 @@
+# TypeScript Review Report
+
+**Branch**: feat/stop-hook--full-interactive-mode-for-all -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Stale `SetupShimConfig` JSDoc says "persistent interactive session" but all sessions now use this path** - `src/implementations/tmux/types.ts:221-222`
+**Confidence**: 85%
+- Problem: The JSDoc for `SetupShimConfig` still says "Configuration for generating a setup shim for a persistent interactive session. Used when persistent=true" but this PR removes the wrapper pipeline, making ALL sessions use the setup shim regardless of `persistent`. The comment is now misleading — a developer reading this would think it only applies to persistent sessions.
+- Fix:
+```typescript
+/**
+ * Configuration for generating a setup shim for an interactive session.
+ * All agent sessions run via the setup shim — output is captured by the Stop hook.
+ */
+export interface SetupShimConfig {
+```
+
+**Same stale "persistent" wording in `TmuxHooksPort.generateSetupShim` JSDoc** - `src/implementations/tmux/types.ts:253-255`
+**Confidence**: 85%
+- Problem: The port interface JSDoc still says "Generates the session directory and setup shim for a persistent interactive session" — same issue as above.
+- Fix: Replace "for a persistent interactive session" with "for an interactive session" since persistence is now an orthogonal lifecycle concern (park vs destroy on sentinel).
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`syntheticConfig` lacks explicit type annotation — relies on structural compatibility without `satisfies`** - `src/implementations/tmux/tmux-connector.ts:422-430`
+**Confidence**: 82%
+- Problem: The `syntheticConfig` object is passed to `buildActiveSession(config: TmuxSpawnConfig, ...)` without a type annotation. It works today because it structurally satisfies `TmuxSpawnConfig`, but if `TmuxSpawnConfig` gains a new required field (e.g., a `staleness` field becomes mandatory), this call site will fail at compile time with a confusing error pointing at the `buildActiveSession` call, not at the object literal.
+  Adding `satisfies TmuxSpawnConfig` (or a `Partial<TmuxSpawnConfig> as TmuxSpawnConfig` cast with a defensive comment) documents the intentional structural subset and makes the maintenance intent explicit.
+- Fix:
+```typescript
+const syntheticConfig = {
+  taskId: newTaskId,
+  sessionsDir: handle.sessionsDir,
+  name: handle.sessionName,
+  command: '',
+  agentArgs: [] as string[],
+  agent: parkedAgent,
+  persistent: true,
+} satisfies TmuxSpawnConfig;
+```
+  Note: `satisfies` will reject if any required field is missing at the object literal — this is the desired behavior (catches regressions earlier).
+
+**Type assertions in `hasStopHookCommand` without narrowing guards are defensive but could be replaced with a type guard** - `src/cli/commands/init.ts:178-183`
+**Confidence**: 80%
+- Problem: The function uses `as Record<string, unknown>` twice after `typeof === 'object'` checks. While functionally correct (the preceding null/typeof checks ensure safety), this pattern accumulates `as` casts that disable type checking within each branch. A single extracted type guard (`isHookEntry(x): x is { hooks: unknown[] }`) would eliminate two casts and make the intent clearer.
+- Fix: Extract a narrowing type guard:
+```typescript
+function isHookEntry(x: unknown): x is { hooks: unknown[] } {
+  return typeof x === 'object' && x !== null && Array.isArray((x as Record<string, unknown>).hooks);
+}
+function isCommandHook(x: unknown): x is { type: string; command: string } {
+  if (typeof x !== 'object' || x === null) return false;
+  const h = x as Record<string, unknown>;
+  return typeof h.type === 'string' && typeof h.command === 'string';
+}
+```
+  This concentrates the casts in well-tested guards and lets `hasStopHookCommand` body be cast-free.
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **`options.taskId as TaskId` cast in base-agent-adapter** - `src/implementations/base-agent-adapter.ts:155` (Confidence: 65%) — The cast is guarded by the TASK_ID_REGEX check above, but a branded-type constructor (e.g., `TaskId(options.taskId)`) would make the narrowing explicit. Low priority as this pattern is pre-existing.
+
+- **`agentArgs: [] as string[]` in syntheticConfig uses `as` where a const annotation would suffice** - `src/implementations/tmux/tmux-connector.ts:427` (Confidence: 70%) — `[] as string[]` widens the empty array type; `[] as const` followed by `satisfies readonly string[]` or simply typing the parent object would be slightly cleaner. Marginal.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 2 | 0 |
+| Should Fix | - | 0 | 2 | 0 |
+| Pre-existing | - | - | 0 | 0 |
+
+**TypeScript Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The TypeScript changes are well-typed overall — the project passes `tsc --noEmit` cleanly, discriminated unions are used correctly (`SessionState`, `AgentResolution`, `HookConfigResult`), Result types are used consistently, and the removal of the wrapper pipeline eliminates dead code without introducing type regressions. The two blocking MEDIUM issues are stale JSDoc comments that will mislead future developers about when `SetupShimConfig` is used. The should-fix items are about strengthening type safety at construction sites (using `satisfies` and type guards instead of `as` casts).

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/architecture.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/architecture.md
@@ -1,0 +1,70 @@
+# Architecture Review Report
+
+**Branch**: fix-fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Non-atomic two-step prompt delivery creates a failure window** - `src/implementations/event-driven-worker-pool.ts:712-733` (launchAndRegister), `src/implementations/event-driven-worker-pool.ts:512-533` (reuseSession), `src/cli/commands/orchestrate-interactive.ts:267-274` (spawnAndDeliverPrompt)
+**Confidence**: 82%
+- Problem: The change splits prompt delivery from a single `sendKeys(prompt + '\n')` call into two calls: `pasteContent(prompt)` followed by `sendControlKeys(handle, 'Enter')`. If `pasteContent` succeeds but `sendControlKeys('Enter')` fails, the prompt text is pasted into the TUI but never submitted. In `launchAndRegister()`, this leaves a spawned session with visible prompt text that will never execute. In `reuseSession()`, the same gap exists. Each call site handles the error by cleaning up and destroying the session, which is correct rollback behavior. However, there is no mechanism to verify that the pasted content was not partially processed or that the buffer was cleaned before destruction. This is mitigated by the fact that both calls are synchronous `spawnSync` under the hood (tmux CLI calls), making the window between them negligible in practice. The rollback paths are correctly implemented in all 4 call sites.
+- Fix: The current rollback approach (destroy session on Enter failure) is architecturally sound. Consider documenting this as a known two-phase delivery contract in the `TmuxConnectorPort` interface — a `deliverAndSubmit(handle, content)` composite method could encapsulate this pattern, but the added abstraction may not justify the complexity given the synchronous nature of both calls. No code change required unless the team wants to consolidate.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Stale JSDoc in TmuxConnectorPort.prepareForReuse references sendKeys(prompt)** - `src/core/tmux-types.ts:210`
+**Confidence**: 92%
+- Problem: The `prepareForReuse` method's JSDoc says "and BEFORE sendKeys(prompt) so watchers are ready before any output arrives." After this PR, prompt delivery uses `pasteContent` + `sendControlKeys('Enter')`, not `sendKeys`. The comment is now inaccurate and contradicts the ADR-004 decision. This same stale reference appears in `src/implementations/tmux/tmux-connector.ts:380` and `src/implementations/tmux/tmux-connector.ts:1036`.
+- Fix: Update the 3 stale comments:
+  - `src/core/tmux-types.ts:210`: `"and BEFORE pasteContent(prompt) + sendControlKeys('Enter') so watchers are ready before any output arrives."`
+  - `src/implementations/tmux/tmux-connector.ts:380`: same update
+  - `src/implementations/tmux/tmux-connector.ts:1036`: change `"then sendKeys() to deliver the next prompt"` to `"then pasteContent() + sendControlKeys('Enter') to deliver the next prompt"`
+
+**TmuxHandle JSDoc still lists sendKeys as a consumer method** - `src/core/tmux-types.ts:25`
+**Confidence**: 88%
+- Problem: The TmuxHandle interface comment reads "Returned from TmuxConnectorPort.spawn(); passed back to destroy/sendKeys/isAlive." After this PR, the primary prompt delivery path uses `pasteContent` + `sendControlKeys`, not `sendKeys`. `sendKeys` is still used for `/clear` but is no longer the primary consumer-facing method for prompt delivery.
+- Fix: Update to: `"Returned from TmuxConnectorPort.spawn(); passed back to destroy/pasteContent/sendControlKeys/isAlive."`
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**`/clear` still uses sendKeys (literal mode) while prompts use pasteContent** - `src/implementations/event-driven-worker-pool.ts:395`
+**Confidence**: 65% (moved to Suggestions -- see below)
+
+## Suggestions (Lower Confidence)
+
+- **Mixed delivery mechanisms for `/clear` vs prompts** - `src/implementations/event-driven-worker-pool.ts:395` (Confidence: 65%) -- `/clear` is still sent via `sendKeys` + `sendControlKeys('Enter')` while prompts use `pasteContent` + `sendControlKeys('Enter')`. This is likely intentional (short fixed string vs long variable-length content), but the inconsistency means two distinct code patterns for "send text to TUI and press Enter." A helper method could unify both, though the simplicity of `/clear` may not warrant it.
+
+- **`sendKeys` method retained on `TmuxConnectorPort` interface** - `src/core/tmux-types.ts:170` (Confidence: 60%) -- After this PR, `sendKeys` is only used for `/clear` in the worker pool. The method remains on the port interface without deprecation annotation. If the project wants to signal that `pasteContent` is the preferred delivery mechanism per ADR-004, a `@deprecated` JSDoc tag on `sendKeys` would make the intent visible to future contributors.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 2 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**Architecture Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+### Rationale
+
+This PR implements a clean, well-scoped architectural change that unifies tmux prompt delivery across all 4 call sites to use `pasteContent` + `sendControlKeys('Enter')`, consistent with the established pattern in `channel-manager.ts` (applies ADR-004). The change respects the existing layering: core-layer consumers (`EventDrivenWorkerPool`, `orchestrate-interactive.ts`) continue to interact with `TmuxConnectorPort` methods without implementation knowledge. Error handling is thorough -- every new call site checks the `Result` from both `pasteContent` and `sendControlKeys`, with proper rollback (destroy session, cleanup worker state) on failure.
+
+The one blocking MEDIUM is informational rather than risky -- the two-phase delivery is inherently non-atomic, but the synchronous nature of `spawnSync`-based tmux calls and the correct rollback logic in all paths make this acceptable. The should-fix items are stale documentation that should be updated to maintain consistency with ADR-004.
+
+**Conditions for merge**: Update the 4 stale JSDoc references to `sendKeys(prompt)` in `tmux-types.ts` and `tmux-connector.ts` to reflect the new `pasteContent` + `sendControlKeys('Enter')` delivery pattern. These are documentation-only changes.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/complexity.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/complexity.md
@@ -1,0 +1,78 @@
+# Complexity Review Report
+
+**Branch**: HEAD -> main
+**Date**: 2026-06-01
+**PR**: #200
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Duplicated error-handling blocks across 3 prompt delivery sites (3 occurrences)** -- Confidence: 82%
+- `src/implementations/event-driven-worker-pool.ts:512-533` (reuseSession)
+- `src/implementations/event-driven-worker-pool.ts:712-732` (launchAndRegister)
+- `src/implementations/event-driven-worker-pool.ts:405-414` (prepareSessionForIteration)
+
+- Problem: Each prompt delivery site now has two near-identical error-handling blocks -- one for `pasteContent` failure and one for `sendControlKeys('Enter')` failure. The cleanup logic in each pair is structurally identical (log warning, cleanup state, return fallback/error). In `reuseSession` lines 512-533 the two blocks both call `cleanupWorkerState` + `cleanupPersistentSession` + `return ok(null)`. In `launchAndRegister` lines 712-732 both call `cleanupWorkerState` + `destroySessionWithWarning` + `return err(...)`. This tripled duplication increases the maintenance surface -- any change to cleanup semantics must be replicated across 6 blocks (2 per site x 3 sites). Applies ADR-004 (the split is intentional; the duplication of cleanup logic is the concern).
+
+- Fix: Extract a `deliverPrompt` helper that encapsulates the `pasteContent` + `sendControlKeys('Enter')` pair and returns a single Result. Each call site invokes the helper and handles one error path instead of two. Example sketch:
+  ```typescript
+  private deliverPromptToSession(
+    handle: TmuxHandle,
+    prompt: string,
+  ): Result<void> {
+    const pasteResult = this.tmuxConnector.pasteContent(handle, prompt);
+    if (!pasteResult.ok) return pasteResult;
+    return this.tmuxConnector.sendControlKeys(handle, 'Enter');
+  }
+  ```
+  Then each call site replaces its two error blocks with one.
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**`prepareSessionForIteration` exceeds 50-line guideline (67 lines)** -- `src/implementations/event-driven-worker-pool.ts:375-442`
+**Confidence**: 80%
+- Problem: At 67 lines (L375-L442), this method exceeds the 50-line warning threshold. The addition of the separate `sendControlKeys('Enter')` error block (L405-L414) pushed it past the guideline. The method handles 4 distinct failure modes (setEnvironment, sendKeys /clear, sendControlKeys Enter, prepareForReuse), each with the same log-cleanup-return pattern.
+- Fix: If the `deliverPrompt` helper from the Blocking finding above is adopted, the /clear delivery could also use a similar two-step helper (or inline it as `sendKeys('/clear')` + `sendControlKeys('Enter')` behind one Result), reducing this method by ~10 lines and bringing it back under 50.
+
+**`reuseSession` at 79 lines** -- `src/implementations/event-driven-worker-pool.ts:466-545`
+**Confidence**: 80%
+- Problem: At 79 lines, `reuseSession` is above the 50-line guideline. The added pasteContent/Enter split contributes ~10 new lines. The method was already near the threshold before this PR but the split pushed it further. The function manages 9 numbered protocol steps, which is inherently complex.
+- Fix: The `deliverPrompt` helper would reduce this by ~10 lines. The method's protocol-step structure is well-documented and the steps are sequential (not deeply nested), so the remaining length is acceptable if the prompt delivery is consolidated.
+
+**`launchAndRegister` at 62 lines** -- `src/implementations/event-driven-worker-pool.ts:681-743`
+**Confidence**: 80%
+- Problem: At 62 lines, slightly above the 50-line guideline. The two separate error blocks for pasteContent and sendControlKeys each include distinct `AutobeatError` messages, which is good for diagnostics but inflates the method.
+- Fix: Same `deliverPrompt` helper would consolidate the two error blocks into one, bringing this to ~52 lines (borderline but acceptable).
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**`event-driven-worker-pool.ts` is 1301 lines** -- `src/implementations/event-driven-worker-pool.ts`
+**Confidence**: 85%
+- Problem: The file is well above the 500-line critical threshold (1301 lines). This is pre-existing -- the PR adds ~20 net lines (69 insertions, 51 deletions per the stat). The class manages spawn, reuse, kill, timeout, heartbeat, flushing, completion, and cleanup -- many responsibilities in one file.
+- Note: Not introduced by this PR. Informational only; does not block merge.
+
+## Suggestions (Lower Confidence)
+
+- **Consider a `submitClear` helper for the /clear + Enter pair** -- `src/implementations/event-driven-worker-pool.ts:394-414` (Confidence: 65%) -- The `/clear` + `sendControlKeys('Enter')` pair in `prepareSessionForIteration` is similar to the prompt delivery pair. A shared `sendCommandAndSubmit(handle, text)` helper could consolidate both patterns, but the `/clear` path uses `sendKeys` (not `pasteContent`) so the abstraction may not fit cleanly.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 3 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Complexity Score**: 7/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The changes are a mechanical, necessary expansion of error handling that correctly applies ADR-004. The duplicated error-handling blocks across 3 sites are the primary complexity concern. Extracting a `deliverPrompt` helper would reduce 6 error blocks to 3 and bring all three affected methods closer to the 50-line guideline. The nesting depth remains shallow (max 2) and cyclomatic complexity increase is modest. No critical or high-severity issues found.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/consistency.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/consistency.md
@@ -1,0 +1,60 @@
+# Consistency Review Report
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**Inconsistent prompt delivery pattern for /clear command** - `src/implementations/event-driven-worker-pool.ts:395`
+**Confidence**: 65% (see Suggestions)
+
+This finding falls below the 80% threshold for blocking. The /clear command uses `sendKeys` + `sendControlKeys('Enter')` while all prompt delivery sites now use `pasteContent` + `sendControlKeys('Enter')`. However, `/clear` is a short fixed string (no shell metacharacters, no newlines) so `sendKeys -l` is safe and appropriate here. The PR description explicitly states "4 prompt delivery sites" were migrated, and the `/clear` command delivery is intentionally kept on `sendKeys` because ADR-004's rationale about `\n` as literal byte only applies to the trailing-newline submission problem, not to short commands submitted via a separate `sendControlKeys('Enter')` call. This is a deliberate design choice, not an oversight. Moved to Suggestions.
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**Stale comment in tmux-connector.ts references sendKeys instead of pasteContent** - `src/implementations/tmux/tmux-connector.ts:1036`
+**Confidence**: 95%
+- Problem: Comment reads "then sendKeys() to deliver the next prompt" but all prompt delivery sites now use `pasteContent()`. This file is not in the PR diff, so this is pre-existing and not blocking.
+- Fix: Update to "then pasteContent() + sendControlKeys('Enter') to deliver the next prompt" in a follow-up.
+
+## Suggestions (Lower Confidence)
+
+- **Mixed pattern for /clear vs prompts** - `src/implementations/event-driven-worker-pool.ts:395` (Confidence: 65%) -- The /clear command uses `sendKeys` + `sendControlKeys('Enter')` while prompts use `pasteContent` + `sendControlKeys('Enter')`. This is likely intentional since /clear is a short fixed command without metacharacters, but could confuse future maintainers. A brief inline comment noting why /clear does not use pasteContent (e.g., "short fixed command, sendKeys -l is safe") would make the distinction explicit. Applies ADR-004 -- the ADR's rationale focuses on `\n` literal byte behavior for prompt submission; /clear has no trailing newline concern since Enter is sent separately.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | - |
+| Should Fix | - | 0 | 0 | - |
+| Pre-existing | - | - | 1 | 0 |
+
+**Consistency Score**: 9/10
+
+The PR achieves strong consistency across all four prompt delivery sites, properly applying the `pasteContent` + `sendControlKeys('Enter')` pattern established in `channel-manager.ts:968-983` (applies ADR-004). The changes are mechanically uniform:
+- Fresh spawn (launchAndRegister step 10): pasteContent + Enter with proper rollback on either failure
+- Session reuse (reuseSession step 8): pasteContent + Enter with cleanupWorkerState + cleanupPersistentSession on failure
+- Interactive orchestrator (orchestrate-interactive.ts): pasteContent + Enter with failWith on either failure
+- /clear command: deliberately kept on sendKeys + sendControlKeys('Enter') -- appropriate for a short fixed command
+
+Comments and docstrings are updated consistently across all modified sites. The test suite mirrors the production code changes faithfully, including the B1-2 failure path test (updated from sendKeys mock to pasteContent mock) and the Phase B ordering test (updated call order assertions to reflect pasteContent + sendControlKeys sequence). Error handling for the two-step delivery (paste then Enter) follows the existing project pattern of early-return with cleanup on each step.
+
+The only minor gap is the pre-existing stale comment in tmux-connector.ts (not in this PR's diff) and the optional suggestion to add a brief note explaining why /clear uses sendKeys rather than pasteContent.
+
+**Recommendation**: APPROVED

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/performance.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/performance.md
@@ -1,0 +1,57 @@
+# Performance Review Report
+
+**Branch**: fix-fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+**pasteContent introduces 3 synchronous subprocess calls + file I/O per prompt delivery vs 1 for sendKeys** - `src/implementations/event-driven-worker-pool.ts:712`, `src/implementations/event-driven-worker-pool.ts:512`, `src/cli/commands/orchestrate-interactive.ts:267`
+**Confidence**: 82%
+- Problem: Each `pasteContent()` call executes: (1) synchronous `writeFileSync` to a temp file, (2) `spawnSync` for `tmux load-buffer`, (3) `spawnSync` for `tmux paste-buffer`, (4) `spawnSync` for `tmux delete-buffer` (best-effort), and (5) `unlinkSync` for temp file cleanup. The subsequent `sendControlKeys('Enter')` adds a 5th `spawnSync`. This replaces the prior `sendKeys` which was a single `spawnSync` call. The total blocking event-loop time increases from ~1 spawnSync to ~5 spawnSync + file I/O per prompt delivery.
+- Impact: As documented in the PR description, this runs once per task spawn (not a hot path). For single-task spawns, the additional ~20-40ms of blocking I/O is negligible. However, in `killAll()` + rapid re-spawn scenarios, or during orchestrator burst-spawning of multiple tasks, the serial blocking calls accumulate. With N concurrent task spawns, the event loop is blocked for roughly N * 5 * (spawnSync latency) instead of N * 1 * (spawnSync latency).
+- Fix: This is an acceptable trade-off given the correctness requirement (applies ADR-004: pasteContent + sendControlKeys Enter is canonical tmux prompt delivery). The PR description explicitly acknowledges the cost and documents it as running once per task spawn. No code change required, but consider adding a JSDoc note at the `pasteContent` call sites documenting the 5x syscall overhead vs sendKeys for future readers evaluating performance in batch-spawn paths.
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**prepareSessionForIteration has a hardcoded 300ms sleep (CLEAR_SETTLE_MS) on every loop iteration reuse** - `src/implementations/event-driven-worker-pool.ts:418`
+**Confidence**: 85%
+- Problem: `await new Promise<void>((resolve) => setTimeout(resolve, CLEAR_SETTLE_MS))` blocks each persistent session reuse for 300ms. For loops with many iterations, this accumulates (e.g., 100 iterations = 30s of pure waiting). This is pre-existing code not introduced by this PR, but the PR touches the surrounding function.
+- Impact: Adds latency to loop iteration turnaround. The 300ms is documented (ADR-002 references it as intentional) as a settling delay for `/clear` with no feedback signal available, so it is a conscious trade-off.
+
+**Synchronous spawnSync calls block the event loop for all tmux operations** - `src/implementations/tmux/tmux-session-manager.ts:253`, `src/implementations/tmux/tmux-session-manager.ts:287`, `src/implementations/tmux/tmux-session-manager.ts:382`
+**Confidence**: 80%
+- Problem: `sendKeys`, `sendControlKeys`, and `pasteContent` all use synchronous `spawnSync` under the hood (via `deps.exec`). Each call blocks the Node.js event loop for the duration of the process spawn. This is a pre-existing architectural decision, not introduced by this PR.
+- Impact: With the change from 1 blocking call per prompt to ~5 blocking calls per prompt, the total event-loop blocking time per spawn increases. Under concurrent task spawning, this serializes all tmux IPC. An async `execFile` alternative would allow concurrent tmux commands, but would require a larger refactor of the TmuxSessionManager.
+
+## Suggestions (Lower Confidence)
+
+- **Two-step prompt delivery creates a race window** - `src/implementations/event-driven-worker-pool.ts:712-723` (Confidence: 65%) -- Between pasteContent (which pastes text into the tmux pane) and sendControlKeys('Enter') (which submits it), there is a brief window where the pasted text is visible but not submitted. If the tmux session dies or another process sends keys in that window, the prompt could be partially delivered. The window is extremely small (consecutive synchronous calls) so this is theoretical rather than practical.
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 2 | 0 |
+
+**Performance Score**: 8/10
+**Recommendation**: APPROVED
+
+The change trades a small performance overhead (3-5 extra synchronous subprocess calls per prompt delivery) for correctness (applies ADR-004). The PR description explicitly acknowledges this trade-off and correctly identifies that prompt delivery runs once per task spawn, not on a hot path. The overhead is negligible for normal operation. The pre-existing 300ms settle delay and synchronous tmux IPC are the larger performance bottlenecks but are outside this PR's scope. No blocking performance issues found.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/regression.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/regression.md
@@ -1,0 +1,57 @@
+# Regression Review Report
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01T08:14
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Missing test coverage for sendControlKeys('Enter') failure paths (2 new branches)** -- Confidence: 85%
+- `src/implementations/event-driven-worker-pool.ts:723-732` (launchAndRegister step 10)
+- `src/implementations/event-driven-worker-pool.ts:523-533` (reuseSession step 8)
+- Problem: The PR introduces new error-handling branches for `sendControlKeys('Enter')` failure after `pasteContent` succeeds. These are distinct from the `pasteContent` failure path (which IS tested). If `sendControlKeys('Enter')` fails, the worker state is cleaned up and the session destroyed -- but no test validates this path. The `pasteContent` failure test at line 369-382 only covers the first half of the two-step delivery.
+- Fix: Add two tests: one in AC-6 for `launchAndRegister` (mock `sendControlKeys` to return `err` after `pasteContent` succeeds, verify cleanup + destroy + error result) and one for `reuseSession` (mock `sendControlKeys` to return `err` after `pasteContent` succeeds in the reuse path, verify fallthrough to fresh spawn + session destroy).
+
+**Missing test coverage for sendControlKeys('Enter') failure after /clear** -- Confidence: 82%
+- `src/implementations/event-driven-worker-pool.ts:405-414` (prepareSessionForIteration step 3)
+- Problem: A new error-handling branch is introduced where `sendControlKeys('Enter')` after `/clear` can fail, triggering `cleanupPersistentSession` and returning `ok(null)` to fall through to fresh spawn. No test exercises this branch. The existing `/clear` failure test only covers the `sendKeys` failure, not the subsequent Enter failure.
+- Fix: Add a test that mocks `sendControlKeys` to fail on the first call (the Enter after `/clear`) during persistent session reuse, and verify the session falls through to a fresh spawn.
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+### LOW
+
+**Stale `sendKeys(prompt)` references in interface documentation (3 locations)** -- Confidence: 92%
+- `src/core/tmux-types.ts:210` -- "and BEFORE sendKeys(prompt)" should reference `pasteContent(prompt)`
+- `src/implementations/tmux/tmux-connector.ts:380` -- same stale comment
+- `src/implementations/tmux/tmux-connector.ts:1036` -- "then sendKeys() to deliver the next prompt" should reference `pasteContent()`
+- Problem: The second commit (9c0cb05) updated comments in `orchestrate-interactive.ts` and `event-driven-worker-pool.ts` but missed these 3 documentation comments in `tmux-types.ts` and `tmux-connector.ts`. These files were not changed in this PR. The comments now describe a pattern that no longer exists (applies ADR-004).
+- Fix: Update all 3 comments to reference `pasteContent(prompt) + sendControlKeys('Enter')` in a follow-up commit or separate PR.
+
+## Suggestions (Lower Confidence)
+
+(none)
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 2 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 0 | 1 |
+
+**Regression Score**: 8/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+### Rationale
+
+The migration is well-executed across all 4 stated delivery sites and aligns with ADR-004 (applies ADR-004). The commit message accurately describes the changes, and all existing tests pass (69/69). The `/clear` path correctly keeps `sendKeys` for the literal text and only adds `sendControlKeys('Enter')` for submission -- consistent with the distinction between literal text injection and keypress delivery.
+
+The two MEDIUM blocking items are about missing test coverage for newly introduced error branches, not about incorrect behavior. The rollback/cleanup logic in these branches follows the same pattern as the tested `pasteContent` failure branch, so the risk of actual regression is low. However, since these are new branches in changed code with error-handling implications, they should be covered by tests.
+
+No lost functionality, no changed return types, no removed exports, and no intent-vs-reality mismatch detected.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/reliability.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/reliability.md
@@ -1,0 +1,71 @@
+# Reliability Review Report
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+### MEDIUM
+
+(none)
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+- **Partial state after pasteContent succeeds but sendControlKeys('Enter') fails on fresh spawn** - `src/implementations/event-driven-worker-pool.ts:723` (Confidence: 65%) -- When pasteContent succeeds (prompt text is pasted into the tmux pane) but the subsequent sendControlKeys('Enter') fails, the prompt text remains visible in the pane's input buffer. The session is correctly destroyed on this failure path, so no operational risk exists. However, if the destroy itself fails (logged as warning, execution continues), the session could be left in a state with pasted-but-unsubmitted text. This is an extremely narrow window and the existing destroy-with-warning pattern is the project's established resilience posture, so this is informational only.
+
+- **No dedicated test for sendControlKeys('Enter') failure on fresh spawn (launchAndRegister step 10)** - `tests/unit/implementations/event-driven-worker-pool.test.ts` (Confidence: 70%) -- The test suite covers pasteContent failure on fresh spawn (line 369) and pasteContent failure on reuse (B1-2, line 1278), but there is no test for the case where pasteContent succeeds and the subsequent sendControlKeys('Enter') call fails in launchAndRegister. The cleanup path for this case (cleanupWorkerState + destroySessionWithWarning) is identical in structure to the pasteContent failure path but exercises a different branch. Adding a test would confirm the cleanup runs correctly when only the Enter step fails.
+
+- **No dedicated test for sendControlKeys('Enter') failure after /clear in prepareSessionForIteration** - `tests/unit/implementations/event-driven-worker-pool.test.ts` (Confidence: 62%) -- The new clearEnterResult error handling at line 405-414 of event-driven-worker-pool.ts correctly calls cleanupPersistentSession and falls through to fresh spawn, but no test exercises this specific failure path. The existing setEnvironment-failure test (line 1088) covers the same fallthrough pattern for a different step, providing indirect confidence.
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | - |
+| Should Fix | - | 0 | 0 | - |
+| Pre-existing | - | - | 0 | 0 |
+
+**Reliability Score**: 9/10
+**Recommendation**: APPROVED
+
+## Analysis
+
+This PR applies ADR-004 (tmux prompt delivery uses pasteContent + sendControlKeys('Enter'), not sendKeys -l with \n suffix) uniformly across all 4 prompt delivery sites. The change directly fixes a reliability defect where `sendKeys -l` with `\n` caused prompts to be received but never submitted, stalling tasks.
+
+### Bounded Iteration
+No loops, retries, or pagination were added or modified. All existing bounded constructs (heartbeat intervals, timeout timers, grace periods) are unchanged. **No issues.**
+
+### Assertion Density
+Each delivery site (4 total) now has explicit Result checks for both the pasteContent call AND the sendControlKeys('Enter') call. Every failure path includes:
+- Structured logging with taskId and error context
+- Appropriate cleanup (destroySessionWithWarning for fresh spawn, cleanupPersistentSession for reuse, failWith for interactive)
+- Correct fallthrough semantics (fresh spawn falls through, reuse falls through, interactive exits process)
+
+This is a meaningful improvement in assertion density over the prior single-call pattern.
+
+### Resource Cleanup
+The pasteContent implementation (pre-existing, not modified in this PR) uses `try/finally` for temp file cleanup and best-effort tmux buffer deletion. The new two-step pattern does not introduce any new resource lifecycle concerns. When pasteContent succeeds but Enter fails, the session is destroyed (fresh spawn) or cleaned up (reuse), preventing orphaned sessions.
+
+### Indirection / Metaprogramming
+No changes to indirection depth or metaprogramming constructs.
+
+### Consistency with ADR-004
+All 4 sites now follow the canonical pattern documented in ADR-004. The /clear command correctly uses sendKeys (not pasteContent) for the short fixed string, then sendControlKeys('Enter') for submission -- this is a reasonable adaptation since /clear is 6 ASCII characters with no shell metacharacter concerns, and sendKeys (without -l flag) handles it correctly.
+
+### Test Coverage
+Tests were updated to assert pasteContent + sendControlKeys instead of sendKeys across all relevant scenarios including the B1-2 failure path and Phase B ordering test. The ordering test now verifies the full sequence: setEnvironment -> sendKeys(/clear) -> sendControlKeys(Enter) -> [settle] -> prepareForReuse -> pasteContent(prompt) -> sendControlKeys(Enter).

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/resolution-summary.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/resolution-summary.md
@@ -1,0 +1,47 @@
+# Resolution Summary
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01_0814
+**Review**: .devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814
+**Command**: /resolve
+
+## Decisions Citations
+
+- applies ADR-004 — batch-1-tests (all 4 issues), batch-2-jsdoc (all 3 issues)
+
+## Statistics
+| Metric | Value |
+|--------|-------|
+| Total Issues | 11 |
+| Fixed | 7 |
+| False Positive | 4 |
+| Deferred | 0 |
+| Blocked | 0 |
+
+## Fixed Issues
+| Issue | File:Line | Commit |
+|-------|-----------|--------|
+| Missing test: sendControlKeys(Enter) failure in fresh spawn | event-driven-worker-pool.test.ts:383 | 09a59a1 |
+| Missing test: sendControlKeys(Enter) failure after /clear | event-driven-worker-pool.test.ts (reuse section) | 09a59a1 |
+| Missing test: sendControlKeys(Enter) failure after paste in reuse | event-driven-worker-pool.test.ts (reuse section) | 09a59a1 |
+| Ordering test: add sendControlKeys(Enter) position assertions | event-driven-worker-pool.test.ts:1340 | 09a59a1 |
+| Stale JSDoc in spawnAndDeliverPrompt (send-keys refs) | orchestrate-interactive.ts:191,194 | fba4498 |
+| Stale JSDoc in prepareForReuse + tmux-connector (3 locations) | tmux-types.ts:210, tmux-connector.ts:380,1036 | fba4498 |
+| Stale TmuxHandle JSDoc (sendKeys consumer list) | tmux-types.ts:25 | fba4498 |
+
+## False Positives
+| Issue | File:Line | Reasoning |
+|-------|-----------|-----------|
+| Duplicated error-handling blocks → deliverPrompt helper | event-driven-worker-pool.ts (3 sites) | Plan explicitly chose no helper: "The explicit two-step pattern is clear and matches channel-manager precedent." Each site has distinct cleanup semantics (destroy vs cleanup-persistent-session, err vs ok(null)). Duplication is intentional. |
+| prepareSessionForIteration 67 lines | event-driven-worker-pool.ts:375-442 | Borderline; driven by protocol complexity (4 failure modes). Not actionable without helper extraction which conflicts with design decision. |
+| reuseSession 79 lines | event-driven-worker-pool.ts:466-545 | Pre-existing growth (9-step protocol). Method is well-documented with sequential steps. |
+| launchAndRegister 62 lines | event-driven-worker-pool.ts:681-743 | Borderline; 12 lines over guideline. Helper extraction conflicts with design decision. |
+| Non-atomic two-step delivery | event-driven-worker-pool.ts (3 sites) | Documented as informational by architecture reviewer. Synchronous spawnSync calls make window negligible. Correct rollback at all sites. |
+
+## Deferred to Tech Debt
+
+(none)
+
+## Blocked
+
+(none)

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/review-summary.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/review-summary.md
@@ -1,0 +1,202 @@
+# Code Review Summary
+
+**Branch**: fix-fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01_0814
+**Cycle**: 1
+
+## Merge Recommendation: CHANGES_REQUESTED
+
+This PR implements a critical correctness fix (applies ADR-004: tmux prompt delivery via `pasteContent` + `sendControlKeys('Enter')` instead of `sendKeys`). The change is architecturally sound and all existing tests pass. However, the two-step delivery mechanism introduces **3 new error-handling branches with missing test coverage** that must be addressed before merge.
+
+---
+
+## Issue Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW | Total |
+|----------|----------|------|--------|-----|-------|
+| **Blocking** | 0 | 3 | 6 | 0 | **9** |
+| **Should Fix** | 0 | 0 | 3 | 0 | **3** |
+| **Pre-existing** | 0 | 0 | 3 | 1 | **4** |
+
+---
+
+## Blocking Issues (9 total — must fix before merge)
+
+### HIGH SEVERITY (3 issues — test coverage)
+
+**1. Missing test for sendControlKeys('Enter') failure in fresh spawn (launchAndRegister)**
+- **Files**: `tests/unit/implementations/event-driven-worker-pool.test.ts`
+- **Confidence**: 90%
+- **Problem**: New failure path where `sendControlKeys('Enter')` fails after `pasteContent` succeeds is untested. Triggers `cleanupWorkerState` + `destroySessionWithWarning` + error return.
+- **Fix Required**: Add test that mocks `sendControlKeys` to fail on 'Enter' while `pasteContent` succeeds, then assert result.ok is false, destroy is called, worker count is 0.
+- **Reviewers**: Testing (HIGH 90%)
+
+**2. Missing test for sendControlKeys('Enter') failure after /clear in reuse path (prepareSessionForIteration)**
+- **Files**: `tests/unit/implementations/event-driven-worker-pool.test.ts`
+- **Confidence**: 88%
+- **Problem**: New failure branch where `sendControlKeys('Enter')` fails after `/clear` is untested. Triggers `cleanupPersistentSession` and falls through to fresh spawn.
+- **Fix Required**: Add test mocking `sendControlKeys` to fail when called with 'Enter' after `/clear`, verify fallthrough to fresh spawn.
+- **Reviewers**: Testing (HIGH 88%)
+
+**3. Missing test for sendControlKeys('Enter') failure after pasteContent in reuse path (reuseSession)**
+- **Files**: `tests/unit/implementations/event-driven-worker-pool.test.ts`
+- **Confidence**: 88%
+- **Problem**: New failure branch where `sendControlKeys('Enter')` fails after `pasteContent` during session reuse is untested. Triggers `cleanupWorkerState` + `cleanupPersistentSession`.
+- **Fix Required**: Add test analogous to existing pasteContent failure test but for `sendControlKeys('Enter')` failure path.
+- **Reviewers**: Testing (HIGH 88%), Regression (MEDIUM 82%)
+
+### MEDIUM SEVERITY (6 issues — architecture, documentation, complexity)
+
+**4. Non-atomic two-step prompt delivery creates a failure window**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:712-733`, `:512-533`, `src/cli/commands/orchestrate-interactive.ts:267-274`
+- **Confidence**: 82%
+- **Problem**: Split delivery (`pasteContent` + `sendControlKeys('Enter')`) is inherently non-atomic. If pasteContent succeeds but Enter fails, prompt text is pasted but never submitted. Mitigated by synchronous spawnSync calls and correct rollback logic in all sites.
+- **Assessment**: Acceptable given ADR-004 mandate and synchronous nature. Documentation update needed (see #5 below).
+- **Reviewers**: Architecture (MEDIUM 82%)
+
+**5. Stale JSDoc in TmuxConnectorPort.prepareForReuse (and 2 other files)**
+- **Files**: `src/core/tmux-types.ts:210`, `src/implementations/tmux/tmux-connector.ts:380`, `:1036`
+- **Confidence**: 92% (architecture), 92% (regression)
+- **Problem**: JSDoc still references old `sendKeys(prompt)` pattern. Contradicts ADR-004 decision and new production code using `pasteContent` + `sendControlKeys('Enter')`.
+- **Fix Required**:
+  - `src/core/tmux-types.ts:210`: Change "BEFORE sendKeys(prompt)" to "BEFORE pasteContent(prompt) + sendControlKeys('Enter')"
+  - `src/implementations/tmux/tmux-connector.ts:380`: Same update
+  - `src/implementations/tmux/tmux-connector.ts:1036`: Change "then sendKeys()" to "then pasteContent() + sendControlKeys('Enter')"
+- **Reviewers**: Architecture (MEDIUM 88%), Regression (LOW 92% confidence but pre-existing)
+
+**6. Stale JSDoc in spawnAndDeliverPrompt function**
+- **Files**: `src/cli/commands/orchestrate-interactive.ts:191,194`
+- **Confidence**: 92%
+- **Problem**: JSDoc still references "send-keys" but function now uses `pasteContent` + `sendControlKeys('Enter')`.
+- **Fix Required**: Update lines 191 and 194 to reference `pasteContent + Enter` instead of `send-keys`.
+- **Reviewers**: TypeScript (MEDIUM 92%)
+
+**7. TmuxHandle JSDoc lists sendKeys as primary consumer**
+- **Files**: `src/core/tmux-types.ts:25`
+- **Confidence**: 88%
+- **Problem**: Comment reads "passed back to destroy/sendKeys/isAlive" but primary delivery now uses `pasteContent` and `sendControlKeys`.
+- **Fix Required**: Update to "passed back to destroy/pasteContent/sendControlKeys/isAlive".
+- **Reviewers**: Architecture (MEDIUM 88%)
+
+**8. Ordering test does not validate sendControlKeys('Enter') positions**
+- **Files**: `tests/unit/implementations/event-driven-worker-pool.test.ts:1304-1348`
+- **Confidence**: 82%
+- **Problem**: Test comment describes 6-step ordering but assertions only check 4 constraints. The two `sendControlKeys('Enter')` calls are not validated, so regressions in their ordering would not be caught.
+- **Fix Required**: Add assertions for both Enter call positions (after /clear and after prompt paste).
+- **Reviewers**: Testing (MEDIUM 82%)
+
+**9. Duplicated error-handling blocks across 3 prompt delivery sites**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:512-533`, `:712-732`, `:405-414`
+- **Confidence**: 82%
+- **Problem**: Each of 3 sites has nearly identical `pasteContent` failure and `sendControlKeys('Enter')` failure blocks (6 blocks total). Cleanup logic is duplicated across all 6. Changes to cleanup semantics must be replicated everywhere.
+- **Fix Required**: Extract `deliverPromptToSession(handle, prompt)` helper that encapsulates both calls and returns single Result. Reduces to 3 error blocks (one per site) and brings method lengths closer to 50-line guideline.
+- **Reviewers**: Complexity (MEDIUM 82%)
+
+---
+
+## Should-Fix Issues (3 total — same file, context cleanup)
+
+**10. prepareSessionForIteration exceeds 50-line guideline (67 lines)**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:375-442`
+- **Confidence**: 80%
+- **Problem**: Method is 67 lines (14 lines over 50-line guideline). Addition of separate `sendControlKeys('Enter')` error block pushed it past threshold.
+- **Fix**: Addressed by #9 (helper extraction) which reduces ~10 lines.
+
+**11. reuseSession exceeds 50-line guideline (79 lines)**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:466-545`
+- **Confidence**: 80%
+- **Problem**: 79 lines, well above guideline. Prompt delivery split added ~10 lines.
+- **Fix**: Addressed by #9 (helper extraction).
+
+**12. launchAndRegister near threshold (62 lines)**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:681-743`
+- **Confidence**: 80%
+- **Problem**: 62 lines, borderline above guideline. Separate error blocks inflate method.
+- **Fix**: Addressed by #9 (helper extraction).
+
+---
+
+## Pre-existing Issues (4 total — informational)
+
+**13. `/clear` uses sendKeys while prompts use pasteContent**
+- **Files**: `src/implementations/event-driven-worker-pool.ts:395`
+- **Confidence**: 65% (moved to suggestions by consistency reviewer)
+- **Note**: Intentional design choice. `/clear` is a short fixed command without shell metacharacters; `sendKeys -l` is safe and appropriate. Not a regression.
+
+**14-15. Stale comments in build-tmux-command tests (2 occurrences)**
+- **Files**: `tests/unit/implementations/build-tmux-command.test.ts:139`, `:164`
+- **Confidence**: 85%
+- **Note**: Tests reference old "sendKeys" delivery mechanism. Fix in follow-up PR; these tests were not modified in this PR.
+
+**16. event-driven-worker-pool.ts is 1301 lines**
+- **Files**: `src/implementations/event-driven-worker-pool.ts`
+- **Confidence**: 85%
+- **Note**: Well above 500-line critical threshold. PR adds ~20 net lines only (not introduced by this change). Informational only.
+
+---
+
+## Convergence Status
+
+| Reviewer | Score | Recommendation | Key Finding |
+|----------|-------|-----------------|-------------|
+| Architecture | 9/10 | APPROVED_WITH_CONDITIONS | ADR-004 applied cleanly; JSDoc stale refs need updates |
+| Testing | 6/10 | CHANGES_REQUESTED | 3 new HIGH error branches untested + ordering assertion gap |
+| Performance | 8/10 | APPROVED | 5x syscall overhead acceptable; non-hot path; documented |
+| Reliability | 9/10 | APPROVED | ADR-004 fixes stalling bug; cleanup logic correct |
+| Regression | 8/10 | APPROVED_WITH_CONDITIONS | Migration well-executed; 2 MEDIUM test coverage gaps |
+| TypeScript | 9/10 | APPROVED_WITH_CONDITIONS | Types correct; 2 JSDoc stale refs need updates |
+| Security | 9/10 | APPROVED | No new security surface; injection paths hardened |
+| Complexity | 7/10 | APPROVED_WITH_CONDITIONS | Duplication pattern suggests helper extraction |
+| Consistency | 9/10 | APPROVED | Uniform application across 4 sites; /clear distinction intentional |
+
+**Convergence**: All 9 reviewers agree on the core fix (ADR-004 applied correctly). Blockers are **test coverage for new error branches** (3 HIGH tests) + **documentation updates** (4 JSDoc fixes) + **code deduplication** (helper extraction). No disagreement on safety or correctness.
+
+---
+
+## Action Items for Developer
+
+### BLOCKING — Must complete before merge
+
+1. **Add 3 missing error-path tests** (HIGH priority)
+   - Test: sendControlKeys('Enter') failure after pasteContent in fresh spawn
+   - Test: sendControlKeys('Enter') failure after /clear in reuse
+   - Test: sendControlKeys('Enter') failure after pasteContent in reuse
+   - Location: `tests/unit/implementations/event-driven-worker-pool.test.ts`
+
+2. **Update stale JSDoc references** (MEDIUM priority)
+   - File: `src/core/tmux-types.ts` lines 25, 210
+   - File: `src/implementations/tmux/tmux-connector.ts` lines 380, 1036
+   - File: `src/cli/commands/orchestrate-interactive.ts` lines 191, 194
+   - Change: Replace `sendKeys(prompt)` / `send-keys` with `pasteContent` + `sendControlKeys('Enter')`
+
+3. **Fix ordering test assertion gap** (MEDIUM priority)
+   - File: `tests/unit/implementations/event-driven-worker-pool.test.ts:1340-1348`
+   - Add: Two assertions validating sendControlKeys('Enter') call positions in sequence
+
+### SHOULD-FIX — Recommended code quality improvements
+
+4. **Extract deliverPromptToSession helper** (Optional but recommended)
+   - Consolidates 6 duplicated error blocks into 3
+   - Brings 3 methods into 50-line guideline compliance
+   - Location: `src/implementations/event-driven-worker-pool.ts`
+
+---
+
+## Summary
+
+This is a **necessary correctness fix** that unifies tmux prompt delivery across 4 call sites per ADR-004. The change eliminates a critical stalling bug where prompts were pasted but never submitted. All existing tests pass, architecture is sound, and error handling is thorough.
+
+The 3 HIGH test coverage gaps are the only blockers — they represent new error-handling paths introduced by the two-step delivery mechanism that need validation. The documentation stale references (4 JSDoc comments) must be updated for accuracy and future maintainability.
+
+Once these items are addressed, the PR is merge-ready.
+
+---
+
+## Next Steps
+
+1. Add the 3 failing error-path tests
+2. Update the 6 stale JSDoc references
+3. Fix the ordering test assertion gap
+4. (Optional) Extract the deliverPromptToSession helper for code quality
+5. Re-run `npm run test:core && npm run test:handlers && npm run test:integration` to verify all tests pass
+6. Resubmit for final validation

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/security.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/security.md
@@ -1,0 +1,68 @@
+# Security Review Report
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+**PR**: #200
+
+## Issues in Your Changes (BLOCKING)
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+(none)
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+(none)
+
+## Summary
+
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 0 | - |
+| Should Fix | - | 0 | 0 | - |
+| Pre-existing | - | - | 0 | 0 |
+
+**Security Score**: 9/10
+**Recommendation**: APPROVED
+
+## Analysis Notes
+
+This PR switches all 4 prompt delivery sites from `sendKeys` (with trailing `\n`) to `pasteContent` + `sendControlKeys('Enter')`. The change is a correctness fix (applies ADR-004) with no new security surface introduced.
+
+### Security Assessment
+
+**1. Command Injection (OWASP A03)**
+All changed code paths delegate to existing, already-hardened tmux methods:
+
+- `pasteContent()` in `tmux-session-manager.ts:382-433` writes content to a temp file (UUID-named, in `os.tmpdir()`), loads it via `tmux load-buffer`, and pastes via `tmux paste-buffer`. The session name is validated against `SESSION_NAME_REGEX`, the temp file path is escaped via `escapeForSingleQuotes()`, and content never touches shell interpolation (it goes through a file, not a command argument). Content size is bounded by `MAX_PASTE_CONTENT_LENGTH` (256 KB).
+
+- `sendControlKeys()` in `tmux-session-manager.ts:270-294` validates keys against a strict allowlist (`ALLOWED_CONTROL_KEYS` set: `C-c`, `C-d`, `C-z`, `C-\\`, `Enter`, `Escape`). Only `'Enter'` is used by this PR. The session name is validated against `SESSION_NAME_REGEX`. No shell injection is possible because the key token is checked before being interpolated.
+
+- `sendKeys()` (still used for `/clear` command delivery) operates in `-l` (literal) mode with `escapeForSingleQuotes()` on the keys parameter and session name validation. The change from `'/clear\n'` to `'/clear'` (without the trailing newline) actually reduces the content sent through this path.
+
+**2. Temp File Handling**
+`pasteContent()` uses `crypto.randomUUID()` for temp file naming (collision-resistant) and cleans up via a `finally` block. No change to this mechanism in this PR.
+
+**3. Error Handling**
+All 4 delivery sites properly handle failure of both `pasteContent()` and the subsequent `sendControlKeys('Enter')` call independently, with appropriate cleanup (session destruction, worker state removal). The two-step approach introduces a window between paste and Enter where the prompt is in the buffer but not submitted -- on Enter failure, the session is destroyed, preventing a stale prompt from lingering.
+
+**4. Atomicity Concern (pasteContent + Enter as two-step operation)**
+The prior `sendKeys` approach delivered content and newline in a single call. The new approach is two calls (`pasteContent` then `sendControlKeys`). If the process crashes between the two calls, the prompt text is pasted into the tmux pane but never submitted. This is not a security issue -- it is a correctness concern at most, and the existing session liveness/heartbeat infrastructure would detect and clean up the stale session.
+
+**5. No New Input Trust Boundaries**
+The prompt content flowing through these paths originates from task definitions (already validated at the MCP adapter boundary via Zod schemas). No new user-facing input surfaces are introduced.
+
+**6. Test Coverage**
+Tests are updated to assert `pasteContent` + `sendControlKeys('Enter')` instead of `sendKeys`. The B1-2 failure path test now correctly tests `pasteContent` failure, and the Phase B ordering test verifies the correct call sequence including both new calls.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/testing.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/testing.md
@@ -1,0 +1,105 @@
+# Testing Review Report
+
+**Branch**: fix-fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### HIGH
+
+**Missing test for sendControlKeys('Enter') failure in fresh spawn path (launchAndRegister)** - `tests/unit/implementations/event-driven-worker-pool.test.ts`
+**Confidence**: 90%
+- Problem: The production code in `event-driven-worker-pool.ts:723-732` adds a new failure branch where `sendControlKeys(handle, 'Enter')` can fail after a successful `pasteContent`. This triggers `cleanupWorkerState` + `destroySessionWithWarning` and returns an error. The existing test at line 369 (`cleans up when pasteContent fails after spawn`) only covers the `pasteContent` failure branch. There is no test for the `sendControlKeys('Enter')` failure branch, leaving a critical error handling path untested. This is a new code path introduced by this PR (applies ADR-004).
+- Fix: Add a test that mocks `sendControlKeys` to fail on 'Enter' while `pasteContent` succeeds, then asserts: (1) result is not ok, (2) `destroy` is called, (3) worker count is 0:
+
+```typescript
+it('cleans up when sendControlKeys(Enter) fails after pasteContent in fresh spawn (step 10)', async () => {
+  (tmuxConnector.sendControlKeys as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+    err(new AutobeatError(ErrorCode.TMUX_SEND_KEYS_FAILED, 'Enter failed')),
+  );
+
+  const task = buildTask();
+  const result = await pool.spawn(task);
+
+  expect(result.ok).toBe(false);
+  expect(tmuxConnector.destroy).toHaveBeenCalled();
+  expect(pool.getWorkerCount()).toBe(0);
+});
+```
+
+**Missing test for sendControlKeys('Enter') failure after /clear in reuse path (prepareSessionForIteration)** - `tests/unit/implementations/event-driven-worker-pool.test.ts`
+**Confidence**: 88%
+- Problem: The production code in `event-driven-worker-pool.ts:405-414` introduces a new failure branch where `sendControlKeys(handle, 'Enter')` fails after successfully sending `/clear`. This triggers `cleanupPersistentSession` and returns `ok(null)`. There is no test covering this path. The existing `setEnvironment error` test covers a different failure within `prepareSessionForIteration`, but the new `clearEnterResult` branch is distinct and untested.
+- Fix: Add a test that mocks `sendControlKeys` to succeed on the first call (from `pasteContent` setup) but fail when called with 'Enter' after `/clear`:
+
+```typescript
+it('reuseSession failure (sendControlKeys Enter after /clear) falls through to fresh spawn', async () => {
+  const task1 = buildPersistentTask('loop-clear-enter', (f) => f.withPrompt('iter 1'));
+  const task2 = buildPersistentTask('loop-clear-enter', (f) => f.withPrompt('iter 2'));
+
+  await pool.spawn(task1);
+
+  // sendControlKeys: first call (Enter after initial pasteContent) already succeeded.
+  // For the reuse path: /clear sendKeys succeeds, but Enter after /clear fails.
+  (tmuxConnector.sendControlKeys as ReturnType<typeof vi.fn>)
+    .mockReturnValueOnce(err(new Error('Enter after clear failed')));
+
+  const [spawnResult] = await Promise.all([pool.spawn(task2), vi.advanceTimersByTimeAsync(400)]);
+
+  expect(spawnResult.ok).toBe(true);
+  expect(tmuxConnector.spawn).toHaveBeenCalledTimes(2); // fell through to fresh spawn
+});
+```
+
+**Missing test for sendControlKeys('Enter') failure after pasteContent in reuse path (reuseSession)** - `tests/unit/implementations/event-driven-worker-pool.test.ts`
+**Confidence**: 88%
+- Problem: The production code in `event-driven-worker-pool.ts:523-533` adds a new failure branch where `sendControlKeys(handle, 'Enter')` fails after `pasteContent(handle, prompt)` succeeds during session reuse. This triggers `cleanupWorkerState` + `cleanupPersistentSession` and returns `ok(null)`. The existing B1-2 test only covers `pasteContent` failure in the reuse path; this is a distinct error branch.
+- Fix: Add a test analogous to B1-2 but for `sendControlKeys('Enter')` failure after successful `pasteContent` during reuse.
+
+### MEDIUM
+
+**Ordering test does not validate sendControlKeys('Enter') positions in the call sequence** - `tests/unit/implementations/event-driven-worker-pool.test.ts:1304-1348`
+**Confidence**: 82%
+- Problem: The test comment on line 1305-1306 describes the expected ordering as `sendKeys(/clear) -> sendControlKeys(Enter) -> [settle] -> prepareForReuse -> pasteContent(prompt) -> sendControlKeys(Enter)`, but the assertions on lines 1340-1348 only check 4 ordering constraints: `envIdx < clearIdx < prepareIdx < promptIdx`. The two `sendControlKeys(Enter)` calls are not validated in the ordering. The `sendControlKeys` mock pushes entries to `callOrder`, so the data is present but the test does not assert their positions. This means a regression where the Enter calls happen in the wrong order would not be caught.
+- Fix: Add assertions for `sendControlKeys(Enter)` positions:
+
+```typescript
+const clearEnterIdx = callOrder.indexOf('sendControlKeys(Enter)');
+expect(clearEnterIdx).toBeGreaterThan(clearIdx);
+expect(prepareIdx).toBeGreaterThan(clearEnterIdx);
+
+const promptEnterIdx = callOrder.lastIndexOf('sendControlKeys(Enter)');
+expect(promptEnterIdx).toBeGreaterThan(promptIdx);
+```
+
+## Issues in Code You Touched (Should Fix)
+
+(none)
+
+## Pre-existing Issues (Not Blocking)
+
+### MEDIUM
+
+**Stale comments referencing "sendKeys" delivery in build-tmux-command tests (3 occurrences)**
+**Confidence**: 85%
+- `tests/unit/implementations/build-tmux-command.test.ts:139` — `// Prompt delivered via sendKeys`
+- `tests/unit/implementations/build-tmux-command.test.ts:164` — `it('agentArgs does NOT contain the prompt text (delivered via sendKeys)'`
+- `tests/unit/implementations/build-tmux-command.test.ts:310`, `:403` — same pattern
+- Problem: These comments and test names reference the old `sendKeys` delivery mechanism. After this PR, prompt delivery uses `pasteContent + sendControlKeys('Enter')` per ADR-004. The comments are now misleading about the actual delivery mechanism. These tests were not modified in this PR so this is purely informational.
+- Fix: Update comments and test names to reference `pasteContent` delivery. Fix in a follow-up PR.
+
+## Suggestions (Lower Confidence)
+
+- **No test coverage for orchestrate-interactive.ts prompt delivery change** - `src/cli/commands/orchestrate-interactive.ts:264-274` (Confidence: 70%) — The `spawnAndDeliverPrompt` function was changed from `sendKeys` to `pasteContent` + `sendControlKeys('Enter')`, but the interactive orchestrator test file (`tests/unit/interactive-orchestrator.test.ts`) does not directly test `spawnAndDeliverPrompt` — it tests higher-level orchestration flows. The function is not exported and is deeply coupled to tmux I/O, making it hard to unit test directly. This may be acceptable given that the lower-level `EventDrivenWorkerPool` tests cover the same mechanism, but the orchestrate-interactive path has distinct error handling (`failWith` pattern with `process.exit`).
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 3 | 1 | 0 |
+| Should Fix | 0 | 0 | 0 | 0 |
+| Pre-existing | 0 | 0 | 1 | 0 |
+
+**Testing Score**: 6/10
+**Recommendation**: CHANGES_REQUESTED
+
+The test updates correctly track the `sendKeys` -> `pasteContent` + `sendControlKeys('Enter')` migration (applies ADR-004), and the mock infrastructure (`createMockTmuxConnector`) already supports `pasteContent`. However, the two-step delivery mechanism introduces 3 new error branches (Enter failure in fresh spawn, Enter failure after /clear in reuse, Enter failure after paste in reuse) that have no test coverage. The existing tests only cover the first step (`pasteContent`) failure paths. Each of these branches has distinct cleanup logic (different combinations of `cleanupWorkerState` and `cleanupPersistentSession`), so they are not redundant with the tested paths. Additionally, the ordering test describes sendControlKeys(Enter) positions in its comment but does not assert them.

--- a/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/typescript.md
+++ b/.devflow/docs/reviews/fix-fix-tmux-prompt-delivery-switch-from-sen/2026-06-01_0814/typescript.md
@@ -1,0 +1,53 @@
+# TypeScript Review Report
+
+**Branch**: fix/fix-tmux-prompt-delivery-switch-from-sen -> main
+**Date**: 2026-06-01
+
+## Issues in Your Changes (BLOCKING)
+
+### MEDIUM
+
+**Stale JSDoc references to `send-keys` in `spawnAndDeliverPrompt`** - `src/cli/commands/orchestrate-interactive.ts:191,194`
+**Confidence**: 92%
+- Problem: The JSDoc comment for `spawnAndDeliverPrompt()` still references `send-keys` in two places: line 191 ("deliver the initial prompt via send-keys") and line 194 ("On failure after spawn (send-keys)"). The second commit (9c0cb05) updated the module-level comment at line 7 but missed the function-level JSDoc. This creates documentation drift between what the code does (pasteContent + Enter) and what the JSDoc says (send-keys). Applies ADR-004.
+- Fix:
+```typescript
+/**
+ * Build the tmux config (stripping AUTOBEAT_WORKER), spawn the session, and deliver
+ * the initial prompt via pasteContent + Enter.
+ *
+ * Calls process.exit(1) on any failure (CLI pattern — null is never returned).
+ * On failure after spawn (pasteContent/Enter), destroys the session before exiting.
+ */
+```
+
+## Issues in Code You Touched (Should Fix)
+
+### MEDIUM
+
+**Stale JSDoc in `TmuxConnectorPort.prepareForReuse` references `sendKeys(prompt)`** - `src/core/tmux-types.ts:210`
+**Confidence**: 88%
+- Problem: The `prepareForReuse` JSDoc at line 210 says "BEFORE sendKeys(prompt) so watchers are ready before any output arrives." All callers of `prepareForReuse` now use `pasteContent(prompt)` + `sendControlKeys('Enter')`. This JSDoc is in the port interface definition that all consumers reference. While `tmux-types.ts` was not modified in this PR, the calling code was, and the JSDoc now misrepresents the protocol.
+- Fix: Update the JSDoc to say "BEFORE pasteContent(prompt)" instead of "BEFORE sendKeys(prompt)".
+
+## Pre-existing Issues (Not Blocking)
+
+(none)
+
+## Suggestions (Lower Confidence)
+
+(none)
+
+## Summary
+| Category | CRITICAL | HIGH | MEDIUM | LOW |
+|----------|----------|------|--------|-----|
+| Blocking | 0 | 0 | 1 | 0 |
+| Should Fix | 0 | 0 | 1 | 0 |
+| Pre-existing | 0 | 0 | 0 | 0 |
+
+**TypeScript Score**: 9/10
+**Recommendation**: APPROVED_WITH_CONDITIONS
+
+The TypeScript changes are well-typed and follow established patterns. All 4 prompt delivery sites correctly use `pasteContent` (returns `Result<void, AutobeatError>`) followed by `sendControlKeys('Enter')` (also `Result<void, AutobeatError>`), with proper Result unwrapping and error propagation at each step. The `/clear` command correctly remains on `sendKeys` (short fixed string, no trailing newline concern). Tests are updated to assert the new call pattern including a dedicated ordering test that verifies the `setEnvironment -> sendKeys(/clear) -> sendControlKeys(Enter) -> prepareForReuse -> pasteContent(prompt) -> sendControlKeys(Enter)` sequence.
+
+The only issues are 2 stale JSDoc comments referencing the old `send-keys` / `sendKeys(prompt)` pattern -- one in the function being changed, one in the port interface definition that describes the protocol. Both should be updated for documentation accuracy. No type safety, null handling, `any` usage, or structural issues found.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -781,6 +781,7 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
         const result = await recovery.recover();
         if (!result.ok) {
           logger.error('Recovery failed', result.error);
+          return result;
         }
       } else {
         recovery.recover().then((result) => {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -55,6 +55,7 @@ export interface ModeFlags {
   skipScheduleExecutor: boolean;
   skipRecovery: boolean;
   skipProxy: boolean;
+  awaitRecovery: boolean;
 }
 
 /**
@@ -72,6 +73,13 @@ export function deriveModeFlags(mode: BootstrapMode): ModeFlags {
     // DECISION: Proxy starts in any mode that spawns workers ('server', 'run').
     // Skipped in 'cli' mode (management commands that never spawn workers).
     skipProxy: mode === 'cli',
+    // DECISION: 'run' mode awaits recovery synchronously before spawning the task worker.
+    // Fire-and-forget recovery in 'run' mode races against freshly-spawned workers: Phase 0's
+    // session snapshot is taken before the new session exists, so Phase 3 sees the new session
+    // as dead and marks the task FAILED. Awaiting recovery ensures Phase 0 completes before
+    // any worker is started, eliminating the race. 'server' and 'cli' keep fire-and-forget
+    // (or skip recovery) because they are long-lived daemons or management commands.
+    awaitRecovery: mode === 'run',
   };
 }
 
@@ -188,7 +196,8 @@ const getFromContainerSafe = <T>(container: Container, key: string): Result<T> =
  */
 export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<Container>> {
   const mode = options.mode ?? 'server';
-  const { skipResourceMonitoring, skipScheduleExecutor, skipRecovery, skipProxy } = deriveModeFlags(mode);
+  const { skipResourceMonitoring, skipScheduleExecutor, skipRecovery, skipProxy, awaitRecovery } =
+    deriveModeFlags(mode);
 
   const container = new Container();
   const config = loadConfiguration();
@@ -765,11 +774,21 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<Result<
     const recoveryResult = container.get('recoveryManager');
     if (recoveryResult.ok) {
       const recovery = recoveryResult.value as RecoveryManager;
-      recovery.recover().then((result) => {
+      if (awaitRecovery) {
+        // DECISION: 'run' mode awaits recovery before returning the container so that
+        // the caller cannot spawn a worker until Phase 0's session snapshot is complete.
+        // This eliminates the race where Phase 3 sees a freshly-spawned session as dead.
+        const result = await recovery.recover();
         if (!result.ok) {
           logger.error('Recovery failed', result.error);
         }
-      });
+      } else {
+        recovery.recover().then((result) => {
+          if (!result.ok) {
+            logger.error('Recovery failed', result.error);
+          }
+        });
+      }
     }
 
     // Channel recovery — re-attach to alive member sessions, mark dead members DESTROYED

--- a/src/services/recovery-manager.ts
+++ b/src/services/recovery-manager.ts
@@ -530,6 +530,36 @@ export class RecoveryManager {
   }
 
   /**
+   * Determine whether a worker's tmux session is currently alive.
+   *
+   * Checks the Phase 0 snapshot first (O(1) set lookup). If the session is absent
+   * from the snapshot, falls back to a live isAlive() call — the session may have
+   * been spawned after Phase 0 ran (the 'run' mode race condition).
+   *
+   * DECISION (defense-in-depth): treat any isAlive() error as dead so genuinely
+   * crashed tasks are still failed correctly.
+   *
+   * Returns false when sessionName is absent (no session to check).
+   */
+  private isWorkerSessionAlive(taskId: string, sessionName: string | undefined, liveTmuxSessions: Set<string>): boolean {
+    if (sessionName === undefined) return false;
+    if (liveTmuxSessions.has(sessionName)) return true;
+
+    // Session not in Phase 0 snapshot — may have been spawned after the snapshot was taken.
+    if (!this.tmuxSessionManager) return false;
+
+    const liveCheck = this.tmuxSessionManager.isAlive(sessionName);
+    const alive = liveCheck.ok && liveCheck.value;
+    if (alive) {
+      this.logger.info('Running task session alive via live check (not in Phase 0 snapshot)', {
+        taskId,
+        sessionName,
+      });
+    }
+    return alive;
+  }
+
+  /**
    * Recover RUNNING tasks using tmux session liveness detection.
    *
    * WHY THIS EXISTS:
@@ -560,25 +590,8 @@ export class RecoveryManager {
         if (!this.tmuxSessionManager && workerRegistration.sessionName !== undefined) {
           continue;
         }
-        // Use the batch session set from Phase 0 — O(1) lookup instead of a per-task exec.
-        let alive =
-          workerRegistration.sessionName !== undefined && liveTmuxSessions.has(workerRegistration.sessionName);
 
-        // DECISION (defense-in-depth): If the session is not in the Phase 0 snapshot, it may
-        // have been spawned after Phase 0 ran (the race condition in 'run' mode). Fall back to
-        // a live isAlive() check before declaring the session dead. Conservative: treat any
-        // isAlive() error as dead so genuinely crashed tasks are still failed correctly.
-        if (!alive && workerRegistration.sessionName !== undefined && this.tmuxSessionManager) {
-          const liveCheck = this.tmuxSessionManager.isAlive(workerRegistration.sessionName);
-          if (liveCheck.ok && liveCheck.value) {
-            alive = true;
-            this.logger.info('Running task session alive via live check (not in Phase 0 snapshot)', {
-              taskId: task.id,
-              sessionName: workerRegistration.sessionName,
-            });
-          }
-        }
-
+        const alive = this.isWorkerSessionAlive(task.id, workerRegistration.sessionName, liveTmuxSessions);
         if (alive) {
           this.logger.info('Running task has live tmux session, skipping', {
             taskId: task.id,

--- a/src/services/recovery-manager.ts
+++ b/src/services/recovery-manager.ts
@@ -561,8 +561,24 @@ export class RecoveryManager {
           continue;
         }
         // Use the batch session set from Phase 0 — O(1) lookup instead of a per-task exec.
-        const alive =
+        let alive =
           workerRegistration.sessionName !== undefined && liveTmuxSessions.has(workerRegistration.sessionName);
+
+        // DECISION (defense-in-depth): If the session is not in the Phase 0 snapshot, it may
+        // have been spawned after Phase 0 ran (the race condition in 'run' mode). Fall back to
+        // a live isAlive() check before declaring the session dead. Conservative: treat any
+        // isAlive() error as dead so genuinely crashed tasks are still failed correctly.
+        if (!alive && workerRegistration.sessionName !== undefined && this.tmuxSessionManager) {
+          const liveCheck = this.tmuxSessionManager.isAlive(workerRegistration.sessionName);
+          if (liveCheck.ok && liveCheck.value) {
+            alive = true;
+            this.logger.info('Running task session alive via live check (not in Phase 0 snapshot)', {
+              taskId: task.id,
+              sessionName: workerRegistration.sessionName,
+            });
+          }
+        }
+
         if (alive) {
           this.logger.info('Running task has live tmux session, skipping', {
             taskId: task.id,

--- a/tests/integration/service-initialization.test.ts
+++ b/tests/integration/service-initialization.test.ts
@@ -392,11 +392,39 @@ describe('Integration: Service initialization', () => {
 
   describe('BootstrapMode flag derivation', () => {
     it.each([
-      ['server', { skipResourceMonitoring: false, skipScheduleExecutor: false, skipRecovery: false, skipProxy: false }],
-      ['cli', { skipResourceMonitoring: false, skipScheduleExecutor: true, skipRecovery: true, skipProxy: true }],
+      [
+        'server',
+        {
+          skipResourceMonitoring: false,
+          skipScheduleExecutor: false,
+          skipRecovery: false,
+          skipProxy: false,
+          awaitRecovery: false,
+        },
+      ],
+      [
+        'cli',
+        {
+          skipResourceMonitoring: false,
+          skipScheduleExecutor: true,
+          skipRecovery: true,
+          skipProxy: true,
+          awaitRecovery: false,
+        },
+      ],
       // DECISION: Resource monitoring enabled in all modes — 'run' mode workers need resource
       // checks to prevent overload.
-      ['run', { skipResourceMonitoring: false, skipScheduleExecutor: true, skipRecovery: false, skipProxy: false }],
+      // DECISION: awaitRecovery=true for 'run' mode — prevents recovery race that kills freshly-spawned workers.
+      [
+        'run',
+        {
+          skipResourceMonitoring: false,
+          skipScheduleExecutor: true,
+          skipRecovery: false,
+          skipProxy: false,
+          awaitRecovery: true,
+        },
+      ],
     ] as const)('mode "%s" produces correct flags', (mode, expected) => {
       expect(deriveModeFlags(mode)).toEqual(expected);
     });

--- a/tests/unit/services/recovery-manager.test.ts
+++ b/tests/unit/services/recovery-manager.test.ts
@@ -798,6 +798,60 @@ describe('RecoveryManager', () => {
         currentStatus: TaskStatus.COMPLETED,
       });
     });
+
+    it('should not fail RUNNING task when session is alive but not in Phase 0 snapshot', async () => {
+      // Reproduces the race condition: Phase 0 snapshot is empty (taken before session spawned),
+      // but the session exists by the time Phase 3 runs the isAlive() fallback.
+      tmuxSessionManager.listSessions.mockReturnValue(ok([])); // Phase 0: empty snapshot
+      const task = buildRunningTask('new-task');
+      setupFindByStatus([], [task]);
+      workerRepo.findByTaskId.mockReturnValue(ok(buildTmuxWorker('w-new', task.id, 'beat-task-new')));
+      // isAlive() fallback returns true — session was spawned after Phase 0
+      tmuxSessionManager.isAlive.mockReturnValue(ok(true));
+
+      const result = await manager.recover();
+
+      expect(result.ok).toBe(true);
+      expect(repo.update).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith('Running task session alive via live check (not in Phase 0 snapshot)', {
+        taskId: task.id,
+        sessionName: 'beat-task-new',
+      });
+    });
+
+    it('should fail RUNNING task when session is not in Phase 0 snapshot AND isAlive returns false', async () => {
+      // Session genuinely dead — not in Phase 0 snapshot and isAlive() confirms dead.
+      tmuxSessionManager.listSessions.mockReturnValue(ok([])); // Phase 0: empty snapshot
+      const task = buildRunningTask('dead-task');
+      setupFindByStatus([], [task]);
+      workerRepo.findByTaskId.mockReturnValue(ok(buildTmuxWorker('w-dead', task.id, 'beat-task-dead')));
+      tmuxSessionManager.isAlive.mockReturnValue(ok(false));
+
+      const result = await manager.recover();
+
+      expect(result.ok).toBe(true);
+      expect(repo.update).toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({ status: TaskStatus.FAILED, exitCode: -1 }),
+      );
+    });
+
+    it('should fail RUNNING task when isAlive returns error (conservative: treat error as dead)', async () => {
+      // tmux command fails entirely — treat as dead to avoid leaving truly crashed tasks as RUNNING.
+      tmuxSessionManager.listSessions.mockReturnValue(ok([])); // Phase 0: empty snapshot
+      const task = buildRunningTask('error-task');
+      setupFindByStatus([], [task]);
+      workerRepo.findByTaskId.mockReturnValue(ok(buildTmuxWorker('w-err', task.id, 'beat-task-error')));
+      tmuxSessionManager.isAlive.mockReturnValue(err(new AutobeatError(ErrorCode.SYSTEM_ERROR, 'tmux exec failed')));
+
+      const result = await manager.recover();
+
+      expect(result.ok).toBe(true);
+      expect(repo.update).toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({ status: TaskStatus.FAILED, exitCode: -1 }),
+      );
+    });
   });
 
   describe('TaskFailed event emission', () => {


### PR DESCRIPTION
## Summary

When `beat run` is invoked alongside stale dead workers, recovery fired as fire-and-forget. Phase 0's tmux session snapshot was taken before the new worker session existed, so Phase 3 treated the new session as absent and marked the freshly-delegated task FAILED immediately after it started.

## Changes

**Primary fix — await recovery in `mode=run` (`src/bootstrap.ts`)**
- Added `awaitRecovery: boolean` to `ModeFlags` interface
- `deriveModeFlags('run')` returns `awaitRecovery: true`; `server` and `cli` return `false`
- `bootstrap()` awaits `recovery.recover()` when `awaitRecovery` is set, ensuring Phase 0's session snapshot is complete before the container is returned to the caller (and any worker is spawned)
- Channel recovery remains fire-and-forget — `run` mode manages tasks, not channels

**Defense-in-depth — `isAlive()` fallback in Phase 3 (`src/services/recovery-manager.ts`)**
- If a RUNNING task's session is not in the Phase 0 snapshot, `recoverRunningTasks` now falls back to a live `isAlive()` call before failing the task
- `isAlive()` error is treated conservatively as dead (preserves crash-recovery correctness)
- The common O(1) set-lookup path is unchanged — fallback adds at most 1 tmux `has-session` exec per RUNNING task not in the snapshot

**Tests**
- Three new tests in `RUNNING task recovery — tmux session-based detection`:
  - Session alive but not in Phase 0 snapshot → task NOT failed (reproduces the bug)
  - Session not in snapshot AND `isAlive` returns false → task correctly failed
  - `isAlive` returns error → task conservatively failed
- `deriveModeFlags` test table updated with `awaitRecovery` expectation for all three modes

## Breaking Changes

None. `ModeFlags` is an internal interface; `deriveModeFlags` is exported only for testing. `RecoveryManager.recover()` signature is unchanged.

## Reviewer Focus Areas

- `bootstrap.ts` ~line 764: the conditional `await` block — verify channel recovery is intentionally excluded
- `recovery-manager.ts` Phase 3 fallback: the `!alive && sessionName && tmuxSessionManager` guard — confirm conservative error handling is appropriate
- Test T-1 (bug reproduction): `listSessions → ok([])` + `isAlive → ok(true)` — should NOT call `repo.update`